### PR TITLE
Fix return value of Js.Date.toJSON (it is nullable).

### DIFF
--- a/jscomp/others/js_date.ml
+++ b/jscomp/others/js_date.ml
@@ -127,6 +127,8 @@ external toGMTString : t -> string = "" [@@bs.send]
 
 external toISOString : t -> string = "" [@@bs.send]
 external toJSON : t -> string = "" [@@bs.send]
+[@@ocaml.deprecated "This method is unsafe. It will be changed to return option in a future release. Please use toJSONUnsafe instead."]
+external toJSONUnsafe : t -> string = "toJSON" [@@bs.send]
 external toLocaleDateString : t -> string = "" [@@bs.send] (* TODO: has overloads with somewhat poor browser support *)
 external toLocaleString: t -> string = "" [@@bs.send] (* TODO: has overloads with somewhat poor browser support *)
 external toLocaleTimeString: t -> string = "" [@@bs.send] (* TODO: has overloads with somewhat poor browser support *)

--- a/jscomp/test/js_date_test.js
+++ b/jscomp/test/js_date_test.js
@@ -923,15 +923,26 @@ var suites_001 = /* :: */[
                                                                                                                               ],
                                                                                                                               /* :: */[
                                                                                                                                 /* tuple */[
-                                                                                                                                  "toUTCString",
+                                                                                                                                  "toJSONUnsafe",
                                                                                                                                   (function () {
                                                                                                                                       return /* Eq */Block.__(0, [
-                                                                                                                                                "Mon, 08 Mar 1976 11:11:56 GMT",
-                                                                                                                                                new Date("1976-03-08T12:34:56.789+01:23").toUTCString()
+                                                                                                                                                "1976-03-08T11:11:56.789Z",
+                                                                                                                                                new Date("1976-03-08T12:34:56.789+01:23").toJSON()
                                                                                                                                               ]);
                                                                                                                                     })
                                                                                                                                 ],
-                                                                                                                                /* [] */0
+                                                                                                                                /* :: */[
+                                                                                                                                  /* tuple */[
+                                                                                                                                    "toUTCString",
+                                                                                                                                    (function () {
+                                                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                                                  "Mon, 08 Mar 1976 11:11:56 GMT",
+                                                                                                                                                  new Date("1976-03-08T12:34:56.789+01:23").toUTCString()
+                                                                                                                                                ]);
+                                                                                                                                      })
+                                                                                                                                  ],
+                                                                                                                                  /* [] */0
+                                                                                                                                ]
                                                                                                                               ]
                                                                                                                             ]
                                                                                                                           ]

--- a/jscomp/test/js_date_test.ml
+++ b/jscomp/test/js_date_test.ml
@@ -437,6 +437,8 @@ let suites = Mt.[
       Eq("1976-03-08T11:11:56.789Z", Js.Date.toISOString (date ())));
     "toJSON", (fun _ ->
       Eq("1976-03-08T11:11:56.789Z", Js.Date.toJSON (date ())));
+    "toJSONUnsafe", (fun _ ->
+      Eq("1976-03-08T11:11:56.789Z", Js.Date.toJSONUnsafe (date ())));
     (* locale dependent
     "toLocaleDateString", (fun _ ->
       Eq("3/8/1976", Js.Date.toLocaleDateString (date ())));


### PR DESCRIPTION
This is a breaking change, unfortunately. But I think it can't be helped. The return type of the `Js.Date.toJSON` binding is incorrect, as

```js
new Date("gibberish").toJSON()
```

gives you `null` in JS. 