### PR TITLE
Support record spreads in inline records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - GenType: Propagate comments from record fields to emitted TypeScript types. https://github.com/rescript-lang/rescript-compiler/pull/6333
+- Variant payloads: Allow spreading record definitions into inline records in variant payloads. https://github.com/rescript-lang/rescript-compiler/pull/6326
 
 #### :boom: Breaking Change
 

--- a/jscomp/test/record_type_spread.js
+++ b/jscomp/test/record_type_spread.js
@@ -48,6 +48,11 @@ var o = {
   id: "1"
 };
 
+var o2 = {
+  TAG: "OneSingle",
+  id: "1"
+};
+
 exports.getY = getY;
 exports.getX = getX;
 exports.v = v;
@@ -55,4 +60,5 @@ exports.d = d;
 exports.x = x;
 exports.DeepSub = DeepSub;
 exports.o = o;
+exports.o2 = o2;
 /* No side effect */

--- a/jscomp/test/record_type_spread.js
+++ b/jscomp/test/record_type_spread.js
@@ -42,10 +42,17 @@ var x = {
   c: "hello"
 };
 
+var o = {
+  TAG: "One",
+  first: "1",
+  id: "1"
+};
+
 exports.getY = getY;
 exports.getX = getX;
 exports.v = v;
 exports.d = d;
 exports.x = x;
 exports.DeepSub = DeepSub;
+exports.o = o;
 /* No side effect */

--- a/jscomp/test/record_type_spread.res
+++ b/jscomp/test/record_type_spread.res
@@ -59,3 +59,12 @@ module DeepSub = {
     z: #Two(1),
   }
 }
+
+type base = {
+  id: string,
+  name?: string,
+}
+
+type inlineRecord = One({first: string, ...base})
+
+let o = One({first: "1", id: "1"})

--- a/jscomp/test/record_type_spread.res
+++ b/jscomp/test/record_type_spread.res
@@ -68,3 +68,7 @@ type base = {
 type inlineRecord = One({first: string, ...base})
 
 let o = One({first: "1", id: "1"})
+
+type inlineRecordSingleSpread = OneSingle({...base})
+
+let o2 = OneSingle({id: "1"})


### PR DESCRIPTION
This allows you to use record spreads in inline records. It's mostly for consistency, record spreads are less useful in inline records because you can't get a hold of the type and coerce it to the underlying type definition. But, it's still useful to be able to spread into the inline record so you can share type definitions.

There's currently an outstanding parser issue I'd like to tackle in this PR as well. The issue is that you can't have just a single spread as the full inline record body. That would be useful to have. One example (that now doesn't parse) of a use case is this:

```rescript
// Directive nodes can appear both standalone and as part of the ast variant

// Simplified type definition just for examplifying
type directiveNode = {
  name: string,
  loc: Location.t,
  payload?: payload
}

// directiveNode can appear both as 
@tag("kind") type astNode = ObjectNode({ name: string, directives: array<directiveNode> }) | DirectiveNode({...directiveNode})
```