### PR TITLE
WIP: ocamlformat 0.26.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 profile = default
-version = 0.22.4
+version = 0.26.0
 
 field-space = tight-decl
 break-cases = toplevel

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
   (ocaml
    (>= 4.10))
   (ocamlformat
-   (= 0.22.4))
+   (= 0.26.0))
   (cppo
    (= 1.6.9))
   (js_of_ocaml-compiler

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -41,11 +41,11 @@ let process_method_attributes_rev (attrs : t) =
                   | None -> true
                   | Some e -> Ast_payload.assert_bool_lit e),
                   undefined )
-              | "undefined" -> (
+              | "undefined" ->
                 ( null,
                   match opt_expr with
                   | None -> true
-                  | Some e -> Ast_payload.assert_bool_lit e ))
+                  | Some e -> Ast_payload.assert_bool_lit e )
               | "nullable" -> (
                 match opt_expr with
                 | None -> (true, true)

--- a/jscomp/frontend/ast_derive_abstract.ml
+++ b/jscomp/frontend/ast_derive_abstract.ml
@@ -84,8 +84,8 @@ let handleTdcl light (tdcl : Parsetree.type_declaration) :
       Ext_list.fold_right label_declarations
         ( [],
           (if has_optional_field then
-           Ast_compatible.arrow ~loc (Ast_literal.type_unit ()) core_type
-          else core_type),
+             Ast_compatible.arrow ~loc (Ast_literal.type_unit ()) core_type
+           else core_type),
           [] )
         (fun ({
                 pld_name = {txt = label_name; loc = label_loc} as pld_name;
@@ -109,7 +109,7 @@ let handleTdcl light (tdcl : Parsetree.type_declaration) :
               ( Ast_compatible.opt_arrow ~loc:pld_loc label_name pld_type maker,
                 Val.mk ~loc:pld_loc
                   (if light then pld_name
-                  else {pld_name with txt = pld_name.txt ^ "Get"})
+                   else {pld_name with txt = pld_name.txt ^ "Get"})
                   ~attrs:get_optional_attrs ~prim
                   (Ast_compatible.arrow ~loc core_type optional_type)
                 :: acc )
@@ -117,7 +117,7 @@ let handleTdcl light (tdcl : Parsetree.type_declaration) :
               ( Ast_compatible.label_arrow ~loc:pld_loc label_name pld_type maker,
                 Val.mk ~loc:pld_loc
                   (if light then pld_name
-                  else {pld_name with txt = pld_name.txt ^ "Get"})
+                   else {pld_name with txt = pld_name.txt ^ "Get"})
                   ~attrs:get_attrs
                   ~prim:
                     ((* Not needed actually*)

--- a/jscomp/frontend/ast_derive_js_mapper.ml
+++ b/jscomp/frontend/ast_derive_js_mapper.ml
@@ -213,10 +213,10 @@ let init () =
                   Ast_comb.single_non_rec_value patFromJs
                     (Ast_compatible.fun_ (Pat.var pat_param)
                        (if createType then
-                        Exp.let_ Nonrecursive
-                          [Vb.mk (Pat.var pat_param) (exp_param +: newType)]
-                          (Exp.constraint_ obj_exp core_type)
-                       else Exp.constraint_ obj_exp core_type))
+                          Exp.let_ Nonrecursive
+                            [Vb.mk (Pat.var pat_param) (exp_param +: newType)]
+                            (Exp.constraint_ obj_exp core_type)
+                        else Exp.constraint_ obj_exp core_type))
                 in
                 let rest = [toJs; fromJs] in
                 if createType then eraseTypeStr :: newTypeStr :: rest else rest
@@ -239,16 +239,17 @@ let init () =
                            ));
                       Ast_comb.single_non_rec_value {loc; txt = revMap}
                         (if has_bs_as then
-                         Exp.extension
-                           ( {txt = "raw"; loc},
-                             PStr
-                               [Str.eval (Exp.constant (Const.string revData))]
-                           )
-                        else expMap);
+                           Exp.extension
+                             ( {txt = "raw"; loc},
+                               PStr
+                                 [
+                                   Str.eval (Exp.constant (Const.string revData));
+                                 ] )
+                         else expMap);
                       toJsBody
                         (if has_bs_as then
-                         app2 unsafeIndexGetExp expMap exp_param
-                        else app1 eraseTypeExp exp_param);
+                           app2 unsafeIndexGetExp expMap exp_param
+                         else app1 eraseTypeExp exp_param);
                       Ast_comb.single_non_rec_value patFromJs
                         (Ast_compatible.fun_ (Pat.var pat_param)
                            (let result =

--- a/jscomp/frontend/ast_derive_projector.ml
+++ b/jscomp/frontend/ast_derive_projector.ml
@@ -60,32 +60,33 @@ let init () =
                     Ast_comb.single_non_rec_value
                       {loc; txt = little_con_name}
                       (if arity = 0 then
-                       (*TODO: add a prefix, better inter-op with FFI *)
-                       Exp.constraint_
-                         (Exp.construct
-                            {loc; txt = Longident.Lident con_name}
-                            None)
-                         annotate_type
-                      else
-                        let vars =
-                          Ext_list.init arity (fun x ->
-                              "param_" ^ string_of_int x)
-                        in
-                        let exp =
-                          Exp.constraint_
-                            (Exp.construct
-                               {loc; txt = Longident.Lident con_name}
-                            @@ Some
-                                 (if arity = 1 then
-                                  Exp.ident {loc; txt = Lident (List.hd vars)}
-                                 else
-                                   Exp.tuple
-                                     (Ext_list.map vars (fun x ->
-                                          Exp.ident {loc; txt = Lident x}))))
-                            annotate_type
-                        in
-                        Ext_list.fold_right vars exp (fun var b ->
-                            Ast_compatible.fun_ (Pat.var {loc; txt = var}) b)))
+                         (*TODO: add a prefix, better inter-op with FFI *)
+                         Exp.constraint_
+                           (Exp.construct
+                              {loc; txt = Longident.Lident con_name}
+                              None)
+                           annotate_type
+                       else
+                         let vars =
+                           Ext_list.init arity (fun x ->
+                               "param_" ^ string_of_int x)
+                         in
+                         let exp =
+                           Exp.constraint_
+                             (Exp.construct
+                                {loc; txt = Longident.Lident con_name}
+                             @@ Some
+                                  (if arity = 1 then
+                                     Exp.ident
+                                       {loc; txt = Lident (List.hd vars)}
+                                   else
+                                     Exp.tuple
+                                       (Ext_list.map vars (fun x ->
+                                            Exp.ident {loc; txt = Lident x}))))
+                             annotate_type
+                         in
+                         Ext_list.fold_right vars exp (fun var b ->
+                             Ast_compatible.fun_ (Pat.var {loc; txt = var}) b)))
               | Ptype_abstract | Ptype_open ->
                 Ast_derive_util.notApplicable tdcl.ptype_loc derivingName;
                 []

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -882,22 +882,22 @@ let handle_attributes (loc : Bs_loc.t) (type_annotation : Parsetree.core_type)
           let arg_label = param_type.label in
           let ty = param_type.ty in
           (if i = 0 && splice then
-           match arg_label with
-           | Optional _ ->
-             Location.raise_errorf ~loc
-               "%@variadic expect the last type to be a non optional"
-           | Labelled _ | Nolabel -> (
-             if ty.ptyp_desc = Ptyp_any then
+             match arg_label with
+             | Optional _ ->
                Location.raise_errorf ~loc
-                 "%@variadic expect the last type to be an array";
-             if spec_of_ptyp true ty <> Nothing then
-               Location.raise_errorf ~loc
-                 "%@variadic expect the last type to be an array";
-             match ty.ptyp_desc with
-             | Ptyp_constr ({txt = Lident "array"; _}, [_]) -> ()
-             | _ ->
-               Location.raise_errorf ~loc
-                 "%@variadic expect the last type to be an array"));
+                 "%@variadic expect the last type to be a non optional"
+             | Labelled _ | Nolabel -> (
+               if ty.ptyp_desc = Ptyp_any then
+                 Location.raise_errorf ~loc
+                   "%@variadic expect the last type to be an array";
+               if spec_of_ptyp true ty <> Nothing then
+                 Location.raise_errorf ~loc
+                   "%@variadic expect the last type to be an array";
+               match ty.ptyp_desc with
+               | Ptyp_constr ({txt = Lident "array"; _}, [_]) -> ()
+               | _ ->
+                 Location.raise_errorf ~loc
+                   "%@variadic expect the last type to be an array"));
           let ( (arg_label : External_arg_spec.label_noname),
                 arg_type,
                 new_arg_types ) =
@@ -974,8 +974,7 @@ let pval_prim_of_option_labels (labels : (bool * string Asttypes.loc) list)
     (ends_with_unit : bool) =
   let arg_kinds =
     Ext_list.fold_right labels
-      (if ends_with_unit then [External_arg_spec.empty_kind Extern_unit]
-      else [])
+      (if ends_with_unit then [External_arg_spec.empty_kind Extern_unit] else [])
       (fun (is_option, p) arg_kinds ->
         let label_name = p.txt in
         let obj_arg_label =

--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -533,7 +533,7 @@ let rec structure_mapper ~await_context (self : mapper) (stru : Ast_structure.t)
     (* Dynamic import of module transformation: module M = @res.await Belt.List *)
     | Pstr_module
         ({pmb_expr = {pmod_desc = Pmod_ident {txt; loc}; pmod_attributes} as me}
-        as mb)
+         as mb)
       when Res_parsetree_viewer.hasAwaitAttribute pmod_attributes ->
       let item = self.structure_item self item in
       let safe_module_type_name = local_module_type_name txt in
@@ -580,8 +580,7 @@ let rec structure_mapper ~await_context (self : mapper) (stru : Ast_structure.t)
                match pvb_expr.pexp_desc with
                | Pexp_letmodule
                    ( _,
-                     ({pmod_desc = Pmod_ident {txt; loc}; pmod_attributes} as
-                     me),
+                     ({pmod_desc = Pmod_ident {txt; loc}; pmod_attributes} as me),
                      _ )
                  when Res_parsetree_viewer.hasAwaitAttribute pmod_attributes
                  -> (

--- a/jscomp/frontend/external_ffi_types.ml
+++ b/jscomp/frontend/external_ffi_types.ml
@@ -296,7 +296,7 @@ let inline_float_primitive (i : string) : string list =
 let rec ffi_bs_aux acc (params : External_arg_spec.params) =
   match params with
   | {arg_type = Nothing; arg_label = Arg_empty}
-    (* same as External_arg_spec.dummy*)
+      (* same as External_arg_spec.dummy*)
     :: rest ->
     ffi_bs_aux (acc + 1) rest
   | _ :: _ -> -1

--- a/jscomp/gentype/EmitJs.ml
+++ b/jscomp/gentype/EmitJs.ml
@@ -156,7 +156,7 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
       match type_ with
       | Function
           ({argTypes = [{aType = Object (closedFlag, fields); aName}]; retType}
-          as function_)
+           as function_)
         when retType |> EmitType.isTypeFunctionComponent ~fields ->
         (* JSX V3 *)
         let fields =
@@ -178,7 +178,7 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
         Function function_
       | Function
           ({argTypes = [{aType = Ident {name} as propsType; aName}]; retType} as
-          function_)
+           function_)
         when Filename.check_suffix name "props"
              && retType |> EmitType.isTypeFunctionComponent ~fields:[] -> (
         match inlineOneLevel propsType with
@@ -305,7 +305,7 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
           Some {HookType.propsType; resolvedTypeName; typeVars} )
       | Function
           ({argTypes = [{aType = Ident {name} as propsType}]; retType} as
-          function_)
+           function_)
         when Filename.check_suffix name "props"
              && retType |> EmitType.isTypeFunctionComponent ~fields:[] ->
         let compType =

--- a/jscomp/gentype/EmitType.ml
+++ b/jscomp/gentype/EmitType.ml
@@ -364,10 +364,11 @@ let emitExportType ~(config : Config.t) ~emitters ~nameAs ~opaque ~type_
     |> Emitters.export ~emitters
   else
     (if isInterface && config.exportInterfaces then
-     docString ^ "export interface " ^ resolvedTypeName ^ typeParamsString ^ " "
-    else
-      "// tslint:disable-next-line:interface-over-type-literal\n" ^ docString
-      ^ "export type " ^ resolvedTypeName ^ typeParamsString ^ " = ")
+       docString ^ "export interface " ^ resolvedTypeName ^ typeParamsString
+       ^ " "
+     else
+       "// tslint:disable-next-line:interface-over-type-literal\n" ^ docString
+       ^ "export type " ^ resolvedTypeName ^ typeParamsString ^ " = ")
     ^ (match type_ with
       | _ -> type_ |> typeToString ~config ~typeNameIsInterface)
     ^ ";" ^ exportNameAs

--- a/jscomp/gentype/GenTypeMain.ml
+++ b/jscomp/gentype/GenTypeMain.ml
@@ -167,4 +167,4 @@ let processCmtFile cmt =
     else (
       outputFile |> GeneratedFiles.logFileAction NoMatch;
       if Sys.file_exists outputFile then Sys.remove outputFile)
-  [@@live]
+[@@live]

--- a/jscomp/gentype/TranslateCoreType.ml
+++ b/jscomp/gentype/TranslateCoreType.ml
@@ -119,11 +119,11 @@ and translateCoreType_ ~config ~typeVarsGen
   | Ttyp_object (tObj, closedFlag) ->
     let getFieldType objectField =
       match objectField with
-      | Typedtree.OTtag ({txt = name}, _, t) -> (
+      | Typedtree.OTtag ({txt = name}, _, t) ->
         ( name,
           match name |> Runtime.isMutableObjectField with
           | true -> {dependencies = []; type_ = ident ""}
-          | false -> t |> translateCoreType_ ~config ~typeVarsGen ~typeEnv ))
+          | false -> t |> translateCoreType_ ~config ~typeVarsGen ~typeEnv )
       | OTinherit t ->
         ("Inherit", t |> translateCoreType_ ~config ~typeVarsGen ~typeEnv)
     in

--- a/jscomp/gentype/TranslateTypeDeclarations.ml
+++ b/jscomp/gentype/TranslateTypeDeclarations.ml
@@ -118,8 +118,8 @@ let traslateDeclarationKind ~config ~loc ~outputFileRelative ~resolver
     let fields =
       fieldTranslations
       |> List.map
-           (fun (name, mutable_, {TranslateTypeExprFromTypes.type_}, docString)
-           ->
+           (fun
+             (name, mutable_, {TranslateTypeExprFromTypes.type_}, docString) ->
              let optional, type1 =
                match type_ with
                | Option type1 when isOptional name -> (Optional, type1)

--- a/jscomp/syntax/cli/res_cli.ml
+++ b/jscomp/syntax/cli/res_cli.ml
@@ -90,7 +90,7 @@ module Color = struct
     | Format.String_tag "dim" -> [Dim]
     | Format.String_tag "filename" -> [FG Cyan]
     | _ -> raise Not_found
-    [@@raises Not_found]
+  [@@raises Not_found]
 
   let color_enabled = ref true
 
@@ -305,7 +305,7 @@ module CliArgProcessor = struct
         in
         printEngine.printImplementation ~width ~filename
           ~comments:parseResult.comments parsetree
-    [@@raises exit]
+  [@@raises exit]
 end
 
 let () =
@@ -317,4 +317,4 @@ let () =
       ~jsxVersion:!ResClflags.jsxVersion ~jsxModule:!ResClflags.jsxModule
       ~jsxMode:!ResClflags.jsxMode ~typechecker:!ResClflags.typechecker
       !ResClflags.file)
-  [@@raises exit]
+[@@raises exit]

--- a/jscomp/syntax/src/reactjs_jsx_v3.ml
+++ b/jscomp/syntax/src/reactjs_jsx_v3.ml
@@ -592,7 +592,7 @@ let jsxMapper ~config =
         pstr_desc =
           Pstr_primitive
             ({pval_name = {txt = fnName}; pval_attributes; pval_type} as
-            value_description);
+             value_description);
       } as pstr -> (
       match List.filter React_jsx_common.hasAttr pval_attributes with
       | [] -> [item]
@@ -1035,7 +1035,7 @@ let jsxMapper ~config =
         psig_desc =
           Psig_value
             ({pval_name = {txt = fnName}; pval_attributes; pval_type} as
-            psig_desc);
+             psig_desc);
       } as psig -> (
       match List.filter React_jsx_common.hasAttr pval_attributes with
       | [] -> [item]

--- a/jscomp/syntax/src/reactjs_jsx_v4.ml
+++ b/jscomp/syntax/src/reactjs_jsx_v4.ml
@@ -953,10 +953,10 @@ let mapBinding ~config ~emptyLoc ~pstr_loc ~fileName ~recFlag binding =
         | None -> makePropsPattern namedTypeList
         | Some _ -> makePropsPattern typVarsOfCoreType)
         (if hasForwardRef then
-         Exp.fun_ nolabel None
-           (Pat.var @@ Location.mknoloc "ref")
-           innerExpression
-        else innerExpression)
+           Exp.fun_ nolabel None
+             (Pat.var @@ Location.mknoloc "ref")
+             innerExpression
+         else innerExpression)
     in
     let fullExpression =
       if !Config.uncurried = Uncurried then
@@ -1274,8 +1274,8 @@ let transformSignatureItem ~config item =
           psig_loc
           ((* If there is Nolabel arg, regard the type as ref in forwardRef *)
            (if !hasForwardRef then
-            [(true, "ref", [], Location.none, refType Location.none)]
-           else [])
+              [(true, "ref", [], Location.none, refType Location.none)]
+            else [])
           @ namedTypeList)
       in
       (* can't be an arrow because it will defensively uncurry *)

--- a/jscomp/syntax/src/res_comment.ml
+++ b/jscomp/syntax/src/res_comment.ml
@@ -43,7 +43,7 @@ let makeMultiLineComment ~loc ~docComment ~standalone txt =
     loc;
     style =
       (if docComment then if standalone then ModuleComment else DocComment
-      else MultiLine);
+       else MultiLine);
     prevTokEndPos = Lexing.dummy_pos;
   }
 

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -66,8 +66,8 @@ module ErrorMessages = struct
      record, since a record needs an explicit declaration and that subset \
      wouldn't have one.\n\
      Solution: you need to pull out each field you want explicitly."
-    (* let recordPatternUnderscore = "Record patterns only support one `_`, at the end." *)
-    [@@live]
+  (* let recordPatternUnderscore = "Record patterns only support one `_`, at the end." *)
+  [@@live]
 
   let arrayPatternSpread =
     "Array's `...` spread is not supported in pattern matches.\n\
@@ -1290,9 +1290,9 @@ and parseRecordPattern ~attrs p =
         match field with
         | PatField field ->
           (if hasSpread then
-           let _, pattern = field in
-           Parser.err ~startPos:pattern.Parsetree.ppat_loc.loc_start p
-             (Diagnostics.message ErrorMessages.recordPatternSpread));
+             let _, pattern = field in
+             Parser.err ~startPos:pattern.Parsetree.ppat_loc.loc_start p
+               (Diagnostics.message ErrorMessages.recordPatternSpread));
           (field :: fields, flag)
         | PatUnderscore -> (fields, flag))
       ([], flag) rawFields
@@ -5621,7 +5621,7 @@ and parseStructureItemRegion p =
       Some
         (Ast_helper.Str.eval ~loc:(mkLoc p.startPos p.prevEndPos) ~attrs expr)
     | _ -> None)
-  [@@progress Parser.next, Parser.expect, LoopProgress.listRest]
+[@@progress Parser.next, Parser.expect, LoopProgress.listRest]
 
 (* include-statement ::= include module-expr *)
 and parseIncludeStatement ~attrs p =
@@ -6253,7 +6253,7 @@ and parseSignatureItemRegion p =
         (Diagnostics.message (ErrorMessages.attributeWithoutNode attr));
       Some Recover.defaultSignatureItem
     | _ -> None)
-  [@@progress Parser.next, Parser.expect, LoopProgress.listRest]
+[@@progress Parser.next, Parser.expect, LoopProgress.listRest]
 
 (* module rec module-name :  module-type  { and module-name:  module-type } *)
 and parseRecModuleSpec ~attrs ~startPos p =

--- a/jscomp/syntax/src/res_doc.ml
+++ b/jscomp/syntax/src/res_doc.ml
@@ -347,4 +347,4 @@ let debug t =
   in
   let doc = toDoc t in
   toString ~width:10 doc |> print_endline
-  [@@live]
+[@@live]

--- a/jscomp/syntax/src/res_driver.ml
+++ b/jscomp/syntax/src/res_driver.ml
@@ -140,7 +140,7 @@ let parse_implementation ?(ignoreParseErrors = false) sourcefile =
     Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
     if not ignoreParseErrors then exit 1);
   parseResult.parsetree
-  [@@raises exit]
+[@@raises exit]
 
 let parse_interface ?(ignoreParseErrors = false) sourcefile =
   Location.input_name := sourcefile;
@@ -151,11 +151,11 @@ let parse_interface ?(ignoreParseErrors = false) sourcefile =
     Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
     if not ignoreParseErrors then exit 1);
   parseResult.parsetree
-  [@@raises exit]
+[@@raises exit]
 
 (* suppress unused optional arg *)
 let _ =
  fun s ->
   ( parse_implementation ~ignoreParseErrors:false s,
     parse_interface ~ignoreParseErrors:false s )
- [@@raises exit]
+[@@raises exit]

--- a/jscomp/syntax/src/res_driver.mli
+++ b/jscomp/syntax/src/res_driver.mli
@@ -24,14 +24,14 @@ val parseImplementationFromSource :
   displayFilename:string ->
   source:string ->
   (Parsetree.structure, Res_diagnostics.t list) parseResult
-  [@@live]
+[@@live]
 
 val parseInterfaceFromSource :
   forPrinter:bool ->
   displayFilename:string ->
   source:string ->
   (Parsetree.signature, Res_diagnostics.t list) parseResult
-  [@@live]
+[@@live]
 
 type printEngine = {
   printImplementation:
@@ -55,8 +55,8 @@ val printEngine : printEngine
 (* ReScript implementation parsing compatible with ocaml pparse driver. Used by the compiler. *)
 val parse_implementation :
   ?ignoreParseErrors:bool -> string -> Parsetree.structure
-  [@@live] [@@raises Location.Error]
+[@@live] [@@raises Location.Error]
 
 (* ReScript interface parsing compatible with ocaml pparse driver. Used by the compiler *)
 val parse_interface : ?ignoreParseErrors:bool -> string -> Parsetree.signature
-  [@@live] [@@raises Location.Error]
+[@@live] [@@raises Location.Error]

--- a/jscomp/syntax/src/res_driver_ml_parser.mli
+++ b/jscomp/syntax/src/res_driver_ml_parser.mli
@@ -3,7 +3,7 @@
 (* extracts comments and the original string data from an ocaml file *)
 val extractOcamlConcreteSyntax :
   string -> (string * Location.t) list * Res_comment.t list
-  [@@live]
+[@@live]
 
 val parsingEngine : unit Res_driver.parsingEngine
 

--- a/jscomp/syntax/src/res_io.ml
+++ b/jscomp/syntax/src/res_io.ml
@@ -11,4 +11,4 @@ let writeFile ~filename ~contents:txt =
   let chan = open_out_bin filename in
   output_string chan txt;
   close_out chan
-  [@@raises Sys_error]
+[@@raises Sys_error]

--- a/jscomp/syntax/src/res_multi_printer.ml
+++ b/jscomp/syntax/src/res_multi_printer.ml
@@ -79,7 +79,7 @@ let printRes ~ignoreParseErrors ~isInterface ~filename =
       if not ignoreParseErrors then exit 1);
     Res_printer.printImplementation ~width:defaultPrintWidth
       ~comments:parseResult.comments parseResult.parsetree
-  [@@raises exit]
+[@@raises exit]
 
 (* print ocaml files to res syntax *)
 let printMl ~isInterface ~filename =
@@ -107,7 +107,7 @@ let print ?(ignoreParseErrors = false) language ~input =
   match language with
   | `res -> printRes ~ignoreParseErrors ~isInterface ~filename:input
   | `ml -> printMl ~isInterface ~filename:input
-  [@@raises exit]
+[@@raises exit]
 
 (* suppress unused optional arg *)
 let _ = fun s -> print ~ignoreParseErrors:false s [@@raises exit]

--- a/jscomp/syntax/src/res_outcome_printer.ml
+++ b/jscomp/syntax/src/res_outcome_printer.ml
@@ -395,7 +395,7 @@ and printOutVariant variant =
            Doc.concat
              [
                (if i > 0 then Doc.text "| "
-               else Doc.ifBreaks (Doc.text "| ") Doc.nil);
+                else Doc.ifBreaks (Doc.text "| ") Doc.nil);
                Doc.group
                  (Doc.concat
                     [
@@ -477,7 +477,7 @@ and printOutConstructorsDoc constructors =
                    Doc.concat
                      [
                        (if i > 0 then Doc.text "| "
-                       else Doc.ifBreaks (Doc.text "| ") Doc.nil);
+                        else Doc.ifBreaks (Doc.text "| ") Doc.nil);
                        printOutConstructorDoc constructor;
                      ])
                  constructors);
@@ -733,7 +733,7 @@ let rec printOutSigItemDoc ?(printNameAsIs = false)
                   attrs;
                   kw;
                   (if printNameAsIs then Doc.text outTypeDecl.otype_name
-                  else printIdentLike ~allowUident:false outTypeDecl.otype_name);
+                   else printIdentLike ~allowUident:false outTypeDecl.otype_name);
                   typeParams;
                   kind;
                 ]);
@@ -870,7 +870,7 @@ and printOutExtensionConstructorDoc
          Doc.text " += ";
          Doc.line;
          (if outExt.oext_private = Asttypes.Private then Doc.text "private "
-         else Doc.nil);
+          else Doc.nil);
          printOutConstructorDoc
            (outExt.oext_name, outExt.oext_args, outExt.oext_ret_type);
        ])
@@ -908,8 +908,8 @@ and printOutTypeExtensionDoc (typeExtension : Outcometree.out_type_extension) =
          typeParams;
          Doc.text " += ";
          (if typeExtension.otyext_private = Asttypes.Private then
-          Doc.text "private "
-         else Doc.nil);
+            Doc.text "private "
+          else Doc.nil);
          printOutConstructorsDoc typeExtension.otyext_constructors;
        ])
 

--- a/jscomp/syntax/src/res_outcome_printer.mli
+++ b/jscomp/syntax/src/res_outcome_printer.mli
@@ -15,4 +15,4 @@ val setup : unit lazy_t [@@live]
 val printOutTypeDoc : Outcometree.out_type -> Res_doc.t [@@live]
 val printOutSigItemDoc :
   ?printNameAsIs:bool -> Outcometree.out_sig_item -> Res_doc.t
-  [@@live]
+[@@live]

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -135,7 +135,7 @@ let rewriteUnderscoreApply expr =
           match arg with
           | ( lbl,
               ({pexp_desc = Pexp_ident ({txt = Longident.Lident "__x"} as lid)}
-              as argExpr) ) ->
+               as argExpr) ) ->
             ( lbl,
               {
                 argExpr with

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -216,7 +216,7 @@ let printLeadingComment ?nextComment comment =
     Doc.concat
       [
         (if singleLine then Doc.concat [Doc.hardLine; Doc.breakParent]
-        else Doc.nil);
+         else Doc.nil);
         (match nextComment with
         | Some next ->
           let nextLoc = Comment.loc next in
@@ -843,7 +843,7 @@ and printModType ~state modType cmtTbl =
                                        Doc.concat
                                          [
                                            (if lbl.txt = "_" then Doc.nil
-                                           else Doc.text ": ");
+                                            else Doc.text ": ");
                                            printModType ~state modType cmtTbl;
                                          ]);
                                    ]
@@ -896,7 +896,7 @@ and printModType ~state modType cmtTbl =
     Doc.concat
       [
         (if attrsAlreadyPrinted then Doc.nil
-        else printAttributes ~state modType.pmty_attributes cmtTbl);
+         else printAttributes ~state modType.pmty_attributes cmtTbl);
         modTypeDoc;
       ]
   in
@@ -1106,23 +1106,23 @@ and printValueDescription ~state valueDescription cmtTbl =
          Doc.text ": ";
          printTypExpr ~state valueDescription.pval_type cmtTbl;
          (if isExternal then
-          Doc.group
-            (Doc.concat
-               [
-                 Doc.text " =";
-                 Doc.indent
-                   (Doc.concat
-                      [
-                        Doc.line;
-                        Doc.join ~sep:Doc.line
-                          (List.map
-                             (fun s ->
-                               Doc.concat
-                                 [Doc.text "\""; Doc.text s; Doc.text "\""])
-                             valueDescription.pval_prim);
-                      ]);
-               ])
-         else Doc.nil);
+            Doc.group
+              (Doc.concat
+                 [
+                   Doc.text " =";
+                   Doc.indent
+                     (Doc.concat
+                        [
+                          Doc.line;
+                          Doc.join ~sep:Doc.line
+                            (List.map
+                               (fun s ->
+                                 Doc.concat
+                                   [Doc.text "\""; Doc.text s; Doc.text "\""])
+                               valueDescription.pval_prim);
+                        ]);
+                 ])
+          else Doc.nil);
        ])
 
 and printTypeDeclarations ~state ~recFlag typeDeclarations cmtTbl =
@@ -1604,16 +1604,16 @@ and printTypExpr ~(state : State.t) (typExpr : Parsetree.core_type) cmtTbl =
              Doc.group attrs;
              Doc.group
                (if hasAttrsBefore then
-                Doc.concat
-                  [
-                    Doc.lparen;
-                    Doc.indent
-                      (Doc.concat
-                         [Doc.softLine; typDoc; Doc.text " => "; returnDoc]);
-                    Doc.softLine;
-                    Doc.rparen;
-                  ]
-               else Doc.concat [typDoc; Doc.text " => "; returnDoc]);
+                  Doc.concat
+                    [
+                      Doc.lparen;
+                      Doc.indent
+                        (Doc.concat
+                           [Doc.softLine; typDoc; Doc.text " => "; returnDoc]);
+                      Doc.softLine;
+                      Doc.rparen;
+                    ]
+                else Doc.concat [typDoc; Doc.text " => "; returnDoc]);
            ])
     | args ->
       let attrs = printAttributes ~state ~inline:true attrsBefore cmtTbl in
@@ -2092,8 +2092,8 @@ and printValueBinding ~state ~recFlag (vb : Parsetree.value_binding) cmtTbl i =
              patternDoc;
              Doc.text " =";
              (if shouldIndent then
-              Doc.indent (Doc.concat [Doc.line; printedExpr])
-             else Doc.concat [Doc.space; printedExpr]);
+                Doc.indent (Doc.concat [Doc.line; printedExpr])
+              else Doc.concat [Doc.space; printedExpr]);
            ])
 
 and printPackageType ~state ~printModuleKeywordAndParens
@@ -2253,13 +2253,13 @@ and printPattern ~state (p : Parsetree.pattern) cmtTbl =
            [
              Doc.text "list{";
              (if shouldHug then children
-             else
-               Doc.concat
-                 [
-                   Doc.indent children;
-                   Doc.ifBreaks (Doc.text ",") Doc.nil;
-                   Doc.softLine;
-                 ]);
+              else
+                Doc.concat
+                  [
+                    Doc.indent children;
+                    Doc.ifBreaks (Doc.text ",") Doc.nil;
+                    Doc.softLine;
+                  ]);
              Doc.rbrace;
            ])
     | Ppat_construct (constrName, constructorArgs) ->
@@ -2304,13 +2304,13 @@ and printPattern ~state (p : Parsetree.pattern) cmtTbl =
             [
               Doc.lparen;
               (if shouldHug then argDoc
-              else
-                Doc.concat
-                  [
-                    Doc.indent (Doc.concat [Doc.softLine; argDoc]);
-                    Doc.trailingComma;
-                    Doc.softLine;
-                  ]);
+               else
+                 Doc.concat
+                   [
+                     Doc.indent (Doc.concat [Doc.softLine; argDoc]);
+                     Doc.trailingComma;
+                     Doc.softLine;
+                   ]);
               Doc.rparen;
             ]
       in
@@ -2355,13 +2355,13 @@ and printPattern ~state (p : Parsetree.pattern) cmtTbl =
             [
               Doc.lparen;
               (if shouldHug then argDoc
-              else
-                Doc.concat
-                  [
-                    Doc.indent (Doc.concat [Doc.softLine; argDoc]);
-                    Doc.trailingComma;
-                    Doc.softLine;
-                  ]);
+               else
+                 Doc.concat
+                   [
+                     Doc.indent (Doc.concat [Doc.softLine; argDoc]);
+                     Doc.trailingComma;
+                     Doc.softLine;
+                   ]);
               Doc.rparen;
             ]
       in
@@ -2410,8 +2410,7 @@ and printPattern ~state (p : Parsetree.pattern) cmtTbl =
             let patternDoc = printPattern ~state pat cmtTbl in
             Doc.concat
               [
-                (if i == 0 then Doc.nil
-                else Doc.concat [Doc.line; Doc.text "| "]);
+                (if i == 0 then Doc.nil else Doc.concat [Doc.line; Doc.text "| "]);
                 (match pat.ppat_desc with
                 (* (Blue | Red) | (Green | Black) | White *)
                 | Ppat_or _ -> addParens patternDoc
@@ -2526,8 +2525,8 @@ and printPatternRecordRow ~state row cmtTbl =
              printLidentPath longident cmtTbl;
              Doc.text ":";
              (if ParsetreeViewer.isHuggablePattern pattern then
-              Doc.concat [Doc.space; rhsDoc]
-             else Doc.indent (Doc.concat [Doc.line; rhsDoc]));
+                Doc.concat [Doc.space; rhsDoc]
+              else Doc.indent (Doc.concat [Doc.line; rhsDoc]));
            ])
     in
     printComments doc cmtTbl locForComments
@@ -2663,7 +2662,7 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
       else
         Doc.group
           (if shouldIndent then Doc.indent (Doc.concat [Doc.line; returnDoc])
-          else Doc.concat [Doc.space; returnDoc])
+           else Doc.concat [Doc.space; returnDoc])
     in
     let typConstraintDoc =
       match typConstraint with
@@ -2817,13 +2816,13 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
             [
               Doc.lparen;
               (if shouldHug then argDoc
-              else
-                Doc.concat
-                  [
-                    Doc.indent (Doc.concat [Doc.softLine; argDoc]);
-                    Doc.trailingComma;
-                    Doc.softLine;
-                  ]);
+               else
+                 Doc.concat
+                   [
+                     Doc.indent (Doc.concat [Doc.softLine; argDoc]);
+                     Doc.trailingComma;
+                     Doc.softLine;
+                   ]);
               Doc.rparen;
             ]
       in
@@ -2942,13 +2941,13 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
             [
               Doc.lparen;
               (if shouldHug then argDoc
-              else
-                Doc.concat
-                  [
-                    Doc.indent (Doc.concat [Doc.softLine; argDoc]);
-                    Doc.trailingComma;
-                    Doc.softLine;
-                  ]);
+               else
+                 Doc.concat
+                   [
+                     Doc.indent (Doc.concat [Doc.softLine; argDoc]);
+                     Doc.trailingComma;
+                     Doc.softLine;
+                   ]);
               Doc.rparen;
             ]
       in
@@ -3136,7 +3135,7 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
            [
              Doc.text "while ";
              (if ParsetreeViewer.isBlockExpr expr1 then condition
-             else Doc.group (Doc.ifBreaks (addParens condition) condition));
+              else Doc.group (Doc.ifBreaks (addParens condition) condition));
              Doc.space;
              printExpressionBlock ~state ~braces:true expr2 cmtTbl;
            ])
@@ -3376,14 +3375,14 @@ and printPexpFun ~state ~inCallback e cmtTbl =
     else
       Doc.group
         (if returnShouldIndent then
-         Doc.concat
-           [
-             Doc.indent (Doc.concat [Doc.line; returnDoc]);
-             (match inCallback with
-             | FitsOnOneLine | ArgumentsFitOnOneLine -> Doc.softLine
-             | _ -> Doc.nil);
-           ]
-        else Doc.concat [Doc.space; returnDoc])
+           Doc.concat
+             [
+               Doc.indent (Doc.concat [Doc.line; returnDoc]);
+               (match inCallback with
+               | FitsOnOneLine | ArgumentsFitOnOneLine -> Doc.softLine
+               | _ -> Doc.nil);
+             ]
+         else Doc.concat [Doc.space; returnDoc])
   in
   let typConstraintDoc =
     match typConstraint with
@@ -3431,8 +3430,8 @@ and printSetFieldExpr ~state attrs lhs longidentLoc rhs loc cmtTbl =
            printLidentPath longidentLoc cmtTbl;
            Doc.text " =";
            (if shouldIndent then
-            Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
-           else Doc.concat [Doc.space; rhsDoc]);
+              Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
+            else Doc.concat [Doc.space; rhsDoc]);
          ])
   in
   let doc =
@@ -3647,8 +3646,8 @@ and printBinaryExpression ~state (expr : Parsetree.expression) cmtTbl =
                    lhsDoc;
                    Doc.text " =";
                    (if shouldIndent then
-                    Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
-                   else Doc.concat [Doc.space; rhsDoc]);
+                      Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
+                    else Doc.concat [Doc.space; rhsDoc]);
                  ])
           in
           let doc =
@@ -3853,8 +3852,8 @@ and printPexpApply ~state expr cmtTbl =
              printExpressionWithComments ~state lhs cmtTbl;
              Doc.text " =";
              (if shouldIndent then
-              Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
-             else Doc.concat [Doc.space; rhsDoc]);
+                Doc.group (Doc.indent (Doc.concat [Doc.line; rhsDoc]))
+              else Doc.concat [Doc.space; rhsDoc]);
            ])
     in
     match expr.pexp_attributes with
@@ -3963,8 +3962,8 @@ and printPexpApply ~state expr cmtTbl =
            Doc.rbracket;
            Doc.text " =";
            (if shouldIndentTargetExpr then
-            Doc.indent (Doc.concat [Doc.line; targetExpr])
-           else Doc.concat [Doc.space; targetExpr]);
+              Doc.indent (Doc.concat [Doc.line; targetExpr])
+            else Doc.concat [Doc.space; targetExpr]);
          ])
   (* TODO: cleanup, are those branches even remotely performant? *)
   | Pexp_apply ({pexp_desc = Pexp_ident lident}, args)
@@ -4109,24 +4108,24 @@ and printJsxExpression ~state lident args cmtTbl =
                   else Doc.greaterThan);
               ]);
          (if isSelfClosing then Doc.nil
-         else
-           Doc.concat
-             [
-               (if hasChildren then printChildren children
-               else
-                 match children with
-                 | Some
-                     {
-                       Parsetree.pexp_desc =
-                         Pexp_construct ({txt = Longident.Lident "[]"}, None);
-                       pexp_loc = loc;
-                     } ->
-                   printCommentsInside cmtTbl loc
-                 | _ -> Doc.nil);
-               Doc.text "</";
-               name;
-               Doc.greaterThan;
-             ]);
+          else
+            Doc.concat
+              [
+                (if hasChildren then printChildren children
+                 else
+                   match children with
+                   | Some
+                       {
+                         Parsetree.pexp_desc =
+                           Pexp_construct ({txt = Longident.Lident "[]"}, None);
+                         pexp_loc = loc;
+                       } ->
+                     printCommentsInside cmtTbl loc
+                   | _ -> Doc.nil);
+                Doc.text "</";
+                name;
+                Doc.greaterThan;
+              ]);
        ])
 
 and printJsxFragment ~state expr cmtTbl =
@@ -4859,9 +4858,9 @@ and printExprFunParameters ~state ~inCallback ~async ~uncurried ~hasConstraint
          [
            maybeAsyncLparen;
            (if shouldHug || inCallback then printedParamaters
-           else
-             Doc.concat
-               [Doc.indent printedParamaters; Doc.trailingComma; Doc.softLine]);
+            else
+              Doc.concat
+                [Doc.indent printedParamaters; Doc.trailingComma; Doc.softLine]);
            Doc.rparen;
          ])
 
@@ -5082,14 +5081,14 @@ and printExpressionBlock ~state ~braces expr cmtTbl =
   in
   Doc.breakableGroup ~forceBreak:true
     (if braces then
-     Doc.concat
-       [
-         Doc.lbrace;
-         Doc.indent (Doc.concat [Doc.line; block]);
-         Doc.line;
-         Doc.rbrace;
-       ]
-    else block)
+       Doc.concat
+         [
+           Doc.lbrace;
+           Doc.indent (Doc.concat [Doc.line; block]);
+           Doc.line;
+           Doc.rbrace;
+         ]
+     else block)
 
 (*
  * // user types:
@@ -5404,12 +5403,12 @@ and printModExpr ~state modExpr cmtTbl =
            [
              Doc.text "unpack(";
              (if shouldHug then unpackDoc
-             else
-               Doc.concat
-                 [
-                   Doc.indent (Doc.concat [Doc.softLine; unpackDoc]);
-                   Doc.softLine;
-                 ]);
+              else
+                Doc.concat
+                  [
+                    Doc.indent (Doc.concat [Doc.softLine; unpackDoc]);
+                    Doc.softLine;
+                  ]);
              Doc.rparen;
            ])
     | Pmod_extension extension ->
@@ -5431,32 +5430,32 @@ and printModExpr ~state modExpr cmtTbl =
            [
              printModExpr ~state callExpr cmtTbl;
              (if isUnitSugar then
-              printModApplyArg ~state (List.hd args [@doesNotRaise]) cmtTbl
-             else
-               Doc.concat
-                 [
-                   Doc.lparen;
-                   (if shouldHug then
-                    printModApplyArg ~state
-                      (List.hd args [@doesNotRaise])
-                      cmtTbl
-                   else
-                     Doc.indent
-                       (Doc.concat
-                          [
-                            Doc.softLine;
-                            Doc.join
-                              ~sep:(Doc.concat [Doc.comma; Doc.line])
-                              (List.map
-                                 (fun modArg ->
-                                   printModApplyArg ~state modArg cmtTbl)
-                                 args);
-                          ]));
-                   (if not shouldHug then
-                    Doc.concat [Doc.trailingComma; Doc.softLine]
-                   else Doc.nil);
-                   Doc.rparen;
-                 ]);
+                printModApplyArg ~state (List.hd args [@doesNotRaise]) cmtTbl
+              else
+                Doc.concat
+                  [
+                    Doc.lparen;
+                    (if shouldHug then
+                       printModApplyArg ~state
+                         (List.hd args [@doesNotRaise])
+                         cmtTbl
+                     else
+                       Doc.indent
+                         (Doc.concat
+                            [
+                              Doc.softLine;
+                              Doc.join
+                                ~sep:(Doc.concat [Doc.comma; Doc.line])
+                                (List.map
+                                   (fun modArg ->
+                                     printModApplyArg ~state modArg cmtTbl)
+                                   args);
+                            ]));
+                    (if not shouldHug then
+                       Doc.concat [Doc.trailingComma; Doc.softLine]
+                     else Doc.nil);
+                    Doc.rparen;
+                  ]);
            ])
     | Pmod_constraint (modExpr, modType) ->
       Doc.concat

--- a/jscomp/syntax/src/res_printer.mli
+++ b/jscomp/syntax/src/res_printer.mli
@@ -15,10 +15,10 @@ val addParens : Res_doc.t -> Res_doc.t
 val printExpression : Parsetree.expression -> Res_comments_table.t -> Res_doc.t
 
 val printPattern : Parsetree.pattern -> Res_comments_table.t -> Res_doc.t
-  [@@live]
+[@@live]
 
 val printStructure : Parsetree.structure -> Res_comments_table.t -> Res_doc.t
-  [@@live]
+[@@live]
 
 val printImplementation :
   width:int -> Parsetree.structure -> comments:Res_comment.t list -> string

--- a/jscomp/syntax/src/res_scanner.ml
+++ b/jscomp/syntax/src/res_scanner.ml
@@ -92,7 +92,7 @@ let _printDebug ~startPos ~endPos scanner token =
   print_char '-';
   print_int endPos.pos_cnum;
   print_endline ""
-  [@@live]
+[@@live]
 
 let next scanner =
   let nextOffset = scanner.offset + 1 in

--- a/jscomp/syntax/src/res_token.ml
+++ b/jscomp/syntax/src/res_token.ml
@@ -238,7 +238,7 @@ let keywordTable = function
   | "when" -> When
   | "while" -> While
   | _ -> raise Not_found
-  [@@raises Not_found]
+[@@raises Not_found]
 
 let isKeyword = function
   | Await | And | As | Assert | Constraint | Else | Exception | External | False

--- a/rescript.opam
+++ b/rescript.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
   "ocaml" {>= "4.10"}
-  "ocamlformat" {= "0.22.4"}
+  "ocamlformat" {= "0.26.0"}
   "cppo" {= "1.6.9"}
   "js_of_ocaml-compiler" {= "4.0.0"}
   "ounit2" {= "2.2.6"}


### PR DESCRIPTION
Upgrade ocamlformat from 0.22.4 to 0.26.0 because

* it seems the old version conflicts with the latest ocaml-lsp-server
* the (few) formatting changes actually look like improvements