### PR TITLE
setup-ocaml: activate dune-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
           opam-depext: false
+          dune-cache: true
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
This used to fail on Windows and might be working again now, see https://github.com/ocaml/setup-ocaml/issues/449#issuecomment-1609260895.