### PR TITLE
Bring `#import` back for Core compatibility

### DIFF
--- a/compiler/ml/translcore.ml
+++ b/compiler/ml/translcore.ml
@@ -396,6 +396,7 @@ let primitives_table =
       ("#nullable_to_opt", Pnull_to_opt);
       ("#undefined_to_opt", Pundefined_to_opt);
       ("#makemutablelist", Pmakelist Mutable);
+      ("#import", Pimport);
       (* FIXME: Deprecated *)
       ("%obj_field", Parrayrefu);
     |]


### PR DESCRIPTION
The primitive for dynamic import has been renamed to `%import`,
but there are a few libraries directly rely on compiler primitives.
