### PR TITLE
fix: incorrect comment on Math.sign

### DIFF
--- a/runtime/Math.resi
+++ b/runtime/Math.resi
@@ -270,7 +270,7 @@ module Int: {
 
   ```rescript
   Math.Int.sign(3) // 1
-  Math.Int.sign(-3) // 1
+  Math.Int.sign(-3) // -1
   Math.Int.sign(0) // 0
   ```
   */


### PR DESCRIPTION
Math.sign(negative_value) should be -1.0 instead of 1.0