### PR TITLE
AST cleanup: first class expression and patterns for records with opt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added infra to modernise AST: theres' Parsetree, Parsetree0 (legacy), and conversion functions to keep compatibility with PPX. https://github.com/rescript-lang/rescript/pull/7185
 - Ast cleanup: remove exp object and exp unreachable. https://github.com/rescript-lang/rescript/pull/7189
 - Ast cleanup: explicit representation for optional record fields in types. https://github.com/rescript-lang/rescript/pull/7190 https://github.com/rescript-lang/rescript/pull/7191
+- AST cleanup: first-class expression and patterns for records with optional fields. https://github.com/rescript-lang/rescript/pull/7192
 
 
 # 12.0.0-alpha.5

--- a/analysis/reanalyze/src/Arnold.ml
+++ b/analysis/reanalyze/src/Arnold.ml
@@ -947,7 +947,8 @@ module Compile = struct
          |> List.map
               (fun
                 ( _desc,
-                  (recordLabelDefinition : Typedtree.record_label_definition) )
+                  (recordLabelDefinition : Typedtree.record_label_definition),
+                  _ )
               ->
                 match recordLabelDefinition with
                 | Kept _typeExpr -> None

--- a/analysis/reanalyze/src/DeadValue.ml
+++ b/analysis/reanalyze/src/DeadValue.ml
@@ -192,7 +192,7 @@ let rec collectExpr super self (e : Typedtree.expression) =
       DeadType.addTypeReference ~posTo ~posFrom:locFrom.loc_start
   | Texp_record {fields} ->
     fields
-    |> Array.iter (fun (_, record_label_definition) ->
+    |> Array.iter (fun (_, record_label_definition, _) ->
            match record_label_definition with
            | Typedtree.Overridden (_, ({exp_loc} as e)) when exp_loc.loc_ghost
              ->
@@ -219,7 +219,7 @@ let collectPattern : _ -> _ -> Typedtree.pattern -> Typedtree.pattern =
   (match pat.pat_desc with
   | Typedtree.Tpat_record (cases, _clodsedFlag) ->
     cases
-    |> List.iter (fun (_loc, {Types.lbl_loc = {loc_start = posTo}}, _pat) ->
+    |> List.iter (fun (_loc, {Types.lbl_loc = {loc_start = posTo}}, _pat, _) ->
            if !Config.analyzeTypes then
              DeadType.addTypeReference ~posFrom ~posTo)
   | _ -> ());

--- a/analysis/reanalyze/src/SideEffects.ml
+++ b/analysis/reanalyze/src/SideEffects.ml
@@ -75,7 +75,8 @@ and exprOptNoSideEffects eo =
   | None -> true
   | Some e -> e |> exprNoSideEffects
 
-and fieldNoSideEffects ((_ld, rld) : _ * Typedtree.record_label_definition) =
+and fieldNoSideEffects
+    ((_ld, rld, _) : _ * Typedtree.record_label_definition * _) =
   match rld with
   | Kept _typeExpr -> true
   | Overridden (_lid, e) -> e |> exprNoSideEffects

--- a/analysis/src/CompletionExpressions.ml
+++ b/analysis/src/CompletionExpressions.ml
@@ -60,7 +60,7 @@ let rec traverseExpr (exp : Parsetree.expression) ~exprPath ~pos
     let fieldWithCursor = ref None in
     let fieldWithExprHole = ref None in
     fields
-    |> List.iter (fun (fname, exp) ->
+    |> List.iter (fun (fname, exp, _) ->
            match
              ( fname.Location.txt,
                exp.Parsetree.pexp_loc |> CursorPosition.classifyLoc ~pos )
@@ -72,7 +72,7 @@ let rec traverseExpr (exp : Parsetree.expression) ~exprPath ~pos
            | _ -> ());
     let seenFields =
       fields
-      |> List.filter_map (fun (fieldName, _f) ->
+      |> List.filter_map (fun (fieldName, _f, _) ->
              match fieldName with
              | {Location.txt = Longident.Lident fieldName} -> Some fieldName
              | _ -> None)

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -473,7 +473,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
         ?contextPath p
     | Ppat_record (fields, _) ->
       fields
-      |> List.iter (fun (fname, p) ->
+      |> List.iter (fun (fname, p, _) ->
              match fname with
              | {Location.txt = Longident.Lident fname} ->
                scopePattern
@@ -879,7 +879,8 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
                  Pstr_eval
                    ( {
                        pexp_desc =
-                         Pexp_record (({txt = Lident "from"}, fromExpr) :: _, _);
+                         Pexp_record
+                           (({txt = Lident "from"}, fromExpr, _) :: _, _);
                      },
                      _ );
              };

--- a/analysis/src/CompletionPatterns.ml
+++ b/analysis/src/CompletionPatterns.ml
@@ -112,7 +112,7 @@ and traversePattern (pat : Parsetree.pattern) ~patternPath ~locHasCursor
     let fieldWithCursor = ref None in
     let fieldWithPatHole = ref None in
     fields
-    |> List.iter (fun (fname, f) ->
+    |> List.iter (fun (fname, f, _) ->
            match
              ( fname.Location.txt,
                f.Parsetree.ppat_loc
@@ -125,7 +125,7 @@ and traversePattern (pat : Parsetree.pattern) ~patternPath ~locHasCursor
            | _ -> ());
     let seenFields =
       fields
-      |> List.filter_map (fun (fieldName, _f) ->
+      |> List.filter_map (fun (fieldName, _f, _) ->
              match fieldName with
              | {Location.txt = Longident.Lident fieldName} -> Some fieldName
              | _ -> None)

--- a/analysis/src/DumpAst.ml
+++ b/analysis/src/DumpAst.ml
@@ -104,7 +104,7 @@ let rec printPattern pattern ~pos ~indentation =
     ^ addIndentation (indentation + 1)
     ^ "fields:\n"
     ^ (fields
-      |> List.map (fun ((Location.{txt} as loc), pat) ->
+      |> List.map (fun ((Location.{txt} as loc), pat, _) ->
              addIndentation (indentation + 2)
              ^ (loc |> printLocDenominatorLoc ~pos)
              ^ (Utils.flattenLongIdent txt |> ident |> str)
@@ -245,7 +245,7 @@ and printExprItem expr ~pos ~indentation =
     ^ addIndentation (indentation + 1)
     ^ "fields:\n"
     ^ (fields
-      |> List.map (fun ((Location.{txt} as loc), expr) ->
+      |> List.map (fun ((Location.{txt} as loc), expr, _) ->
              addIndentation (indentation + 2)
              ^ (loc |> printLocDenominatorLoc ~pos)
              ^ (Utils.flattenLongIdent txt |> ident |> str)

--- a/analysis/src/Hint.ml
+++ b/analysis/src/Hint.ml
@@ -44,7 +44,7 @@ let inlay ~path ~pos ~maxLength ~debug =
     match pat.ppat_desc with
     | Ppat_tuple pl -> pl |> List.iter processPattern
     | Ppat_record (fields, _) ->
-      fields |> List.iter (fun (_, p) -> processPattern p)
+      fields |> List.iter (fun (_, p, _) -> processPattern p)
     | Ppat_array fields -> fields |> List.iter processPattern
     | Ppat_var {loc} -> push loc Type
     | _ -> ()

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -459,7 +459,7 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         pats |> List.iter (fun p -> handlePattern [] p)
       | Tpat_or (p, _, _) -> handlePattern [] p
       | Tpat_record (items, _) ->
-        items |> List.iter (fun (_, _, p) -> handlePattern [] p)
+        items |> List.iter (fun (_, _, p, _) -> handlePattern [] p)
       | Tpat_lazy p -> handlePattern [] p
       | Tpat_variant (_, Some p, _) -> handlePattern [] p
       | Tpat_variant (_, None, _) | Tpat_any | Tpat_constant _ -> ()

--- a/analysis/src/ProcessExtra.ml
+++ b/analysis/src/ProcessExtra.ml
@@ -237,7 +237,7 @@ let addForRecord ~env ~extra ~recordType items =
   | Tconstr (path, _args, _memo) ->
     let t = getTypeAtPath ~env path in
     items
-    |> List.iter (fun ({Asttypes.txt; loc}, _, _) ->
+    |> List.iter (fun ({Asttypes.txt; loc}, _, _, _) ->
            (* let name = Longident.last(txt); *)
            let name = handleConstructor txt in
            let nameLoc = Utils.endOfLocation loc (String.length name) in
@@ -394,9 +394,9 @@ let expr ~env ~(extra : extra) (iter : Tast_iterator.iterator)
   | Texp_record {fields} ->
     addForRecord ~env ~extra ~recordType:expression.exp_type
       (fields |> Array.to_list
-      |> Utils.filterMap (fun (desc, item) ->
+      |> Utils.filterMap (fun (desc, item, opt) ->
              match item with
-             | Typedtree.Overridden (loc, _) -> Some (loc, desc, ())
+             | Typedtree.Overridden (loc, _) -> Some (loc, desc, (), opt)
              | _ -> None))
   | Texp_constant constant ->
     addLocItem extra expression.exp_loc (Constant constant)

--- a/analysis/src/SemanticTokens.ml
+++ b/analysis/src/SemanticTokens.ml
@@ -226,7 +226,8 @@ let command ~debug ~emitter ~path =
       Ast_iterator.default_iterator.pat iterator p
     | Ppat_record (cases, _) ->
       cases
-      |> List.iter (fun (label, _) -> emitter |> emitRecordLabel ~label ~debug);
+      |> List.iter (fun (label, _, _) ->
+             emitter |> emitRecordLabel ~label ~debug);
       Ast_iterator.default_iterator.pat iterator p
     | Ppat_construct (name, _) ->
       emitter |> emitVariant ~name ~debug;
@@ -309,7 +310,7 @@ let command ~debug ~emitter ~path =
       Ast_iterator.default_iterator.expr iterator e
     | Pexp_record (cases, _) ->
       cases
-      |> List.filter_map (fun ((label : Longident.t Location.loc), _) ->
+      |> List.filter_map (fun ((label : Longident.t Location.loc), _, _) ->
              match label.txt with
              | Longident.Lident s when not (Utils.isFirstCharUppercase s) ->
                Some label

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -637,8 +637,10 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                   fields
                   |> List.find_map
                        (fun
-                         (({loc; txt}, expr) :
-                           Longident.t Location.loc * Parsetree.expression)
+                         (({loc; txt}, expr, _) :
+                           Longident.t Location.loc
+                           * Parsetree.expression
+                           * bool)
                        ->
                          if
                            posBeforeCursor >= Pos.ofLexing loc.loc_start
@@ -679,8 +681,8 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                   fields
                   |> List.find_map
                        (fun
-                         (({loc; txt}, pat) :
-                           Longident.t Location.loc * Parsetree.pattern)
+                         (({loc; txt}, pat, _) :
+                           Longident.t Location.loc * Parsetree.pattern * bool)
                        ->
                          if
                            posBeforeCursor >= Pos.ofLexing loc.loc_start

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -78,10 +78,10 @@ module IfThenElse = struct
       | None -> None
       | Some patList -> Some (mkPat (Ppat_tuple patList)))
     | Pexp_record (items, None) -> (
-      let itemToPat (x, e) =
+      let itemToPat (x, e, o) =
         match expToPat e with
         | None -> None
-        | Some p -> Some (x, p)
+        | Some p -> Some (x, p, o)
       in
       match listToPat ~itemToPat items with
       | None -> None

--- a/compiler/common/pattern_printer.ml
+++ b/compiler/common/pattern_printer.ml
@@ -32,7 +32,8 @@ let untype typed =
     | Tpat_record (subpatterns, closed_flag) ->
       let fields =
         List.map
-          (fun (_, lbl, p) -> (mknoloc (Longident.Lident lbl.lbl_name), loop p))
+          (fun (_, lbl, p, opt) ->
+            (mknoloc (Longident.Lident lbl.lbl_name), loop p, opt))
           subpatterns
       in
       mkpat (Ppat_record (fields, closed_flag))

--- a/compiler/frontend/ast_derive_js_mapper.ml
+++ b/compiler/frontend/ast_derive_js_mapper.ml
@@ -44,7 +44,8 @@ let handle_config (config : Parsetree.expression option) =
                   ( Pexp_construct
                       ({txt = Lident (("true" | "false") as x)}, None)
                   | Pexp_ident {txt = Lident ("newType" as x)} );
-              } );
+              },
+              _ );
           ],
           None ) ->
       not (x = "false")
@@ -193,7 +194,7 @@ let init () =
                                            txt = Longident.Lident txt;
                                          }
                                        in
-                                       (label, Exp.field exp_param label)))
+                                       (label, Exp.field exp_param label, false)))
                                   None);
                            ] ))
                 in
@@ -205,7 +206,7 @@ let init () =
                          let label =
                            {Asttypes.loc; txt = Longident.Lident txt}
                          in
-                         (label, js_field exp_param label)))
+                         (label, js_field exp_param label, false)))
                     None
                 in
                 let from_js =

--- a/compiler/frontend/ast_external_process.ml
+++ b/compiler/frontend/ast_external_process.ml
@@ -266,8 +266,8 @@ let parse_external_attributes (no_arguments : bool) (prim_name_check : string)
               fields
               |> List.iter
                    (fun
-                     ((l, exp) :
-                       Longident.t Location.loc * Parsetree.expression)
+                     ((l, exp, _) :
+                       Longident.t Location.loc * Parsetree.expression * bool)
                    ->
                      match (l, exp.pexp_desc) with
                      | ( {txt = Lident "from"; _},
@@ -293,8 +293,10 @@ let parse_external_attributes (no_arguments : bool) (prim_name_check : string)
                   with_fields
                   |> List.filter_map
                        (fun
-                         ((l, exp) :
-                           Longident.t Location.loc * Parsetree.expression)
+                         ((l, exp, _) :
+                           Longident.t Location.loc
+                           * Parsetree.expression
+                           * bool)
                        ->
                          match exp.pexp_desc with
                          | Pexp_constant (Pconst_string (s, _)) -> (

--- a/compiler/frontend/ast_tuple_pattern_flatten.ml
+++ b/compiler/frontend/ast_tuple_pattern_flatten.ml
@@ -65,7 +65,7 @@ let flattern_tuple_pattern_vb (self : Bs_ast_mapper.mapper)
           :: acc)
     | _ -> {pvb_pat; pvb_expr; pvb_loc = vb.pvb_loc; pvb_attributes} :: acc)
   | Ppat_record (lid_pats, _), Pexp_pack {pmod_desc = Pmod_ident id} ->
-    Ext_list.map_append lid_pats acc (fun (lid, pat) ->
+    Ext_list.map_append lid_pats acc (fun (lid, pat, _) ->
         match lid.txt with
         | Lident s ->
           {

--- a/compiler/frontend/ast_uncurry_gen.ml
+++ b/compiler/frontend/ast_uncurry_gen.ml
@@ -57,7 +57,9 @@ let to_method_callback loc (self : Bs_ast_mapper.mapper) label
         ( Nolabel,
           Exp.constraint_ ~loc
             (Exp.record ~loc
-               [({loc; txt = Ast_literal.Lid.hidden_field arity_s}, body)]
+               [
+                 ({loc; txt = Ast_literal.Lid.hidden_field arity_s}, body, false);
+               ]
                None)
             (Typ.constr ~loc
                {

--- a/compiler/frontend/ast_util.ml
+++ b/compiler/frontend/ast_util.ml
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression) list
+type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression * bool) list
 
 let js_property loc obj (name : string) =
   Parsetree.Pexp_send (obj, {loc; txt = name})
@@ -31,7 +31,7 @@ let record_as_js_object loc (self : Bs_ast_mapper.mapper)
     (label_exprs : label_exprs) : Parsetree.expression_desc =
   let labels, args, arity =
     Ext_list.fold_right label_exprs ([], [], 0)
-      (fun ({txt; loc}, e) (labels, args, i) ->
+      (fun ({txt; loc}, e, _) (labels, args, i) ->
         match txt with
         | Lident x ->
           ( {Asttypes.loc; txt = x} :: labels,

--- a/compiler/frontend/ast_util.mli
+++ b/compiler/frontend/ast_util.mli
@@ -28,7 +28,7 @@
     - convert a uncuried application to normal 
 *)
 
-type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression) list
+type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression * bool) list
 
 val record_as_js_object :
   Location.t -> Bs_ast_mapper.mapper -> label_exprs -> Parsetree.expression_desc

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -69,6 +69,7 @@ type mapper = {
   with_constraint: mapper -> with_constraint -> with_constraint;
 }
 
+let id x = x
 let map_fst f (x, y) = (f x, y)
 let map_snd f (x, y) = (x, f y)
 let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
@@ -331,7 +332,7 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) l)
+        (List.map (map_tuple3 (map_loc sub) (sub.expr sub) id) l)
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -397,7 +398,7 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
+        (List.map (map_tuple3 (map_loc sub) (sub.pat sub) id) lpl)
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -99,7 +99,11 @@ module Pat : sig
   val construct : ?loc:loc -> ?attrs:attrs -> lid -> pattern option -> pattern
   val variant : ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
   val record :
-    ?loc:loc -> ?attrs:attrs -> (lid * pattern) list -> closed_flag -> pattern
+    ?loc:loc ->
+    ?attrs:attrs ->
+    (lid * pattern * bool) list ->
+    closed_flag ->
+    pattern
   val array : ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
   val or_ : ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern
   val constraint_ : ?loc:loc -> ?attrs:attrs -> pattern -> core_type -> pattern
@@ -150,7 +154,7 @@ module Exp : sig
   val record :
     ?loc:loc ->
     ?attrs:attrs ->
-    (lid * expression) list ->
+    (lid * expression * bool) list ->
     expression option ->
     expression
   val field : ?loc:loc -> ?attrs:attrs -> expression -> lid -> expression

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -302,7 +302,7 @@ module E = struct
       iter_opt (sub.expr sub) arg
     | Pexp_variant (_lab, eo) -> iter_opt (sub.expr sub) eo
     | Pexp_record (l, eo) ->
-      List.iter (iter_tuple (iter_loc sub) (sub.expr sub)) l;
+      List.iter (iter_tuple3 (iter_loc sub) (sub.expr sub) (fun _ -> ())) l;
       iter_opt (sub.expr sub) eo
     | Pexp_field (e, lid) ->
       sub.expr sub e;
@@ -380,7 +380,7 @@ module P = struct
       iter_opt (sub.pat sub) p
     | Ppat_variant (_l, p) -> iter_opt (sub.pat sub) p
     | Ppat_record (lpl, _cf) ->
-      List.iter (iter_tuple (iter_loc sub) (sub.pat sub)) lpl
+      List.iter (iter_tuple3 (iter_loc sub) (sub.pat sub) (fun _ -> ())) lpl
     | Ppat_array pl -> List.iter (sub.pat sub) pl
     | Ppat_or (p1, p2) ->
       sub.pat sub p1;

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -61,6 +61,7 @@ type mapper = {
   with_constraint: mapper -> with_constraint -> with_constraint;
 }
 
+let id x = x
 let map_fst f (x, y) = (f x, y)
 let map_snd f (x, y) = (x, f y)
 let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
@@ -294,7 +295,7 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) l)
+        (List.map (map_tuple3 (map_loc sub) (sub.expr sub) id) l)
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -360,7 +361,7 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
+        (List.map (map_tuple3 (map_loc sub) (sub.pat sub) (fun x -> x)) lpl)
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)
@@ -534,7 +535,8 @@ module PpxContext = struct
     ( lid "cookies",
       make_list
         (make_pair make_string (fun x -> x))
-        (StringMap.bindings !cookies) )
+        (StringMap.bindings !cookies),
+      false )
 
   let mk fields =
     ( {txt = "ocaml.ppx.context"; loc = Location.none},
@@ -543,11 +545,11 @@ module PpxContext = struct
   let make ~tool_name () =
     let fields =
       [
-        (lid "tool_name", make_string tool_name);
-        (lid "include_dirs", make_list make_string !Clflags.include_dirs);
-        (lid "load_path", make_list make_string !Config.load_path);
-        (lid "open_modules", make_list make_string !Clflags.open_modules);
-        (lid "debug", make_bool !Clflags.debug);
+        (lid "tool_name", make_string tool_name, false);
+        (lid "include_dirs", make_list make_string !Clflags.include_dirs, false);
+        (lid "load_path", make_list make_string !Config.load_path, false);
+        (lid "open_modules", make_list make_string !Clflags.open_modules, false);
+        (lid "debug", make_bool !Clflags.debug, false);
         get_cookies ();
       ]
     in
@@ -616,14 +618,14 @@ module PpxContext = struct
     in
     List.iter
       (function
-        | {txt = Lident name}, x -> field name x
+        | {txt = Lident name}, x, _ -> field name x
         | _ -> ())
       fields
 
   let update_cookies fields =
     let fields =
       Ext_list.filter fields (function
-        | {txt = Lident "cookies"}, _ -> false
+        | {txt = Lident "cookies"}, _, _ -> false
         | _ -> true)
     in
     fields @ [get_cookies ()]

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -301,7 +301,13 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) l)
+        (Ext_list.map l (fun (lid, e) ->
+             let lid1 = map_loc sub lid in
+             let e1 = sub.expr sub e in
+             let optional, attrs =
+               Parsetree0.get_optional_attr e1.pexp_attributes
+             in
+             (lid1, {e1 with pexp_attributes = attrs}, optional)))
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -370,7 +376,13 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
+        (Ext_list.map lpl (fun (lid, p) ->
+             let lid1 = map_loc sub lid in
+             let p1 = sub.pat sub p in
+             let optional, attrs =
+               Parsetree0.get_optional_attr p1.ppat_attributes
+             in
+             (lid1, {p1 with ppat_attributes = attrs}, optional)))
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -300,7 +300,13 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) l)
+        (Ext_list.map l (fun (lid, e, optional) ->
+             let lid1 = map_loc sub lid in
+             let e1 = sub.expr sub e in
+             let attr =
+               Parsetree0.add_optional_attr ~optional e1.pexp_attributes
+             in
+             (lid1, {e1 with pexp_attributes = attr})))
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -367,7 +373,13 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
+        (Ext_list.map lpl (fun (lid, p, optional) ->
+             let lid1 = map_loc sub lid in
+             let p1 = sub.pat sub p in
+             let attr =
+               Parsetree0.add_optional_attr ~optional p1.ppat_attributes
+             in
+             (lid1, {p1 with ppat_attributes = attr})))
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/compiler/ml/ast_payload.ml
+++ b/compiler/ml/ast_payload.ml
@@ -209,10 +209,12 @@ let ident_or_record_as_config loc (x : t) :
       Ext_list.map label_exprs (fun u ->
           match u with
           | ( {txt = Lident name; loc},
-              {Parsetree.pexp_desc = Pexp_ident {txt = Lident name2}} )
+              {Parsetree.pexp_desc = Pexp_ident {txt = Lident name2}},
+              _ )
             when name2 = name ->
             ({Asttypes.txt = name; loc}, None)
-          | {txt = Lident name; loc}, y -> ({Asttypes.txt = name; loc}, Some y)
+          | {txt = Lident name; loc}, y, _ ->
+            ({Asttypes.txt = name; loc}, Some y)
           | _ -> Location.raise_errorf ~loc "Qualified label is not allowed")
     | Some _ ->
       unrecognized_config_record loc "`with` is not supported, discarding";

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -185,7 +185,7 @@ let rec add_pattern bv pat =
     add_opt add_pattern bv op
   | Ppat_record (pl, _) ->
     List.iter
-      (fun (lbl, p) ->
+      (fun (lbl, p, _) ->
         add bv lbl;
         add_pattern bv p)
       pl
@@ -238,7 +238,7 @@ let rec add_expr bv exp =
   | Pexp_variant (_, opte) -> add_opt add_expr bv opte
   | Pexp_record (lblel, opte) ->
     List.iter
-      (fun (lbl, e) ->
+      (fun (lbl, e, _) ->
         add bv lbl;
         add_expr bv e)
       lblel;

--- a/compiler/ml/lambda.ml
+++ b/compiler/ml/lambda.ml
@@ -84,9 +84,9 @@ let find_name (attr : Parsetree.attribute) =
     Some s
   | _ -> None
 
-let blk_record (fields : (label * _) array) mut =
+let blk_record (fields : (label * _ * _) array) mut =
   let all_labels_info =
-    Ext_array.map fields (fun (lbl, _) ->
+    Ext_array.map fields (fun (lbl, _, _) ->
         ( Ext_list.find_def lbl.lbl_attributes find_name lbl.lbl_name,
           lbl.lbl_optional ))
   in
@@ -95,7 +95,7 @@ let blk_record (fields : (label * _) array) mut =
 let blk_record_ext fields mutable_flag =
   let all_labels_info =
     Array.map
-      (fun ((lbl : label), _) ->
+      (fun ((lbl : label), _, _) ->
         Ext_list.find_def lbl.Types.lbl_attributes find_name lbl.lbl_name)
       fields
   in
@@ -104,7 +104,7 @@ let blk_record_ext fields mutable_flag =
 let blk_record_inlined fields name num_nonconst ~tag ~attrs mutable_flag =
   let fields =
     Array.map
-      (fun ((lbl : label), _) ->
+      (fun ((lbl : label), _, _) ->
         ( Ext_list.find_def lbl.lbl_attributes find_name lbl.lbl_name,
           lbl.lbl_optional ))
       fields

--- a/compiler/ml/lambda.mli
+++ b/compiler/ml/lambda.mli
@@ -63,17 +63,17 @@ val find_name : Parsetree.attribute -> Asttypes.label option
 val tag_of_tag_info : tag_info -> int
 val mutable_flag_of_tag_info : tag_info -> mutable_flag
 val blk_record :
-  (Types.label_description * Typedtree.record_label_definition) array ->
+  (Types.label_description * Typedtree.record_label_definition * bool) array ->
   mutable_flag ->
   tag_info
 
 val blk_record_ext :
-  (Types.label_description * Typedtree.record_label_definition) array ->
+  (Types.label_description * Typedtree.record_label_definition * bool) array ->
   mutable_flag ->
   tag_info
 
 val blk_record_inlined :
-  (Types.label_description * Typedtree.record_label_definition) array ->
+  (Types.label_description * Typedtree.record_label_definition * bool) array ->
   string ->
   int ->
   tag:int ->

--- a/compiler/ml/parmatch.mli
+++ b/compiler/ml/parmatch.mli
@@ -31,8 +31,8 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 val normalize_pat : pattern -> pattern
 val all_record_args :
-  (Longident.t loc * label_description * pattern) list ->
-  (Longident.t loc * label_description * pattern) list
+  (Longident.t loc * label_description * pattern * bool) list ->
+  (Longident.t loc * label_description * pattern * bool) list
 val const_compare : constant -> constant -> int
 
 val le_pat : pattern -> pattern -> bool

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -183,7 +183,8 @@ and pattern_desc =
     (* `A             (None)
        `A P           (Some P)
     *)
-  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+  | Ppat_record of
+      (Longident.t loc * pattern * bool (* optional *)) list * closed_flag
     (* { l1=P1; ...; ln=Pn }     (flag = Closed)
        { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
@@ -260,7 +261,9 @@ and expression_desc =
     (* `A             (None)
        `A E           (Some E)
     *)
-  | Pexp_record of (Longident.t loc * expression) list * expression option
+  | Pexp_record of
+      (Longident.t loc * expression * bool (* optional *)) list
+      * expression option
     (* { l1=P1; ...; ln=Pn }     (None)
        { E0 with l1=P1; ...; ln=Pn }   (Some E0)
 

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -396,15 +396,16 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
     | Ppat_type li ->
         pp f "#%a" longident_loc li
     | Ppat_record (l, closed) ->
-        let longident_x_pattern f (li, p) =
+        let longident_x_pattern f (li, p, opt) =
+          let opt_str = if opt then "?" else "" in
           match (li,p) with
           | ({txt=Lident s;_ },
              {ppat_desc=Ppat_var {txt;_};
               ppat_attributes=[]; _})
             when s = txt ->
-              pp f "@[<2>%a@]"  longident_loc li
+              pp f "@[<2>%a%s@]"  longident_loc li opt_str
           | _ ->
-              pp f "@[<2>%a@;=@;%a@]" longident_loc li (pattern1 ctxt) p
+              pp f "@[<2>%a%s@;=@;%a@]" longident_loc li opt_str (pattern1 ctxt) p
         in
         begin match closed with
         | Closed ->
@@ -712,13 +713,14 @@ and simple_expr ctxt f x =
           (core_type ctxt) ct
     | Pexp_variant (l, None) -> pp f "`%s" l
     | Pexp_record (l, eo) ->
-        let longident_x_expression f ( li, e) =
+        let longident_x_expression f ( li, e, opt) =
+          let opt_str = if opt then "?" else "" in
           match e with
           |  {pexp_desc=Pexp_ident {txt;_};
               pexp_attributes=[]; _} when li.txt = txt ->
-              pp f "@[<hov2>%a@]" longident_loc li
+              pp f "@[<hov2>%a%s@]" longident_loc li opt_str
           | _ ->
-              pp f "@[<hov2>%a@;=@;%a@]" longident_loc li (simple_expr ctxt) e
+              pp f "@[<hov2>%a@;=@;%s%a@]" longident_loc li opt_str (simple_expr ctxt) e
         in
         pp f "@[<hv0>@[<hv2>{@;%a%a@]@;}@]"(* "@[<hov2>{%a%a}@]" *)
           (option ~last:" with@;" (simple_expr ctxt)) eo

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -637,8 +637,8 @@ and label_decl i ppf {pld_name; pld_mutable; pld_type; pld_loc; pld_attributes}
   line (i + 1) ppf "%a" fmt_string_loc pld_name;
   core_type (i + 1) ppf pld_type
 
-and longident_x_pattern i ppf (li, p) =
-  line i ppf "%a\n" fmt_longident_loc li;
+and longident_x_pattern i ppf (li, p, opt) =
+  line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");
   pattern (i + 1) ppf p
 
 and case i ppf {pc_lhs; pc_guard; pc_rhs} =
@@ -661,8 +661,8 @@ and string_x_expression i ppf (s, e) =
   line i ppf "<override> %a\n" fmt_string_loc s;
   expression (i + 1) ppf e
 
-and longident_x_expression i ppf (li, e) =
-  line i ppf "%a\n" fmt_longident_loc li;
+and longident_x_expression i ppf (li, e, opt) =
+  line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");
   expression (i + 1) ppf e
 
 and label_x_expression i ppf (l, e) =

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -634,8 +634,8 @@ and label_decl i ppf
   line (i + 1) ppf "%a" fmt_ident ld_id;
   core_type (i + 1) ppf ld_type
 
-and longident_x_pattern i ppf (li, _, p) =
-  line i ppf "%a\n" fmt_longident li;
+and longident_x_pattern i ppf (li, _, p, opt) =
+  line i ppf "%a%s\n" fmt_longident li (if opt then "?" else "");
   pattern (i + 1) ppf p
 
 and case i ppf {c_lhs; c_guard; c_rhs} =
@@ -655,10 +655,10 @@ and value_binding i ppf x =
   expression (i + 1) ppf x.vb_expr
 
 and record_field i ppf = function
-  | _, Overridden (li, e) ->
-    line i ppf "%a\n" fmt_longident li;
+  | _, Overridden (li, e), opt ->
+    line i ppf "%a%s\n" fmt_longident li (if opt then "?" else "");
     expression (i + 1) ppf e
-  | _, Kept _ -> line i ppf "<kept>"
+  | _, Kept _, _ -> line i ppf "<kept>"
 
 and label_x_expression i ppf (l, e) =
   line i ppf "<arg>\n";

--- a/compiler/ml/rec_check.ml
+++ b/compiler/ml/rec_check.ml
@@ -157,7 +157,7 @@ let rec pattern_variables : Typedtree.pattern -> Ident.t list =
   | Tpat_variant (_, Some pat, _) -> pattern_variables pat
   | Tpat_variant (_, None, _) -> []
   | Tpat_record (fields, _) ->
-    List.concat (List.map (fun (_, _, p) -> pattern_variables p) fields)
+    List.concat (List.map (fun (_, _, p, _) -> pattern_variables p) fields)
   | Tpat_array pats -> List.concat (List.map pattern_variables pats)
   | Tpat_or (l, r, _) -> pattern_variables l @ pattern_variables r
   | Tpat_lazy p -> pattern_variables p
@@ -264,8 +264,8 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
       | Record_regular | Record_inlined _ | Record_extension -> Use.guard
     in
     let field env = function
-      | _, Kept _ -> Use.empty
-      | _, Overridden (_, e) -> expression env e
+      | _, Kept _, _ -> Use.empty
+      | _, Overridden (_, e), _ -> expression env e
     in
     Use.join (use (array field env es)) (option expression env eo)
   | Texp_ifthenelse (cond, ifso, ifnot) ->
@@ -458,7 +458,7 @@ let check_recursive_bindings valbinds =
   Ext_list.iter valbinds (fun {vb_expr} ->
       match vb_expr.exp_desc with
       | Texp_record
-          {fields = [|(_, Overridden (_, {exp_desc = Texp_function _}))|]}
+          {fields = [|(_, Overridden (_, {exp_desc = Texp_function _}), _)|]}
       | Texp_function _ ->
         ()
       (*TODO: add uncurried function too*)

--- a/compiler/ml/tast_iterator.ml
+++ b/compiler/ml/tast_iterator.ml
@@ -131,7 +131,7 @@ let pat sub {pat_extra; pat_desc; pat_env; _} =
   | Tpat_tuple l -> List.iter (sub.pat sub) l
   | Tpat_construct (_, _, l) -> List.iter (sub.pat sub) l
   | Tpat_variant (_, po, _) -> Option.iter (sub.pat sub) po
-  | Tpat_record (l, _) -> List.iter (fun (_, _, i) -> sub.pat sub i) l
+  | Tpat_record (l, _) -> List.iter (fun (_, _, i, _) -> sub.pat sub i) l
   | Tpat_array l -> List.iter (sub.pat sub) l
   | Tpat_or (p1, p2, _) ->
     sub.pat sub p1;
@@ -172,8 +172,8 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_record {fields; extended_expression; _} ->
     Array.iter
       (function
-        | _, Kept _ -> ()
-        | _, Overridden (_, exp) -> sub.expr sub exp)
+        | _, Kept _, _ -> ()
+        | _, Overridden (_, exp), _ -> sub.expr sub exp)
       fields;
     Option.iter (sub.expr sub) extended_expression
   | Texp_field (exp, _, _) -> sub.expr sub exp

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -59,6 +59,7 @@ type mapper = {
 let id x = x
 let tuple2 f1 f2 (x, y) = (f1 x, f2 y)
 let tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
+let tuple4 f1 f2 f3 f4 (x, y, z, w) = (f1 x, f2 y, f3 z, f4 w)
 let opt f = function
   | None -> None
   | Some x -> Some (f x)
@@ -173,7 +174,7 @@ let pat sub x =
       Tpat_construct (loc, cd, List.map (sub.pat sub) l)
     | Tpat_variant (l, po, rd) -> Tpat_variant (l, opt (sub.pat sub) po, rd)
     | Tpat_record (l, closed) ->
-      Tpat_record (List.map (tuple3 id id (sub.pat sub)) l, closed)
+      Tpat_record (List.map (tuple4 id id (sub.pat sub) id) l, closed)
     | Tpat_array l -> Tpat_array (List.map (sub.pat sub) l)
     | Tpat_or (p1, p2, rd) -> Tpat_or (sub.pat sub p1, sub.pat sub p2, rd)
     | Tpat_alias (p, id, s) -> Tpat_alias (sub.pat sub p, id, s)
@@ -215,9 +216,9 @@ let expr sub x =
       let fields =
         Array.map
           (function
-            | label, Kept t -> (label, Kept t)
-            | label, Overridden (lid, exp) ->
-              (label, Overridden (lid, sub.expr sub exp)))
+            | label, Kept t, o -> (label, Kept t, o)
+            | label, Overridden (lid, exp), o ->
+              (label, Overridden (lid, sub.expr sub exp), o))
           fields
       in
       Texp_record

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -154,7 +154,7 @@ let iter_expression f e =
     | Pexp_construct (_, eo) | Pexp_variant (_, eo) -> may expr eo
     | Pexp_record (iel, eo) ->
       may expr eo;
-      List.iter (fun (_, e) -> expr e) iel
+      List.iter (fun (_, e, _) -> expr e) iel
     | Pexp_open (_, _, e)
     | Pexp_newtype (_, e)
     | Pexp_poly (e, _)
@@ -299,14 +299,13 @@ let extract_concrete_variant env ty =
 
 let label_is_optional ld = ld.lbl_optional
 
-let check_optional_attr env ld attrs loc =
+let check_optional_attr env ld optional loc =
   let check_redundant () =
     if not (label_is_optional ld) then
       raise (Error (loc, env, Field_not_optional (ld.lbl_name, ld.lbl_res)));
     true
   in
-  Ext_list.exists attrs (fun ({txt}, _) ->
-      txt = "res.optional" && check_redundant ())
+  optional && check_redundant ()
 
 (* unification inside type_pat*)
 let unify_pat_types loc env ty ty' =
@@ -493,11 +492,11 @@ let rec build_as_type env p =
            row_closed = false;
          })
   | Tpat_record (lpl, _) ->
-    let lbl = snd3 (List.hd lpl) in
+    let lbl = snd4 (List.hd lpl) in
     if lbl.lbl_private = Private then p.pat_type
     else
       let ty = newvar () in
-      let ppl = List.map (fun (_, l, p) -> (l.lbl_pos, p)) lpl in
+      let ppl = List.map (fun (_, l, p, _) -> (l.lbl_pos, p)) lpl in
       let do_label lbl =
         let _, ty_arg, ty_res = instance_label false lbl in
         unify_pat env {p with pat_type = ty} ty_res;
@@ -989,7 +988,7 @@ let disambiguate_label_by_ids closed ids labels =
 
 (* Only issue warnings once per record constructor/pattern *)
 let disambiguate_lid_a_list loc closed env opath lid_a_list =
-  let ids = List.map (fun (lid, _) -> Longident.last lid.txt) lid_a_list in
+  let ids = List.map (fun (lid, _, _) -> Longident.last lid.txt) lid_a_list in
   let w_amb = ref [] in
   let warn loc msg =
     let open Warnings in
@@ -1020,12 +1019,12 @@ let disambiguate_lid_a_list loc closed env opath lid_a_list =
     (* will fail later *)
   in
   let lbl_a_list =
-    List.map (fun (lid, a) -> (lid, process_label lid, a)) lid_a_list
+    List.map (fun (lid, a, opt) -> (lid, process_label lid, a, opt)) lid_a_list
   in
   (match List.rev !w_amb with
   | (_, types) :: _ as amb ->
     let paths =
-      List.map (fun (_, lbl, _) -> Label.get_type_path lbl) lbl_a_list
+      List.map (fun (_, lbl, _, _) -> Label.get_type_path lbl) lbl_a_list
     in
     let path = List.hd paths in
     if List.for_all (compare_type_path env path) (List.tl paths) then
@@ -1041,7 +1040,7 @@ let disambiguate_lid_a_list loc closed env opath lid_a_list =
 
 let rec find_record_qual = function
   | [] -> None
-  | ({txt = Longident.Ldot (modname, _)}, _) :: _ -> Some modname
+  | ({txt = Longident.Ldot (modname, _)}, _, _) :: _ -> Some modname
   | _ :: rest -> find_record_qual rest
 
 let map_fold_cont f xs k =
@@ -1054,14 +1053,14 @@ let map_fold_cont f xs k =
 let type_label_a_list ?labels loc closed env type_lbl_a opath lid_a_list k =
   let lbl_a_list =
     match (lid_a_list, labels) with
-    | ({txt = Longident.Lident s}, _) :: _, Some labels
+    | ({txt = Longident.Lident s}, _, _) :: _, Some labels
       when Hashtbl.mem labels s ->
       (* Special case for rebuilt syntax trees *)
       List.map
         (function
-          | lid, a -> (
+          | lid, a, opt -> (
             match lid.txt with
-            | Longident.Lident s -> (lid, Hashtbl.find labels s, a)
+            | Longident.Lident s -> (lid, Hashtbl.find labels s, a, opt)
             | _ -> assert false))
         lid_a_list
     | _ ->
@@ -1070,10 +1069,10 @@ let type_label_a_list ?labels loc closed env type_lbl_a opath lid_a_list k =
         | None -> lid_a_list
         | Some modname ->
           List.map
-            (fun ((lid, a) as lid_a) ->
+            (fun ((lid, a, opt) as lid_a) ->
               match lid.txt with
               | Longident.Lident s ->
-                ({lid with txt = Longident.Ldot (modname, s)}, a)
+                ({lid with txt = Longident.Ldot (modname, s)}, a, opt)
               | _ -> lid_a)
             lid_a_list
       in
@@ -1082,7 +1081,7 @@ let type_label_a_list ?labels loc closed env type_lbl_a opath lid_a_list k =
   (* Invariant: records are sorted in the typed tree *)
   let lbl_a_list =
     List.sort
-      (fun (_, lbl1, _) (_, lbl2, _) -> compare lbl1.lbl_pos lbl2.lbl_pos)
+      (fun (_, lbl1, _, _) (_, lbl2, _, _) -> compare lbl1.lbl_pos lbl2.lbl_pos)
       lbl_a_list
   in
   map_fold_cont type_lbl_a lbl_a_list k
@@ -1094,10 +1093,10 @@ let check_recordpat_labels ~get_jsx_component_error_info loc lbl_pat_list closed
     =
   match lbl_pat_list with
   | [] -> () (* should not happen *)
-  | ((l : Longident.t loc), label1, _) :: _ ->
+  | ((l : Longident.t loc), label1, _, _) :: _ ->
     let all = label1.lbl_all in
     let defined = Array.make (Array.length all) false in
-    let check_defined (_, label, _) =
+    let check_defined (_, label, _, _) =
       if defined.(label.lbl_pos) then
         raise
           (Error
@@ -1490,9 +1489,9 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env sp
       get_jsx_component_error_info ~extract_concrete_typedecl opath !env
         record_ty
     in
-    let process_optional_label (ld, pat) =
+    let process_optional_label (ld, pat, optional) =
       let exp_optional_attr =
-        check_optional_attr !env ld pat.ppat_attributes pat.ppat_loc
+        check_optional_attr !env ld optional pat.ppat_loc
       in
       let is_from_pamatch =
         match pat.ppat_desc with
@@ -1506,8 +1505,8 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env sp
         Ast_helper.Pat.construct ~loc:pat.ppat_loc lid (Some pat)
       else pat
     in
-    let type_label_pat (label_lid, label, sarg) k =
-      let sarg = process_optional_label (label, sarg) in
+    let type_label_pat (label_lid, label, sarg, opt) k =
+      let sarg = process_optional_label (label, sarg, opt) in
       begin_def ();
       let vars, ty_arg, ty_res = instance_label false label in
       if vars = [] then end_def ();
@@ -1527,7 +1526,7 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env sp
             if List.exists instantiated vars then
               raise
                 (Error (label_lid.loc, !env, Polymorphic_label label_lid.txt)));
-          k (label_lid, label, arg))
+          k (label_lid, label, arg, opt))
     in
     let k' k lbl_pat_list =
       check_recordpat_labels ~get_jsx_component_error_info loc lbl_pat_list
@@ -1822,7 +1821,7 @@ let rec is_nonexpansive exp =
   | Texp_variant (_, arg) -> is_nonexpansive_opt arg
   | Texp_record {fields; extended_expression} ->
     Array.for_all
-      (fun (lbl, definition) ->
+      (fun (lbl, definition, _) ->
         match definition with
         | Overridden (_, exp) -> lbl.lbl_mut = Immutable && is_nonexpansive exp
         | Kept _ -> true)
@@ -2087,7 +2086,7 @@ let iter_ppat f p =
   | Ppat_constraint (p, _)
   | Ppat_lazy p ->
     f p
-  | Ppat_record (args, _flag) -> List.iter (fun (_, p) -> f p) args
+  | Ppat_record (args, _flag) -> List.iter (fun (_, p, _) -> f p) args
 
 let contains_polymorphic_variant p =
   let rec loop p =
@@ -2167,7 +2166,7 @@ let duplicate_ident_types caselist env =
 (* note: check_duplicates would better be implemented in
          type_label_a_list directly *)
 let rec check_duplicates ~get_jsx_component_error_info loc env = function
-  | (_, lbl1, _) :: ((l : Longident.t loc), lbl2, _) :: _
+  | (_, lbl1, _, _) :: ((l : Longident.t loc), lbl2, _, _) :: _
     when lbl1.lbl_pos = lbl2.lbl_pos ->
     raise
       (Error
@@ -2289,15 +2288,13 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
     unify_exp ?type_clash_context env (re exp) (instance env ty_expected);
     exp
   in
-  let process_optional_label (id, ld, e) =
-    let exp_optional_attr =
-      check_optional_attr env ld e.pexp_attributes e.pexp_loc
-    in
+  let process_optional_label (id, ld, e, opt) =
+    let exp_optional_attr = check_optional_attr env ld opt e.pexp_loc in
     if label_is_optional ld && not exp_optional_attr then
       let lid = mknoloc Longident.(Ldot (Lident "*predef*", "Some")) in
       let e = Ast_helper.Exp.construct ~loc:e.pexp_loc lid (Some e) in
-      (id, ld, e)
-    else (id, ld, e)
+      (id, ld, e, opt)
+    else (id, ld, e, opt)
   in
   match sexp.pexp_desc with
   | Pexp_ident lid ->
@@ -2630,7 +2627,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
     check_duplicates ~get_jsx_component_error_info loc env lbl_exp_list;
     let label_descriptions, representation =
       match (lbl_exp_list, repr_opt) with
-      | ( (_, {lbl_all = label_descriptions; lbl_repres = representation}, _)
+      | ( (_, {lbl_all = label_descriptions; lbl_repres = representation}, _, _)
           :: _,
           _ ) ->
         (label_descriptions, representation)
@@ -2657,12 +2654,14 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
     let labels_missing = ref [] in
     let label_definitions =
       let matching_label lbl =
-        List.find (fun (_, lbl', _) -> lbl'.lbl_pos = lbl.lbl_pos) lbl_exp_list
+        List.find
+          (fun (_, lbl', _, _) -> lbl'.lbl_pos = lbl.lbl_pos)
+          lbl_exp_list
       in
       Array.map
         (fun lbl ->
           match matching_label lbl with
-          | lid, _lbl, lbl_exp -> Overridden (lid, lbl_exp)
+          | lid, _lbl, lbl_exp, _ -> Overridden (lid, lbl_exp)
           | exception Not_found ->
             if not (label_is_optional lbl) then
               labels_missing := lbl.lbl_name :: !labels_missing;
@@ -2682,7 +2681,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
                } ));
     let fields =
       Array.map2
-        (fun descr def -> (descr, def))
+        (fun descr def -> (descr, def, false))
         label_descriptions label_definitions
     in
     re
@@ -2736,16 +2735,18 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
     unify_exp_types loc env ty_record (instance env ty_expected);
     check_duplicates ~get_jsx_component_error_info loc env lbl_exp_list;
     let opt_exp, label_definitions =
-      let _lid, lbl, _lbl_exp = List.hd lbl_exp_list in
+      let _lid, lbl, _lbl_exp, _opt = List.hd lbl_exp_list in
       let matching_label lbl =
-        List.find (fun (_, lbl', _) -> lbl'.lbl_pos = lbl.lbl_pos) lbl_exp_list
+        List.find
+          (fun (_, lbl', _, _) -> lbl'.lbl_pos = lbl.lbl_pos)
+          lbl_exp_list
       in
       let ty_exp = instance env exp.exp_type in
       let unify_kept lbl =
         let _, ty_arg1, ty_res1 = instance_label false lbl in
         unify_exp_types exp.exp_loc env ty_exp ty_res1;
         match matching_label lbl with
-        | lid, _lbl, lbl_exp ->
+        | lid, _lbl, lbl_exp, _ ->
           (* do not connect result types for overridden labels *)
           Overridden (lid, lbl_exp)
         | exception Not_found ->
@@ -2760,7 +2761,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
     let num_fields =
       match lbl_exp_list with
       | [] -> assert false
-      | (_, lbl, _) :: _ -> Array.length lbl.lbl_all
+      | (_, lbl, _, _) :: _ -> Array.length lbl.lbl_all
     in
     let opt_exp =
       if List.length lid_sexp_list = num_fields then (
@@ -2769,12 +2770,12 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
       else opt_exp
     in
     let label_descriptions, representation =
-      let _, {lbl_all; lbl_repres}, _ = List.hd lbl_exp_list in
+      let _, {lbl_all; lbl_repres}, _, _ = List.hd lbl_exp_list in
       (lbl_all, lbl_repres)
     in
     let fields =
       Array.map2
-        (fun descr def -> (descr, def))
+        (fun descr def -> (descr, def, false))
         label_descriptions label_definitions
     in
     re
@@ -2803,9 +2804,9 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
   | Pexp_setfield (srecord, lid, snewval) ->
     let record, label, opath = type_label_access env srecord lid in
     let ty_record = if opath = None then newvar () else record.exp_type in
-    let label_loc, label, newval =
+    let label_loc, label, newval, _ =
       type_label_exp ~type_clash_context:SetRecordField false env loc ty_record
-        (lid, label, snewval)
+        (lid, label, snewval, false)
     in
     unify_exp env record ty_record;
     if label.lbl_mut = Immutable then
@@ -3354,7 +3355,7 @@ and type_label_access env srecord lid =
    These formats are used by functions in modules Printf, Format, and Scanf.
    (Handling of * modifiers contributed by Thorsten Ohl.) *)
 and type_label_exp ?type_clash_context create env loc ty_expected
-    (lid, label, sarg) =
+    (lid, label, sarg, opt) =
   (* Here also ty_expected may be at generic_level *)
   begin_def ();
   let separate = Env.has_local_constraints env in
@@ -3403,7 +3404,7 @@ and type_label_exp ?type_clash_context create env loc ty_expected
       | Error (_, _, Less_general _) as e -> raise e
       | _ -> raise exn (* In case of failure return the first error *))
   in
-  (lid, label, {arg with exp_type = instance env arg.exp_type})
+  (lid, label, {arg with exp_type = instance env arg.exp_type}, opt)
 
 and type_argument ?type_clash_context ?recarg env sarg ty_expected' ty_expected
     =

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -50,7 +50,8 @@ and pattern_desc =
   | Tpat_construct of Longident.t loc * constructor_description * pattern list
   | Tpat_variant of label * pattern option * row_desc ref
   | Tpat_record of
-      (Longident.t loc * label_description * pattern) list * closed_flag
+      (Longident.t loc * label_description * pattern * bool (* optional *)) list
+      * closed_flag
   | Tpat_array of pattern list
   | Tpat_or of pattern * pattern * row_desc option
   | Tpat_lazy of pattern
@@ -89,7 +90,11 @@ and expression_desc =
       Longident.t loc * constructor_description * expression list
   | Texp_variant of label * expression option
   | Texp_record of {
-      fields: (Types.label_description * record_label_definition) array;
+      fields:
+        (Types.label_description
+        * record_label_definition
+        * bool (* optional *))
+        array;
       representation: Types.record_representation;
       extended_expression: expression option;
     }
@@ -414,7 +419,7 @@ let iter_pattern_desc f = function
   | Tpat_construct (_, _, patl) -> List.iter f patl
   | Tpat_variant (_, pat, _) -> may f pat
   | Tpat_record (lbl_pat_list, _) ->
-    List.iter (fun (_, _, pat) -> f pat) lbl_pat_list
+    List.iter (fun (_, _, pat, _) -> f pat) lbl_pat_list
   | Tpat_array patl -> List.iter f patl
   | Tpat_or (p1, p2, _) ->
     f p1;
@@ -427,7 +432,7 @@ let map_pattern_desc f d =
   | Tpat_alias (p1, id, s) -> Tpat_alias (f p1, id, s)
   | Tpat_tuple pats -> Tpat_tuple (List.map f pats)
   | Tpat_record (lpats, closed) ->
-    Tpat_record (List.map (fun (lid, l, p) -> (lid, l, f p)) lpats, closed)
+    Tpat_record (List.map (fun (lid, l, p, o) -> (lid, l, f p, o)) lpats, closed)
   | Tpat_construct (lid, c, pats) -> Tpat_construct (lid, c, List.map f pats)
   | Tpat_array pats -> Tpat_array (List.map f pats)
   | Tpat_lazy p1 -> Tpat_lazy (f p1)

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -83,7 +83,8 @@ and pattern_desc =
             See {!Types.row_desc} for an explanation of the last parameter.
          *)
   | Tpat_record of
-      (Longident.t loc * label_description * pattern) list * closed_flag
+      (Longident.t loc * label_description * pattern * bool (* optional *)) list
+      * closed_flag
       (** { l1=P1; ...; ln=Pn }     (flag = Closed)
             { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
@@ -180,7 +181,11 @@ and expression_desc =
          *)
   | Texp_variant of label * expression option
   | Texp_record of {
-      fields: (Types.label_description * record_label_definition) array;
+      fields:
+        (Types.label_description
+        * record_label_definition
+        * bool (* optional *))
+        array;
       representation: Types.record_representation;
       extended_expression: expression option;
     }

--- a/compiler/ml/typedtreeIter.ml
+++ b/compiler/ml/typedtreeIter.ml
@@ -199,7 +199,7 @@ end = struct
       | None -> ()
       | Some pat -> iter_pattern pat)
     | Tpat_record (list, _closed) ->
-      List.iter (fun (_, _, pat) -> iter_pattern pat) list
+      List.iter (fun (_, _, pat, _) -> iter_pattern pat) list
     | Tpat_array list -> List.iter iter_pattern list
     | Tpat_or (p1, p2, _) ->
       iter_pattern p1;
@@ -255,8 +255,8 @@ end = struct
     | Texp_record {fields; extended_expression; _} -> (
       Array.iter
         (function
-          | _, Kept _ -> ()
-          | _, Overridden (_, exp) -> iter_expression exp)
+          | _, Kept _, _ -> ()
+          | _, Overridden (_, exp), _ -> iter_expression exp)
         fields;
       match extended_expression with
       | None -> ()

--- a/compiler/ml/untypeast.ml
+++ b/compiler/ml/untypeast.ml
@@ -261,7 +261,8 @@ let pattern sub pat =
       | Tpat_record (list, closed) ->
         Ppat_record
           ( List.map
-              (fun (lid, _, pat) -> (map_loc sub lid, sub.pat sub pat))
+              (fun (lid, _, pat, opt) ->
+                (map_loc sub lid, sub.pat sub pat, opt))
               list,
             closed )
       | Tpat_array list -> Ppat_array (List.map (sub.pat sub) list)
@@ -361,8 +362,8 @@ let expression sub exp =
       let list =
         Array.fold_left
           (fun l -> function
-            | _, Kept _ -> l
-            | _, Overridden (lid, exp) -> (lid, sub.expr sub exp) :: l)
+            | _, Kept _, _ -> l
+            | _, Overridden (lid, exp), opt -> (lid, sub.expr sub exp, opt) :: l)
           [] fields
       in
       Pexp_record (list, map_opt (sub.expr sub) extended_expression)

--- a/compiler/syntax/src/jsx_common.ml
+++ b/compiler/syntax/src/jsx_common.ml
@@ -45,8 +45,6 @@ let raise_error_multiple_component ~loc =
     "Only one component definition is allowed for each module. Move to a \
      submodule or other file if necessary."
 
-let optional_attr = ({txt = "res.optional"; loc = Location.none}, PStr [])
-
 let extract_uncurried typ =
   if Ast_uncurried.core_type_is_uncurried_fun typ then
     let _arity, t = Ast_uncurried.core_type_extract_uncurried_fun typ in

--- a/compiler/syntax/src/jsx_ppx.ml
+++ b/compiler/syntax/src/jsx_ppx.ml
@@ -19,7 +19,7 @@ type config_key = Int | String
 let get_jsx_config_by_key ~key ~type_ record_fields =
   let values =
     List.filter_map
-      (fun ((lid, expr) : Longident.t Location.loc * expression) ->
+      (fun ((lid, expr, _) : Longident.t Location.loc * expression * bool) ->
         match (type_, lid, expr) with
         | ( Int,
             {txt = Lident k},

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -624,7 +624,7 @@ module SexpAst = struct
             Sexp.atom "Pexp_record";
             Sexp.list
               (map_empty
-                 ~f:(fun (longident_loc, expr) ->
+                 ~f:(fun (longident_loc, expr, _) ->
                    Sexp.list
                      [longident longident_loc.Asttypes.txt; expression expr])
                  rows);
@@ -774,7 +774,7 @@ module SexpAst = struct
             closed_flag flag;
             Sexp.list
               (map_empty
-                 ~f:(fun (longident_loc, p) ->
+                 ~f:(fun (longident_loc, p, _) ->
                    Sexp.list [longident longident_loc.Location.txt; pattern p])
                  rows);
           ]

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -947,7 +947,7 @@ and walk_expression expr t comments =
         PStr [{pstr_desc = Pstr_eval ({pexp_desc = Pexp_record (rows, _)}, [])}]
       ) ->
     walk_list
-      (rows |> List.map (fun (li, e) -> ExprRecordRow (li, e)))
+      (rows |> List.map (fun (li, e, _) -> ExprRecordRow (li, e)))
       t comments
   | Pexp_extension extension -> walk_extension extension t comments
   | Pexp_letexception (extension_constructor, expr2) ->
@@ -1067,7 +1067,7 @@ and walk_expression expr t comments =
           rest
       in
       walk_list
-        (rows |> List.map (fun (li, e) -> ExprRecordRow (li, e)))
+        (rows |> List.map (fun (li, e, _) -> ExprRecordRow (li, e)))
         t comments
   | Pexp_field (expr, longident) ->
     let leading, inside, trailing = partition_by_loc comments expr.pexp_loc in
@@ -1755,7 +1755,7 @@ and walk_pattern pat t comments =
   | Ppat_type _ -> ()
   | Ppat_record (record_rows, _) ->
     walk_list
-      (record_rows |> List.map (fun (li, p) -> PatternRecordRow (li, p)))
+      (record_rows |> List.map (fun (li, p, _) -> PatternRecordRow (li, p)))
       t comments
   | Ppat_or _ ->
     walk_list

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -15,13 +15,13 @@ let expr expr =
     | {pexp_desc = Pexp_constraint _} -> Parenthesized
     | _ -> Nothing)
 
-let expr_record_row_rhs e =
+let expr_record_row_rhs ~optional e =
   let kind = expr e in
   match kind with
-  | Nothing when Res_parsetree_viewer.has_optional_attribute e.pexp_attributes
-    -> (
+  | Nothing when optional -> (
     match e.pexp_desc with
     | Pexp_ifthenelse _ | Pexp_fun _ -> Parenthesized
+    | _ when ParsetreeViewer.is_binary_expression e -> Parenthesized
     | _ -> kind)
   | _ -> kind
 

--- a/compiler/syntax/src/res_parens.mli
+++ b/compiler/syntax/src/res_parens.mli
@@ -39,4 +39,4 @@ val arrow_return_typ_expr : Parsetree.core_type -> bool
 
 val pattern_record_row_rhs : Parsetree.pattern -> bool
 
-val expr_record_row_rhs : Parsetree.expression -> kind
+val expr_record_row_rhs : optional:bool -> Parsetree.expression -> kind

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -232,9 +232,9 @@ let filter_parsing_attrs attrs =
       | ( {
             Location.txt =
               ( "res.arity" | "res.braces" | "ns.braces" | "res.iflet"
-              | "res.namedArgLoc" | "res.optional" | "res.ternary" | "res.async"
-              | "res.await" | "res.template" | "res.taggedTemplate"
-              | "res.patVariantSpread" | "res.dictPattern" );
+              | "res.namedArgLoc" | "res.ternary" | "res.async" | "res.await"
+              | "res.template" | "res.taggedTemplate" | "res.patVariantSpread"
+              | "res.dictPattern" );
           },
           _ ) ->
         false
@@ -375,12 +375,6 @@ let is_if_let_expr expr =
     when has_if_let_attribute attrs ->
     true
   | _ -> false
-
-let rec has_optional_attribute attrs =
-  match attrs with
-  | [] -> false
-  | ({Location.txt = "ns.optional" | "res.optional"}, _) :: _ -> true
-  | _ :: attrs -> has_optional_attribute attrs
 
 let has_attributes attrs =
   List.exists

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -102,7 +102,6 @@ val filter_fragile_match_attributes :
 
 val is_jsx_expression : Parsetree.expression -> bool
 val has_jsx_attribute : Parsetree.attributes -> bool
-val has_optional_attribute : Parsetree.attributes -> bool
 
 val should_indent_binary_expr : Parsetree.expression -> bool
 val should_inline_rhs_binary_expr : Parsetree.expression -> bool

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/record.res.txt
@@ -12,30 +12,19 @@ let r = { expr with pexp_attributes = [||]; pexp_loc = loc }
 let r = { expr with pexp_attributes = [||] }
 let r = { (make () : myRecord) with foo = bar }
 let r = { (make () : myRecord) with foo = bar }
-let r =
-  {
-    x = ((None)[@res.optional ]);
-    y = ((None)[@res.optional ]);
-    z = (((None : tt))[@res.optional ])
-  }
-let z = ((Function$ (fun name -> { name = ((name)[@res.optional ]); x = 3 }))
-  [@res.arity 1])
-let z = ((Function$ (fun name -> { name = ((name)[@res.optional ]); x = 3 }))
-  [@res.arity 1])
-let z = ((Function$ (fun name -> { name; x = ((x)[@res.optional ]) }))
-  [@res.arity 1])
-let zz = ((Function$ (fun name -> { name; x = ((x)[@res.optional ]) }))
-  [@res.arity 1])
+let r = { x = ?None; y = ?None; z = ?(None : tt) }
+let z = ((Function$ (fun name -> { name?; x = 3 }))[@res.arity 1])
+let z = ((Function$ (fun name -> { name?; x = 3 }))[@res.arity 1])
+let z = ((Function$ (fun name -> { name; x? }))[@res.arity 1])
+let zz = ((Function$ (fun name -> { name; x? }))[@res.arity 1])
 let _ =
   match z with
-  | { x = ((None)[@res.optional ]); y = ((None)[@res.optional ]);
-      z = (((None : tt))[@res.optional ]) } -> 11
-  | { name = ((name)[@res.optional ]); x = 3 } -> 42
-  | { name = ((name)[@res.optional ]); x = 3 } -> 4242
-  | { x = ((None)[@res.optional ]); y = ((None)[@res.optional ]);
-      z = (((None : tt))[@res.optional ]) } -> 11
-  | { name = ((name)[@res.optional ]); x = 3 } -> 42
-  | { name = ((name)[@res.optional ]); x = 3 } -> 4242
+  | { x? = None; y? = None; z? = (None : tt) } -> 11
+  | { name?; x = 3 } -> 42
+  | { name?; x = 3 } -> 4242
+  | { x? = None; y? = None; z? = (None : tt) } -> 11
+  | { name?; x = 3 } -> 42
+  | { name?; x = 3 } -> 4242
 type nonrec tt = {
   x: int ;
   y: string [@ns.opttinal ]}

--- a/tests/syntax_tests/data/parsing/grammar/pattern/expected/dict.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/pattern/expected/dict.res.txt
@@ -1,5 +1,5 @@
 let someDict = Primitive_dict.make [|("one", {js|one|js})|]
-let (({ one = ((one)[@res.optional ]);_})[@res.dictPattern ]) = someDict
+let (({ one?;_})[@res.dictPattern ]) = someDict
 let foo =
   ((Function$
       (fun () ->
@@ -29,9 +29,9 @@ let decodeUser =
                   {
                     name;
                     age =
-                      (((match ageJson with
+                      ?((match ageJson with
                          | Number age -> Some age
-                         | _ -> None))[@res.optional ])
+                         | _ -> None))
                   }
             | _ -> (Js.log {js|Not an object.|js}; None))
          [@res.braces ]) : user option)))

--- a/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
@@ -21,7 +21,7 @@ module V4C = {
             ~props={
               type_: "text",
               ?className,
-              ref: ?Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef),
+              ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)),
             },
             [],
           ),
@@ -78,7 +78,7 @@ module V4CUncurried = {
             ~props={
               type_: "text",
               ?className,
-              ref: ?Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef),
+              ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)),
             },
             [],
           ),
@@ -135,7 +135,7 @@ module V4A = {
               {
                 type_: "text",
                 ?className,
-                ref: ?Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef),
+                ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)),
               },
             ),
             children,
@@ -189,7 +189,7 @@ module V4AUncurried = {
               {
                 type_: "text",
                 ?className,
-                ref: ?Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef),
+                ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)),
               },
             ),
             children,

--- a/tests/syntax_tests/data/printer/expr/expected/record.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/record.res.txt
@@ -100,5 +100,6 @@ type ttt = {x: int, y?: string}
 let optParen = {x: 3, y: ?(someBool ? Some("") : None)}
 let optParen = {x: 3, y: ?(3 + 4)}
 let optParen = {x: 3, y: ?foo(bar)}
-let optParen = {x: 3, y: ?foo->bar}
+let optParen = {x: 3, y: ?(foo->bar)}
 let optParen = {x: 3, y: ?() => 3}
+let optParen = {x: 3, y: ?-3}

--- a/tests/syntax_tests/data/printer/expr/record.res
+++ b/tests/syntax_tests/data/printer/expr/record.res
@@ -92,3 +92,4 @@ let optParen = { x:3, y: ? (3+4) }
 let optParen = { x:3, y: ? (foo(bar)) }
 let optParen = { x:3, y: ? (foo->bar) }
 let optParen = { x:3, y: ? (()=>3) }
+let optParen = { x:3, y: ? (-3) }

--- a/tests/tests/src/res_debug.res
+++ b/tests/tests/src/res_debug.res
@@ -63,11 +63,11 @@ type props<'name> = {key?: string, name?: string}
 let name = None
 
 let ok = {name: ?optionMap(name, x => x)}
-let bad = {name: ?name->optionMap(x => x)}
+let bad = {name: ?(name->optionMap(x => x))}
 
 let identity = x => x
 
 let name1 = Some("ReScript")
 
 let ok1 = {name: ?identity(name1)}
-let bad1 = {name: ?name1->identity}
+let bad1 = {name: ?(name1->identity)}


### PR DESCRIPTION
…ional fields.

Extend record patterns and expressions in untyped and typed AST with a per-field boolean. To indicate `x : ? e`.
This was previously represented as an attribute `res.optional`.

