### PR TITLE
Fix formatter handling of wildcard pattern matching in record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix bug where a ref assignment is moved ouside a conditional. https://github.com/rescript-lang/rescript/pull/7176
 - Fix nullable to opt conversion. https://github.com/rescript-lang/rescript/pull/7193
 - Raise error when defining external React components with `@react.componentWithProps`. https://github.com/rescript-lang/rescript/pull/7217
+- Fix formatter handling of wildcard in pattern matching records with no fields specified. https://github.com/rescript-lang/rescript/pull/7224
 
 #### :house: Internal
 

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -2420,6 +2420,8 @@ and print_pattern ~state (p : Parsetree.pattern) cmt_tbl =
           Doc.soft_line;
           Doc.rbrace;
         ]
+    | Ppat_record ([], Open) ->
+      Doc.concat [Doc.lbrace; Doc.text "_"; Doc.rbrace]
     | Ppat_record (rows, open_flag) ->
       Doc.group
         (Doc.concat

--- a/tests/syntax_tests/data/printer/pattern/expected/record.res.txt
+++ b/tests/syntax_tests/data/printer/pattern/expected/record.res.txt
@@ -114,3 +114,14 @@ let get_age3 = ({age: module(P: S), name: _}) => age2
 let get_age3 = ({age: exception Exit, name: _}) => age2
 
 let get_age3 = ({age: %raw("__GC"), name: _}) => age2
+
+let get_age3 = ({age, _}) => age
+let get_age3 = ({_}) => ""
+let get_age3 = () =>
+  switch x {
+  | {age, _} => age
+  }
+let get_age3 = () =>
+  switch x {
+  | {_} => ""
+  }

--- a/tests/syntax_tests/data/printer/pattern/record.res
+++ b/tests/syntax_tests/data/printer/pattern/record.res
@@ -58,3 +58,14 @@ let get_age3 = ({age: module(P: S), name: _}) => age2
 let get_age3 = ({age: exception Exit, name: _}) => age2
 
 let get_age3 = ({age: %raw("__GC"), name: _}) => age2
+
+let get_age3 = ({age, _}) => age
+let get_age3 = ({_}) => ""
+let get_age3 = () => 
+  switch x {
+  | {age, _} => age
+  }
+let get_age3 = () => 
+  switch x {
+  | {_} => ""
+  }


### PR DESCRIPTION
Handle the case when no fields are specified when pattern matching.

Fix https://github.com/rescript-lang/rescript/issues/7179