### PR TITLE
Ast types first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - Editor: Fix issue where pipe completions would not trigger with generic type arguments. https://github.com/rescript-lang/rescript/pull/7231
 - Fix leftover assert false in code for `null != undefined`. https://github.com/rescript-lang/rescript/pull/7232
 
+#### :house: Internal
+
+- AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
+
+
 # 12.0.0-alpha.7
 
 #### :bug: Bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 #### :house: Internal
 
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
-
+- AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 
 # 12.0.0-alpha.7
 

--- a/compiler/frontend/bs_builtin_ppx.ml
+++ b/compiler/frontend/bs_builtin_ppx.ml
@@ -111,8 +111,6 @@ let expr_mapper ~async_context ~in_function_def (self : mapper)
     {e with pexp_desc = Pexp_constant (Pconst_integer (s, None))}
   (* End rewriting *)
   | Pexp_newtype (s, body) ->
-    let async = Ast_async.has_async_payload e.pexp_attributes in
-    let body = Ast_async.add_async_attribute ~async body in
     let res = self.expr self body in
     {e with pexp_desc = Pexp_newtype (s, res)}
   | Pexp_fun {arg_label = label; lhs = pat; rhs = body} -> (

--- a/compiler/ml/ast_async.ml
+++ b/compiler/ml/ast_async.ml
@@ -1,8 +1,5 @@
-let is_async : Parsetree.attribute -> bool = fun ({txt}, _) -> txt = "res.async"
-
-let has_async_payload attrs = Ext_list.exists attrs is_async
-
-let make_async_attr loc = (Location.mkloc "res.async" loc, Parsetree.PStr [])
+let has_async_payload attrs =
+  Ext_list.exists attrs (fun ({Location.txt}, _) -> txt = "res.async")
 
 let add_async_attribute ~async (body : Parsetree.expression) =
   if async then
@@ -13,15 +10,6 @@ let add_async_attribute ~async (body : Parsetree.expression) =
         :: body.pexp_attributes;
     }
   else body
-
-let extract_async_attribute attrs =
-  let rec process async acc attrs =
-    match attrs with
-    | [] -> (async, List.rev acc)
-    | ({Location.txt = "res.async"}, _) :: rest -> process true acc rest
-    | attr :: rest -> process async (attr :: acc) rest
-  in
-  process false [] attrs
 
 let add_promise_type ?(loc = Location.none) ~async
     (result : Parsetree.expression) =

--- a/compiler/ml/ast_async.ml
+++ b/compiler/ml/ast_async.ml
@@ -2,13 +2,25 @@ let has_async_payload attrs =
   Ext_list.exists attrs (fun ({Location.txt}, _) -> txt = "res.async")
 
 let add_async_attribute ~async (body : Parsetree.expression) =
+  let add (exp : Parsetree.expression) =
+    if has_async_payload exp.pexp_attributes then exp
+    else
+      {
+        exp with
+        pexp_attributes =
+          ({txt = "res.async"; loc = Location.none}, PStr [])
+          :: exp.pexp_attributes;
+      }
+  in
   if async then
-    {
-      body with
-      pexp_attributes =
-        ({txt = "res.async"; loc = Location.none}, PStr [])
-        :: body.pexp_attributes;
-    }
+    let rec add_to_fun (exp : Parsetree.expression) =
+      match exp.pexp_desc with
+      | Pexp_newtype (txt, e) ->
+        {exp with pexp_desc = Pexp_newtype (txt, add_to_fun e)}
+      | Pexp_fun _ -> add exp
+      | _ -> exp
+    in
+    add (add_to_fun body)
   else body
 
 let add_promise_type ?(loc = Location.none) ~async

--- a/compiler/ml/ast_async.ml
+++ b/compiler/ml/ast_async.ml
@@ -1,6 +1,12 @@
 let has_async_payload attrs =
   Ext_list.exists attrs (fun ({Location.txt}, _) -> txt = "res.async")
 
+let rec dig_async_payload_from_function (expr : Parsetree.expression) =
+  match expr.pexp_desc with
+  | Pexp_fun _ -> has_async_payload expr.pexp_attributes
+  | Pexp_newtype (_, body) -> dig_async_payload_from_function body
+  | _ -> false
+
 let add_async_attribute ~async (body : Parsetree.expression) =
   let add (exp : Parsetree.expression) =
     if has_async_payload exp.pexp_attributes then exp
@@ -20,7 +26,7 @@ let add_async_attribute ~async (body : Parsetree.expression) =
       | Pexp_fun _ -> add exp
       | _ -> exp
     in
-    add (add_to_fun body)
+    add_to_fun body
   else body
 
 let add_promise_type ?(loc = Location.none) ~async

--- a/compiler/syntax/src/jsx_common.ml
+++ b/compiler/syntax/src/jsx_common.ml
@@ -50,22 +50,6 @@ let raise_error_multiple_component ~loc =
     "Only one component definition is allowed for each module. Move to a \
      submodule or other file if necessary."
 
-let remove_arity binding =
-  let rec remove_arity_record expr =
-    match expr.pexp_desc with
-    | _ when Ast_uncurried.expr_is_uncurried_fun expr ->
-      Ast_uncurried.expr_extract_uncurried_fun expr
-    | Pexp_newtype (label, e) ->
-      {expr with pexp_desc = Pexp_newtype (label, remove_arity_record e)}
-    | Pexp_apply (forward_ref, [(label, e)]) ->
-      {
-        expr with
-        pexp_desc = Pexp_apply (forward_ref, [(label, remove_arity_record e)]);
-      }
-    | _ -> expr
-  in
-  {binding with pvb_expr = remove_arity_record binding.pvb_expr}
-
 let async_component ~async expr =
   if async then
     let open Ast_helper in

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -955,10 +955,8 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
       modified_binding ~binding_loc ~binding_pat_loc ~fn_name binding
     in
     let is_async =
-      Ext_list.find_first binding.pvb_expr.pexp_attributes Ast_async.is_async
-      |> Option.is_some
+      Ast_async.has_async_payload binding.pvb_expr.pexp_attributes
     in
-    (* do stuff here! *)
     let named_arg_list, newtypes, _typeConstraints =
       recursively_transform_named_args_for_make
         (modified_binding_old binding)
@@ -1192,9 +1190,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
     in
 
     let is_async =
-      Ext_list.find_first modified_binding.pvb_expr.pexp_attributes
-        Ast_async.is_async
-      |> Option.is_some
+      Ast_async.has_async_payload modified_binding.pvb_expr.pexp_attributes
     in
 
     let make_new_binding ~loc ~full_module_name binding =

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -927,7 +927,6 @@ let vb_match_expr named_arg_list expr =
 let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
   if Jsx_common.has_attr_on_binding Jsx_common.has_attr binding then (
     check_multiple_components ~config ~loc:pstr_loc;
-    let binding = Jsx_common.remove_arity binding in
     let core_type_of_attr =
       Jsx_common.core_type_of_attrs binding.pvb_attributes
     in
@@ -1173,12 +1172,10 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
     (Some props_record_type, binding, new_binding))
   else if Jsx_common.has_attr_on_binding Jsx_common.has_attr_with_props binding
   then
-    let modified_binding = Jsx_common.remove_arity binding in
     let modified_binding =
       {
-        modified_binding with
-        pvb_attributes =
-          modified_binding.pvb_attributes |> List.filter other_attrs_pure;
+        binding with
+        pvb_attributes = binding.pvb_attributes |> List.filter other_attrs_pure;
       }
     in
     let fn_name = get_fn_name modified_binding.pvb_pat in

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -954,9 +954,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
     let binding_wrapper, has_forward_ref, expression =
       modified_binding ~binding_loc ~binding_pat_loc ~fn_name binding
     in
-    let is_async =
-      Ast_async.has_async_payload binding.pvb_expr.pexp_attributes
-    in
+    let is_async = Ast_async.dig_async_payload_from_function binding.pvb_expr in
     let named_arg_list, newtypes, _typeConstraints =
       recursively_transform_named_args_for_make
         (modified_binding_old binding)
@@ -1190,7 +1188,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
     in
 
     let is_async =
-      Ast_async.has_async_payload modified_binding.pvb_expr.pexp_attributes
+      Ast_async.dig_async_payload_from_function modified_binding.pvb_expr
     in
 
     let make_new_binding ~loc ~full_module_name binding =

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -7,13 +7,6 @@ module ResPrinter = Res_printer
 module Scanner = Res_scanner
 module Parser = Res_parser
 
-module LoopProgress = struct
-  let list_rest list =
-    match list with
-    | [] -> assert false
-    | _ :: rest -> rest
-end
-
 let mk_loc start_loc end_loc =
   Location.{loc_start = start_loc; loc_end = end_loc; loc_ghost = false}
 
@@ -1548,19 +1541,6 @@ and parse_es6_arrow_expression ?(arrow_attrs = []) ?(arrow_start_pos = None)
         {p with attrs = update_attrs p.attrs; pos = update_pos p.pos}
       :: rest
     | [] -> parameters
-  in
-  let parameters =
-    (* Propagate any dots from type parameters to the first term *)
-    let rec loop ~dot_in_type params =
-      match params with
-      | (TypeParameter _ as p) :: _ ->
-        let rest = LoopProgress.list_rest params in
-        (* Tell termination checker about progress *)
-        p :: loop ~dot_in_type rest
-      | (TermParameter _ as p) :: rest -> p :: rest
-      | [] -> []
-    in
-    loop ~dot_in_type:false parameters
   in
   let return_type =
     match p.Parser.token with
@@ -5749,7 +5729,7 @@ and parse_structure_item_region p =
            ~loc:(mk_loc p.start_pos p.prev_end_pos)
            ~attrs expr)
     | _ -> None)
-[@@progress Parser.next, Parser.expect, LoopProgress.list_rest]
+[@@progress Parser.next, Parser.expect]
 
 (* include-statement ::= include module-expr *)
 and parse_include_statement ~attrs p =
@@ -6402,7 +6382,7 @@ and parse_signature_item_region p =
         (Diagnostics.message (ErrorMessages.attribute_without_node attr));
       Some Recover.default_signature_item
     | _ -> None)
-[@@progress Parser.next, Parser.expect, LoopProgress.list_rest]
+[@@progress Parser.next, Parser.expect]
 
 (* module rec module-name :  module-type  { and module-name:  module-type } *)
 and parse_rec_module_spec ~attrs ~start_pos p =

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -1597,25 +1597,19 @@ and parse_es6_arrow_expression ?(arrow_attrs = []) ?(arrow_start_pos = None)
   Parser.eat_breadcrumb p;
   let end_pos = p.prev_end_pos in
   let type_param_opt, term_parameters = parameters in
-  let _paramNum, arrow_expr =
+  let arrow_expr =
     List.fold_right
-      (fun parameter (term_param_num, expr) ->
+      (fun parameter expr ->
         let {attrs; p_label = lbl; expr = default_expr; pat; p_pos = start_pos}
             =
           parameter
         in
         let loc = mk_loc start_pos end_pos in
-        let fun_expr =
-          Ast_helper.Exp.fun_ ~loc ~attrs ~arity:None lbl default_expr pat expr
-        in
-        if term_param_num = 1 then
-          ( term_param_num - 1,
-            Ast_uncurried.uncurried_fun
-              ~arity:(List.length term_parameters)
-              fun_expr )
-        else (term_param_num - 1, fun_expr))
-      term_parameters
-      (List.length term_parameters, body)
+        Ast_helper.Exp.fun_ ~loc ~attrs ~arity:None lbl default_expr pat expr)
+      term_parameters body
+  in
+  let arrow_expr =
+    Ast_uncurried.uncurried_fun ~arity:(List.length term_parameters) arrow_expr
   in
   let arrow_expr =
     match type_param_opt with

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -3303,12 +3303,8 @@ and parse_expr_block ?first p =
 and parse_async_arrow_expression ?(arrow_attrs = []) p =
   let start_pos = p.Parser.start_pos in
   Parser.expect (Lident "async") p;
-  let async_attr =
-    Ast_async.make_async_attr (mk_loc start_pos p.prev_end_pos)
-  in
-  parse_es6_arrow_expression
-    ~arrow_attrs:(async_attr :: arrow_attrs)
-    ~arrow_start_pos:(Some start_pos) p
+  Ast_async.add_async_attribute ~async:true
+    (parse_es6_arrow_expression ~arrow_attrs ~arrow_start_pos:(Some start_pos) p)
 
 and parse_await_expression p =
   let await_loc = mk_loc p.Parser.start_pos p.end_pos in

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -301,7 +301,7 @@ let ternary_operand expr =
       Nothing
     | {pexp_desc = Pexp_constraint _} -> Parenthesized
     | _ when Res_parsetree_viewer.is_fun_newtype expr -> (
-      let _parameters, return_expr = ParsetreeViewer.fun_expr expr in
+      let _, _parameters, return_expr = ParsetreeViewer.fun_expr expr in
       match return_expr.pexp_desc with
       | Pexp_constraint _ -> Parenthesized
       | _ -> Nothing)

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -301,9 +301,7 @@ let ternary_operand expr =
       Nothing
     | {pexp_desc = Pexp_constraint _} -> Parenthesized
     | _ when Res_parsetree_viewer.is_fun_newtype expr -> (
-      let _attrsOnArrow, _parameters, return_expr =
-        ParsetreeViewer.fun_expr expr
-      in
+      let _parameters, return_expr = ParsetreeViewer.fun_expr expr in
       match return_expr.pexp_desc with
       | Pexp_constraint _ -> Parenthesized
       | _ -> Nothing)

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -86,17 +86,6 @@ let has_partial_attribute attrs =
       | _ -> false)
     attrs
 
-type function_attributes_info = {async: bool; attributes: Parsetree.attributes}
-
-let process_function_attributes attrs =
-  let rec process async acc attrs =
-    match attrs with
-    | [] -> {async; attributes = List.rev acc}
-    | ({Location.txt = "res.async"}, _) :: rest -> process true acc rest
-    | attr :: rest -> process async (attr :: acc) rest
-  in
-  process false [] attrs
-
 let has_await_attribute attrs =
   List.exists
     (function
@@ -198,7 +187,8 @@ let fun_expr expr =
          };
     } ->
       (List.rev params, rewrite_underscore_apply expr)
-    | {pexp_desc = Pexp_newtype (string_loc, rest); pexp_attributes = attrs} ->
+    | {pexp_desc = Pexp_newtype (string_loc, rest); pexp_attributes = attrs}
+      when n_fun = 0 ->
       let string_locs, return_expr = collect_new_types [string_loc] rest in
       let param = NewTypes {attrs; locs = string_locs} in
       collect ~n_fun ~params:(param :: params) return_expr

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -166,7 +166,7 @@ type fun_param_kind =
   | NewTypes of {attrs: Parsetree.attributes; locs: string Asttypes.loc list}
 
 let fun_expr expr_ =
-  let async = Ast_async.has_async_payload expr_.pexp_attributes in
+  let async = Ast_async.dig_async_payload_from_function expr_ in
   let rec collect_params ~n_fun ~params expr =
     match expr with
     | {

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -53,8 +53,7 @@ type fun_param_kind =
   | NewTypes of {attrs: Parsetree.attributes; locs: string Asttypes.loc list}
 
 val fun_expr :
-  Parsetree.expression ->
-  Parsetree.attributes * fun_param_kind list * Parsetree.expression
+  Parsetree.expression -> fun_param_kind list * Parsetree.expression
 
 (* example:
    *  `makeCoordinate({

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -53,7 +53,7 @@ type fun_param_kind =
   | NewTypes of {attrs: Parsetree.attributes; locs: string Asttypes.loc list}
 
 val fun_expr :
-  Parsetree.expression -> fun_param_kind list * Parsetree.expression
+  Parsetree.expression -> bool * fun_param_kind list * Parsetree.expression
 
 (* example:
    *  `makeCoordinate({

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1980,7 +1980,7 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
      };
    pvb_expr = {pexp_desc = Pexp_newtype _} as expr;
   } -> (
-    let parameters, return_expr = ParsetreeViewer.fun_expr expr in
+    let _, parameters, return_expr = ParsetreeViewer.fun_expr expr in
     let abstract_type =
       match parameters with
       | [NewTypes {locs = vars}] ->
@@ -2695,9 +2695,8 @@ and print_if_chain ~state pexp_attributes ifs else_expr cmt_tbl =
 
 and print_expression ~state (e : Parsetree.expression) cmt_tbl =
   let print_arrow e =
-    let parameters, return_expr = ParsetreeViewer.fun_expr e in
+    let async, parameters, return_expr = ParsetreeViewer.fun_expr e in
     let attrs_on_arrow = e.pexp_attributes in
-    let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
     let return_expr, typ_constraint =
       match return_expr.pexp_desc with
       | Pexp_constraint (expr, typ) ->
@@ -2760,7 +2759,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
         Doc.concat [Doc.text ": "; typ_doc]
       | _ -> Doc.nil
     in
-    let attrs = print_attributes ~state attrs cmt_tbl in
+    let attrs = print_attributes ~state attrs_on_arrow cmt_tbl in
     Doc.group
       (Doc.concat
          [
@@ -3437,9 +3436,8 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
   | _ -> expr_with_await
 
 and print_pexp_fun ~state ~in_callback e cmt_tbl =
-  let parameters, return_expr = ParsetreeViewer.fun_expr e in
+  let async, parameters, return_expr = ParsetreeViewer.fun_expr e in
   let attrs_on_arrow = e.pexp_attributes in
-  let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
   let return_expr, typ_constraint =
     match return_expr.pexp_desc with
     | Pexp_constraint (expr, typ) ->
@@ -3505,7 +3503,7 @@ and print_pexp_fun ~state ~in_callback e cmt_tbl =
   in
   Doc.concat
     [
-      print_attributes ~state attrs cmt_tbl;
+      print_attributes ~state attrs_on_arrow cmt_tbl;
       parameters_doc;
       typ_constraint_doc;
       Doc.text " =>";

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -2697,9 +2697,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
   let print_arrow e =
     let parameters, return_expr = ParsetreeViewer.fun_expr e in
     let attrs_on_arrow = e.pexp_attributes in
-    let ParsetreeViewer.{async; attributes = attrs} =
-      ParsetreeViewer.process_function_attributes attrs_on_arrow
-    in
+    let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
     let return_expr, typ_constraint =
       match return_expr.pexp_desc with
       | Pexp_constraint (expr, typ) ->
@@ -3441,9 +3439,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
 and print_pexp_fun ~state ~in_callback e cmt_tbl =
   let parameters, return_expr = ParsetreeViewer.fun_expr e in
   let attrs_on_arrow = e.pexp_attributes in
-  let ParsetreeViewer.{async; attributes = attrs} =
-    ParsetreeViewer.process_function_attributes attrs_on_arrow
-  in
+  let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
   let return_expr, typ_constraint =
     match return_expr.pexp_desc with
     | Pexp_constraint (expr, typ) ->

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1980,7 +1980,7 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
      };
    pvb_expr = {pexp_desc = Pexp_newtype _} as expr;
   } -> (
-    let _attrs, parameters, return_expr = ParsetreeViewer.fun_expr expr in
+    let parameters, return_expr = ParsetreeViewer.fun_expr expr in
     let abstract_type =
       match parameters with
       | [NewTypes {locs = vars}] ->
@@ -2695,8 +2695,11 @@ and print_if_chain ~state pexp_attributes ifs else_expr cmt_tbl =
 
 and print_expression ~state (e : Parsetree.expression) cmt_tbl =
   let print_arrow e =
-    let attrs_on_arrow, parameters, return_expr = ParsetreeViewer.fun_expr e in
-    let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
+    let parameters, return_expr = ParsetreeViewer.fun_expr e in
+    let attrs_on_arrow = e.pexp_attributes in
+    let ParsetreeViewer.{async; attributes = attrs} =
+      ParsetreeViewer.process_function_attributes attrs_on_arrow
+    in
     let return_expr, typ_constraint =
       match return_expr.pexp_desc with
       | Pexp_constraint (expr, typ) ->
@@ -3436,8 +3439,11 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
   | _ -> expr_with_await
 
 and print_pexp_fun ~state ~in_callback e cmt_tbl =
-  let attrs_on_arrow, parameters, return_expr = ParsetreeViewer.fun_expr e in
-  let async, attrs = Ast_async.extract_async_attribute attrs_on_arrow in
+  let parameters, return_expr = ParsetreeViewer.fun_expr e in
+  let attrs_on_arrow = e.pexp_attributes in
+  let ParsetreeViewer.{async; attributes = attrs} =
+    ParsetreeViewer.process_function_attributes attrs_on_arrow
+  in
   let return_expr, typ_constraint =
     match return_expr.pexp_desc with
     | Pexp_constraint (expr, typ) ->

--- a/tests/analysis_tests/tests-generic-jsx-transform/package-lock.json
+++ b/tests/analysis_tests/tests-generic-jsx-transform/package-lock.json
@@ -9,7 +9,8 @@
       }
     },
     "../../..": {
-      "version": "12.0.0-alpha.7",
+      "name": "rescript",
+      "version": "12.0.0-alpha.8",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {

--- a/tests/analysis_tests/tests-incremental-typechecking/package-lock.json
+++ b/tests/analysis_tests/tests-incremental-typechecking/package-lock.json
@@ -9,7 +9,8 @@
       }
     },
     "../../..": {
-      "version": "12.0.0-alpha.7",
+      "name": "rescript",
+      "version": "12.0.0-alpha.8",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {

--- a/tests/analysis_tests/tests-reanalyze/deadcode/package-lock.json
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/package-lock.json
@@ -15,7 +15,8 @@
       }
     },
     "../../../..": {
-      "version": "12.0.0-alpha.7",
+      "name": "rescript",
+      "version": "12.0.0-alpha.8",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",

--- a/tests/analysis_tests/tests-reanalyze/termination/package-lock.json
+++ b/tests/analysis_tests/tests-reanalyze/termination/package-lock.json
@@ -12,7 +12,8 @@
       }
     },
     "../../../..": {
-      "version": "12.0.0-alpha.7",
+      "name": "rescript",
+      "version": "12.0.0-alpha.8",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",

--- a/tests/analysis_tests/tests/package-lock.json
+++ b/tests/analysis_tests/tests/package-lock.json
@@ -33,6 +33,7 @@
       }
     },
     "../../..": {
+      "name": "rescript",
       "version": "12.0.0-alpha.8",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
@@ -35,15 +35,15 @@ let ex4 = (((foo.bar).baz)[@res.await ])
 let attr1 = ((fun [arity:1]x -> x + 1)[@res.async ][@a ])
 let attr2 = ((fun (type a) ->
   ((fun [arity:1]() -> fun (type b) -> fun (type c) -> fun [arity:1]x -> 3)
-  [@res.async ]))[@res.async ][@a ])
+  [@res.async ]))[@a ])
 let attr3 = ((fun (type a) ->
-  fun [arity:1]() -> ((fun (type b) -> fun (type c) -> ((fun [arity:1]x -> 3)
-    [@res.async ]))[@res.async ]))
+  fun [arity:1]() -> fun (type b) -> fun (type c) -> ((fun [arity:1]x -> 3)
+    [@res.async ]))
   [@a ])
 let attr4 = ((fun (type a) ->
   fun [arity:1]() -> ((fun (type b) -> fun (type c) -> ((fun [arity:1]x -> 3)
-    [@res.async ]))[@res.async ][@b ]))
+    [@res.async ]))[@b ]))
   [@a ])
 let (attr5 : int) = ((fun (type a) -> fun (type b) -> fun (type c) ->
-  ((fun [arity:1]() -> fun [arity:1](x : a) -> x)[@res.async ]))
-  [@res.async ][@a ][@b ])
+  ((fun [arity:1]() -> fun [arity:1](x : a) -> x)[@res.async ]))[@a ]
+  [@b ])

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
@@ -34,15 +34,16 @@ let ex3 = ((foo |.u (bar ~arg:((arg)[@res.namedArgLoc ])))[@res.await ])
 let ex4 = (((foo.bar).baz)[@res.await ])
 let attr1 = ((fun [arity:1]x -> x + 1)[@res.async ][@a ])
 let attr2 = ((fun (type a) ->
-  fun [arity:1]() -> fun (type b) -> fun (type c) -> fun [arity:1]x -> 3)
-  [@res.async ][@a ])
+  ((fun [arity:1]() -> fun (type b) -> fun (type c) -> fun [arity:1]x -> 3)
+  [@res.async ]))[@res.async ][@a ])
 let attr3 = ((fun (type a) ->
-  fun [arity:1]() -> ((fun (type b) -> fun (type c) -> fun [arity:1]x -> 3)
-    [@res.async ]))
+  fun [arity:1]() -> ((fun (type b) -> fun (type c) -> ((fun [arity:1]x -> 3)
+    [@res.async ]))[@res.async ]))
   [@a ])
 let attr4 = ((fun (type a) ->
-  fun [arity:1]() -> ((fun (type b) -> fun (type c) -> fun [arity:1]x -> 3)
-    [@res.async ][@b ]))
+  fun [arity:1]() -> ((fun (type b) -> fun (type c) -> ((fun [arity:1]x -> 3)
+    [@res.async ]))[@res.async ][@b ]))
   [@a ])
 let (attr5 : int) = ((fun (type a) -> fun (type b) -> fun (type c) ->
-  fun [arity:1]() -> fun [arity:1](x : a) -> x)[@res.async ][@a ][@b ])
+  ((fun [arity:1]() -> fun [arity:1](x : a) -> x)[@res.async ]))
+  [@res.async ][@a ][@b ])

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/locallyAbstractTypes.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/locallyAbstractTypes.res.txt
@@ -1,16 +1,16 @@
 let f (type t) [arity:1](xs : t list) = ()
-let f (type t) [arity:2](xs : t list) (type s) (ys : s list) = ()
+let f (type t) (type s) [arity:2](xs : t list) (ys : s list) = ()
 let f (type t) (type u) (type v) [arity:1](xs : (t * u * v) list) = ()
-let f (type t) (type u) (type v) [arity:2](xs : (t * u * v) list) (type s)
-  (type w) (type z) (ys : (s * w * z) list) = ()
-let f = ((fun (type t) -> fun (type u) -> fun (type v) ->
-  fun [arity:2](xs : (t * u * v) list) -> ((fun (type s) -> fun (type w) ->
-    fun (type z) -> fun (ys : (s * w * z) list) -> ())[@attr2 ]))
-  [@attr ])
-let f = ((fun (type t) -> ((fun (type s) ->
-  fun [arity:2](xs : (t * s) list) -> ((fun (type u) -> ((fun (type v) -> fun
-    (type w) -> fun (ys : (u * v * w) list) -> ())[@attr ]))[@attr ]))
-  [@attr ]))[@attr ])
+let f (type t) (type u) (type v) (type s) (type w) (type z)
+  [arity:2](xs : (t * u * v) list) (ys : (s * w * z) list) = ()
+let f = ((fun (type t) -> fun (type u) -> fun (type v) -> fun (type s) -> fun
+  (type w) -> fun (type z) ->
+  fun [arity:2](xs : (t * u * v) list) -> fun (ys : (s * w * z) list) -> ())
+  [@attr ][@attr2 ])
+let f = ((fun (type t) -> fun (type s) -> fun (type u) -> fun (type v) -> fun
+  (type w) ->
+  fun [arity:2](xs : (t * s) list) -> fun (ys : (u * v * w) list) -> ())
+  [@attr ][@attr ][@attr ][@attr ])
 let cancel_and_collect_callbacks :
   'a 'u 'c .
     packed_callbacks list ->

--- a/tests/syntax_tests/data/printer/comments/expected/expr.res.txt
+++ b/tests/syntax_tests/data/printer/comments/expected/expr.res.txt
@@ -227,8 +227,11 @@ let f = (
 ) => /* c7 */ ()
 
 let multiply = (type /* c-2 */ t /* c-1 */, /* c0 */ m1 /* c1 */, /* c2 */ m2 /* c3 */) => ()
-let multiply = (type /* c-4 */ t /* c-3 */, /* c0 */ m1 /* c1 */) =>
-  (type /* c-2 */ s /* c-1 */, /* c2 */ m2 /* c3 */) => ()
+let multiply = (
+  type /* c-4 */ t /* c-3 */ s,
+  /* c0 */ m1 /* c1 */,
+  /* c-2 */ /* c-1 */ /* c2 */ m2 /* c3 */,
+) => ()
 
 f(
   // a

--- a/tests/syntax_tests/data/printer/expr/expected/newtype.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/newtype.res.txt
@@ -1,14 +1,12 @@
 let f = (type t, xs: list<t>) => ()
 let f = @attr (type t, xs: list<t>) => ()
-let f = (type t, xs: list<t>) => (type s, ys: list<s>) => ()
-let f = @attr (type t, xs: list<t>) => @attr2 (type s, ys: list<s>) => ()
+let f = (type t s, xs: list<t>, ys: list<s>) => ()
+let f = @attr @attr2 (type t s, xs: list<t>, ys: list<s>) => ()
 let f = (type t u v, xs: list<(t, u, v)>) => ()
 let f = @attr (type t u v, xs: list<(t, u, v)>) => ()
-let f = (type t u v, xs: list<(t, u, v)>) => (type s w z, ys: list<(s, w, z)>) => ()
-let f = @attr (type t u v, xs: list<(t, u, v)>) => @attr2 (type s w z, ys: list<(s, w, z)>) => ()
-let f = @attr
-(type t, @attr type s, xs: list<(t, s)>) =>
-  @attr (type u, @attr type v w, ys: list<(u, v, w)>) => ()
+let f = (type t u v s w z, xs: list<(t, u, v)>, ys: list<(s, w, z)>) => ()
+let f = @attr @attr2 (type t u v s w z, xs: list<(t, u, v)>, ys: list<(s, w, z)>) => ()
+let f = @attr @attr @attr @attr (type t s u v w, xs: list<(t, s)>, ys: list<(u, v, w)>) => ()
 
 let mk_formatting_gen:
   type a b c d e f. formatting_gen<a, b, c, d, e, f> => Parsetree.expression =

--- a/tests/tools_tests/package-lock.json
+++ b/tests/tools_tests/package-lock.json
@@ -14,7 +14,8 @@
       }
     },
     "../..": {
-      "version": "12.0.0-alpha.7",
+      "name": "rescript",
+      "version": "12.0.0-alpha.8",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {


### PR DESCRIPTION
AST: always put type parameters first in function definitions.

Normalize function definitions to be of the form `(type a b c, x, y) => ...`, moving all the types first if they are not already.
