### PR TITLE
AST: Remove Pexp_new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
 - AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 - AST cleanup: Remove `@res.async` attribute from the internal representation, and add a flag to untyped and typed ASTs instead. https://github.com/rescript-lang/rescript/pull/7234
-- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar`, `expression_desc.Pexp_override` & `expression_desc.Pexp_poly` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
+- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar`, `expression_desc.Pexp_override`, `expression_desc.Pexp_poly`, `exp_extra.Texp_poly`, `expression_desc.Texp_new`, `expression_desc.Texp_setinstvar` & `expression_desc.Texp_override` from AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
 
 # 12.0.0-alpha.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
 - AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 - AST cleanup: Remove `@res.async` attribute from the internal representation, and add a flag to untyped and typed ASTs instead. https://github.com/rescript-lang/rescript/pull/7234
-- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar`, `expression_desc.Pexp_override`, `expression_desc.Pexp_poly`, `exp_extra.Texp_poly`, `expression_desc.Texp_new`, `expression_desc.Texp_setinstvar` & `expression_desc.Texp_override` from AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
+- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar`, `expression_desc.Pexp_override`, `expression_desc.Pexp_poly`, `exp_extra.Texp_poly`, `expression_desc.Texp_new`, `expression_desc.Texp_setinstvar`, `expression_desc.Texp_override` & `expression_desc.Texp_instvar` from AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
 
 # 12.0.0-alpha.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
 - AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 - AST cleanup: Remove `@res.async` attribute from the internal representation, and add a flag to untyped and typed ASTs instead. https://github.com/rescript-lang/rescript/pull/7234
-- AST cleanup: Remove `expression_desc.Pexp_new` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
+- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar` & `expression_desc.Pexp_override` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
 
 # 12.0.0-alpha.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
 - AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 - AST cleanup: Remove `@res.async` attribute from the internal representation, and add a flag to untyped and typed ASTs instead. https://github.com/rescript-lang/rescript/pull/7234
-- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar` & `expression_desc.Pexp_override` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
+- AST cleanup: Remove `expression_desc.Pexp_new`, `expression_desc.Pexp_setinstvar`, `expression_desc.Pexp_override` & `expression_desc.Pexp_poly` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
 
 # 12.0.0-alpha.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - AST cleanup: Prepare for ast async cleanup: Refactor code for "@res.async" payload handling and clean up handling of type and term parameters, so that now each `=>` in a function definition corresponds to a function. https://github.com/rescript-lang/rescript/pull/7223
 - AST: always put type parameters first in function definitions. https://github.com/rescript-lang/rescript/pull/7233
 - AST cleanup: Remove `@res.async` attribute from the internal representation, and add a flag to untyped and typed ASTs instead. https://github.com/rescript-lang/rescript/pull/7234
+- AST cleanup: Remove `expression_desc.Pexp_new` from the untyped typed AST as it is unused. https://github.com/rescript-lang/rescript/pull/7239
 
 # 12.0.0-alpha.7
 

--- a/analysis/reanalyze/src/Arnold.ml
+++ b/analysis/reanalyze/src/Arnold.ml
@@ -975,9 +975,6 @@ module Compile = struct
     | Texp_send _ ->
       notImplemented "Texp_send";
       assert false
-    | Texp_instvar _ ->
-      notImplemented "Texp_instvar";
-      assert false
     | Texp_letmodule _ ->
       notImplemented "Texp_letmodule";
       assert false

--- a/analysis/reanalyze/src/Arnold.ml
+++ b/analysis/reanalyze/src/Arnold.ml
@@ -975,17 +975,8 @@ module Compile = struct
     | Texp_send _ ->
       notImplemented "Texp_send";
       assert false
-    | Texp_new _ ->
-      notImplemented "Texp_new";
-      assert false
     | Texp_instvar _ ->
       notImplemented "Texp_instvar";
-      assert false
-    | Texp_setinstvar _ ->
-      notImplemented "Texp_setinstvar";
-      assert false
-    | Texp_override _ ->
-      notImplemented "Texp_override";
       assert false
     | Texp_letmodule _ ->
       notImplemented "Texp_letmodule";

--- a/analysis/reanalyze/src/SideEffects.ml
+++ b/analysis/reanalyze/src/SideEffects.ml
@@ -61,10 +61,7 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
     e1 |> exprNoSideEffects && e2 |> exprNoSideEffects
     && e3 |> exprNoSideEffects
   | Texp_send _ -> false
-  | Texp_new _ -> true
   | Texp_instvar _ -> true
-  | Texp_setinstvar _ -> false
-  | Texp_override _ -> false
   | Texp_letexception (_ec, e) -> e |> exprNoSideEffects
   | Texp_pack _ -> false
   | Texp_extension_constructor _ when true -> true

--- a/analysis/reanalyze/src/SideEffects.ml
+++ b/analysis/reanalyze/src/SideEffects.ml
@@ -61,7 +61,6 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
     e1 |> exprNoSideEffects && e2 |> exprNoSideEffects
     && e3 |> exprNoSideEffects
   | Texp_send _ -> false
-  | Texp_instvar _ -> true
   | Texp_letexception (_ec, e) -> e |> exprNoSideEffects
   | Texp_pack _ -> false
   | Texp_extension_constructor _ when true -> true

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -103,7 +103,6 @@ let identifyPexp pexp =
   | Pexp_constraint _ -> "Pexp_constraint"
   | Pexp_coerce _ -> "Pexp_coerce"
   | Pexp_send _ -> "Pexp_send"
-  | Pexp_override _ -> "Pexp_override"
   | Pexp_letmodule _ -> "Pexp_letmodule"
   | Pexp_letexception _ -> "Pexp_letexception"
   | Pexp_assert _ -> "Pexp_assert"

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -107,7 +107,6 @@ let identifyPexp pexp =
   | Pexp_letexception _ -> "Pexp_letexception"
   | Pexp_assert _ -> "Pexp_assert"
   | Pexp_lazy _ -> "Pexp_lazy"
-  | Pexp_poly _ -> "Pexp_poly"
   | Pexp_newtype _ -> "Pexp_newtype"
   | Pexp_pack _ -> "Pexp_pack"
   | Pexp_extension _ -> "Pexp_extension"

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -103,7 +103,6 @@ let identifyPexp pexp =
   | Pexp_constraint _ -> "Pexp_constraint"
   | Pexp_coerce _ -> "Pexp_coerce"
   | Pexp_send _ -> "Pexp_send"
-  | Pexp_new _ -> "Pexp_new"
   | Pexp_setinstvar _ -> "Pexp_setinstvar"
   | Pexp_override _ -> "Pexp_override"
   | Pexp_letmodule _ -> "Pexp_letmodule"

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -103,7 +103,6 @@ let identifyPexp pexp =
   | Pexp_constraint _ -> "Pexp_constraint"
   | Pexp_coerce _ -> "Pexp_coerce"
   | Pexp_send _ -> "Pexp_send"
-  | Pexp_setinstvar _ -> "Pexp_setinstvar"
   | Pexp_override _ -> "Pexp_override"
   | Pexp_letmodule _ -> "Pexp_letmodule"
   | Pexp_letexception _ -> "Pexp_letexception"

--- a/compiler/frontend/bs_ast_invariant.ml
+++ b/compiler/frontend/bs_ast_invariant.ml
@@ -94,8 +94,6 @@ let emit_external_warnings : iterator =
       (fun self ({pexp_loc = loc} as a) ->
         match a.pexp_desc with
         | Pexp_constant const -> check_constant loc const
-        | Pexp_new _ ->
-          Location.raise_errorf ~loc "OCaml style objects are not supported"
         | Pexp_variant (s, None) when Ext_string.is_valid_hash_number s -> (
           try ignore (Ext_string.hash_number_as_i32_exn s : int32)
           with _ ->

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -354,8 +354,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_setinstvar (s, e) ->
-      setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->
       override ~loc ~attrs
         (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -363,8 +363,6 @@ module E = struct
         (sub.expr sub e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub.expr sub e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub.expr sub e)
-    | Pexp_poly (e, t) ->
-      poly ~loc ~attrs (sub.expr sub e) (map_opt (sub.typ sub) t)
     | Pexp_newtype (s, e) ->
       newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_pack me -> pack ~loc ~attrs (sub.module_expr sub me)

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -354,9 +354,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_override sel ->
-      override ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)
     | Pexp_letmodule (s, me, e) ->
       letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
         (sub.expr sub e)

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -354,7 +354,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_new lid -> new_ ~loc ~attrs (map_loc sub lid)
     | Pexp_setinstvar (s, e) ->
       setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->

--- a/compiler/frontend/bs_builtin_ppx.ml
+++ b/compiler/frontend/bs_builtin_ppx.ml
@@ -87,24 +87,6 @@ let expr_mapper ~async_context ~in_function_def (self : mapper)
   (* Its output should not be rewritten anymore *)
   | Pexp_extension extension ->
     Ast_exp_extension.handle_extension e self extension
-  | Pexp_setinstvar ({txt; loc}, expr) ->
-    if Stack.is_empty Js_config.self_stack then
-      Location.raise_errorf ~loc:e.pexp_loc
-        "This assignment can only happen in object context";
-    let name = Stack.top Js_config.self_stack in
-    if name = "" then
-      Location.raise_errorf ~loc:e.pexp_loc
-        "The current object does not assign a name";
-    let open Ast_helper in
-    self.expr self
-      (Exp.apply ~loc:e.pexp_loc
-         (Exp.ident ~loc {loc; txt = Lident "#="})
-         [
-           ( Nolabel,
-             Exp.send ~loc (Exp.ident ~loc {loc; txt = Lident name}) {loc; txt}
-           );
-           (Nolabel, expr);
-         ])
   | Pexp_constant (Pconst_string (s, Some delim)) ->
     Ast_utf8_string_interp.transform_exp e s delim
   | Pexp_constant (Pconst_integer (s, Some 'l')) ->

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -171,7 +171,6 @@ module Exp = struct
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
   let coerce ?loc ?attrs a c = mk ?loc ?attrs (Pexp_coerce (a, (), c))
   let send ?loc ?attrs a b = mk ?loc ?attrs (Pexp_send (a, b))
-  let new_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_new a)
   let setinstvar ?loc ?attrs a b = mk ?loc ?attrs (Pexp_setinstvar (a, b))
   let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
   let letmodule ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_letmodule (a, b, c))

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -171,7 +171,6 @@ module Exp = struct
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
   let coerce ?loc ?attrs a c = mk ?loc ?attrs (Pexp_coerce (a, (), c))
   let send ?loc ?attrs a b = mk ?loc ?attrs (Pexp_send (a, b))
-  let setinstvar ?loc ?attrs a b = mk ?loc ?attrs (Pexp_setinstvar (a, b))
   let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
   let letmodule ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_letmodule (a, b, c))
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -175,7 +175,6 @@ module Exp = struct
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_lazy a)
-  let poly ?loc ?attrs a b = mk ?loc ?attrs (Pexp_poly (a, b))
   let newtype ?loc ?attrs a b = mk ?loc ?attrs (Pexp_newtype (a, b))
   let pack ?loc ?attrs a = mk ?loc ?attrs (Pexp_pack a)
   let open_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_open (a, b, c))

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -171,7 +171,6 @@ module Exp = struct
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
   let coerce ?loc ?attrs a c = mk ?loc ?attrs (Pexp_coerce (a, (), c))
   let send ?loc ?attrs a b = mk ?loc ?attrs (Pexp_send (a, b))
-  let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
   let letmodule ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_letmodule (a, b, c))
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -192,7 +192,6 @@ module Exp : sig
   val constraint_ :
     ?loc:loc -> ?attrs:attrs -> expression -> core_type -> expression
   val send : ?loc:loc -> ?attrs:attrs -> expression -> str -> expression
-  val new_ : ?loc:loc -> ?attrs:attrs -> lid -> expression
   val setinstvar : ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
   val override :
     ?loc:loc -> ?attrs:attrs -> (str * expression) list -> expression

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -192,8 +192,6 @@ module Exp : sig
   val constraint_ :
     ?loc:loc -> ?attrs:attrs -> expression -> core_type -> expression
   val send : ?loc:loc -> ?attrs:attrs -> expression -> str -> expression
-  val override :
-    ?loc:loc -> ?attrs:attrs -> (str * expression) list -> expression
   val letmodule :
     ?loc:loc -> ?attrs:attrs -> str -> module_expr -> expression -> expression
   val letexception :

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -192,7 +192,6 @@ module Exp : sig
   val constraint_ :
     ?loc:loc -> ?attrs:attrs -> expression -> core_type -> expression
   val send : ?loc:loc -> ?attrs:attrs -> expression -> str -> expression
-  val setinstvar : ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
   val override :
     ?loc:loc -> ?attrs:attrs -> (str * expression) list -> expression
   val letmodule :

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -202,8 +202,6 @@ module Exp : sig
     expression
   val assert_ : ?loc:loc -> ?attrs:attrs -> expression -> expression
   val lazy_ : ?loc:loc -> ?attrs:attrs -> expression -> expression
-  val poly :
-    ?loc:loc -> ?attrs:attrs -> expression -> core_type option -> expression
   val newtype : ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
   val pack : ?loc:loc -> ?attrs:attrs -> module_expr -> expression
   val open_ :

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -333,9 +333,6 @@ module E = struct
       sub.expr sub e;
       sub.typ sub t
     | Pexp_send (e, _s) -> sub.expr sub e
-    | Pexp_setinstvar (s, e) ->
-      iter_loc sub s;
-      sub.expr sub e
     | Pexp_override sel ->
       List.iter (iter_tuple (iter_loc sub) (sub.expr sub)) sel
     | Pexp_letmodule (s, me, e) ->

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -342,9 +342,6 @@ module E = struct
       sub.expr sub e
     | Pexp_assert e -> sub.expr sub e
     | Pexp_lazy e -> sub.expr sub e
-    | Pexp_poly (e, t) ->
-      sub.expr sub e;
-      iter_opt (sub.typ sub) t
     | Pexp_newtype (_s, e) -> sub.expr sub e
     | Pexp_pack me -> sub.module_expr sub me
     | Pexp_open (_ovf, lid, e) ->

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -333,8 +333,6 @@ module E = struct
       sub.expr sub e;
       sub.typ sub t
     | Pexp_send (e, _s) -> sub.expr sub e
-    | Pexp_override sel ->
-      List.iter (iter_tuple (iter_loc sub) (sub.expr sub)) sel
     | Pexp_letmodule (s, me, e) ->
       iter_loc sub s;
       sub.module_expr sub me;

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -333,7 +333,6 @@ module E = struct
       sub.expr sub e;
       sub.typ sub t
     | Pexp_send (e, _s) -> sub.expr sub e
-    | Pexp_new lid -> iter_loc sub lid
     | Pexp_setinstvar (s, e) ->
       iter_loc sub s;
       sub.expr sub e

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -317,7 +317,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_new lid -> new_ ~loc ~attrs (map_loc sub lid)
     | Pexp_setinstvar (s, e) ->
       setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -326,8 +326,6 @@ module E = struct
         (sub.expr sub e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub.expr sub e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub.expr sub e)
-    | Pexp_poly (e, t) ->
-      poly ~loc ~attrs (sub.expr sub e) (map_opt (sub.typ sub) t)
     | Pexp_newtype (s, e) ->
       newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_pack me -> pack ~loc ~attrs (sub.module_expr sub me)

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -317,8 +317,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_setinstvar (s, e) ->
-      setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->
       override ~loc ~attrs
         (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -317,9 +317,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_override sel ->
-      override ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)
     | Pexp_letmodule (s, me, e) ->
       letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
         (sub.expr sub e)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -377,8 +377,8 @@ module E = struct
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
     | Pexp_new _ -> failwith "Pexp_new is no longer present in ReScript"
-    | Pexp_setinstvar (s, e) ->
-      setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
+    | Pexp_setinstvar _ ->
+      failwith "Pexp_setinstvar is no longer present in ReScript"
     | Pexp_override sel ->
       override ~loc ~attrs
         (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -379,9 +379,8 @@ module E = struct
     | Pexp_new _ -> failwith "Pexp_new is no longer present in ReScript"
     | Pexp_setinstvar _ ->
       failwith "Pexp_setinstvar is no longer present in ReScript"
-    | Pexp_override sel ->
-      override ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)
+    | Pexp_override _ ->
+      failwith "Pexp_override is no longer present in ReScript"
     | Pexp_letmodule (s, me, e) ->
       letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
         (sub.expr sub e)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -376,7 +376,7 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_new lid -> new_ ~loc ~attrs (map_loc sub lid)
+    | Pexp_new _ -> failwith "Pexp_new is no longer present in ReScript"
     | Pexp_setinstvar (s, e) ->
       setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -390,8 +390,7 @@ module E = struct
         (sub.expr sub e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub.expr sub e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub.expr sub e)
-    | Pexp_poly (e, t) ->
-      poly ~loc ~attrs (sub.expr sub e) (map_opt (sub.typ sub) t)
+    | Pexp_poly _ -> failwith "Pexp_poly is no longer present in ReScript"
     | Pexp_object () -> assert false
     | Pexp_newtype (s, e) ->
       newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -365,9 +365,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_override sel ->
-      override ~loc ~attrs
-        (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)
     | Pexp_letmodule (s, me, e) ->
       letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
         (sub.expr sub e)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -374,8 +374,6 @@ module E = struct
         (sub.expr sub e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub.expr sub e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub.expr sub e)
-    | Pexp_poly (e, t) ->
-      poly ~loc ~attrs (sub.expr sub e) (map_opt (sub.typ sub) t)
     | Pexp_newtype (s, e) ->
       newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_pack me -> pack ~loc ~attrs (sub.module_expr sub me)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -365,8 +365,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_setinstvar (s, e) ->
-      setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->
       override ~loc ~attrs
         (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -365,7 +365,6 @@ module E = struct
     | Pexp_constraint (e, t) ->
       constraint_ ~loc ~attrs (sub.expr sub e) (sub.typ sub t)
     | Pexp_send (e, s) -> send ~loc ~attrs (sub.expr sub e) (map_loc sub s)
-    | Pexp_new lid -> new_ ~loc ~attrs (map_loc sub lid)
     | Pexp_setinstvar (s, e) ->
       setinstvar ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_override sel ->

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -271,7 +271,6 @@ let rec add_expr bv exp =
     add_expr bv e1;
     add_type bv ty2
   | Pexp_send (e, _m) -> add_expr bv e
-  | Pexp_new li -> add bv li
   | Pexp_setinstvar (_v, e) -> add_expr bv e
   | Pexp_override sel -> List.iter (fun (_s, e) -> add_expr bv e) sel
   | Pexp_letmodule (id, m, e) ->

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -277,9 +277,6 @@ let rec add_expr bv exp =
   | Pexp_letexception (_, e) -> add_expr bv e
   | Pexp_assert e -> add_expr bv e
   | Pexp_lazy e -> add_expr bv e
-  | Pexp_poly (e, t) ->
-    add_expr bv e;
-    add_opt add_type bv t
   | Pexp_newtype (_, e) -> add_expr bv e
   | Pexp_pack m -> add_module bv m
   | Pexp_open (_ovf, m, e) ->

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -271,7 +271,6 @@ let rec add_expr bv exp =
     add_expr bv e1;
     add_type bv ty2
   | Pexp_send (e, _m) -> add_expr bv e
-  | Pexp_override sel -> List.iter (fun (_s, e) -> add_expr bv e) sel
   | Pexp_letmodule (id, m, e) ->
     let b = add_module_binding bv m in
     add_expr (StringMap.add id.txt b bv) e

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -271,7 +271,6 @@ let rec add_expr bv exp =
     add_expr bv e1;
     add_type bv ty2
   | Pexp_send (e, _m) -> add_expr bv e
-  | Pexp_setinstvar (_v, e) -> add_expr bv e
   | Pexp_override sel -> List.iter (fun (_s, e) -> add_expr bv e) sel
   | Pexp_letmodule (id, m, e) ->
     let b = add_module_binding bv m in

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -291,7 +291,6 @@ and expression_desc =
     (* (E :> T)        (None, T)
          *)
   | Pexp_send of expression * label loc (*  E # m *)
-  | Pexp_new of Longident.t loc (* new M.c *)
   | Pexp_setinstvar of label loc * expression (* x <- 2 *)
   | Pexp_override of (label loc * expression) list
     (* {< x1 = E1; ...; Xn = En >} *)

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -291,7 +291,6 @@ and expression_desc =
     (* (E :> T)        (None, T)
          *)
   | Pexp_send of expression * label loc (*  E # m *)
-  | Pexp_setinstvar of label loc * expression (* x <- 2 *)
   | Pexp_override of (label loc * expression) list
     (* {< x1 = E1; ...; Xn = En >} *)
   | Pexp_letmodule of string loc * module_expr * expression

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -291,8 +291,6 @@ and expression_desc =
     (* (E :> T)        (None, T)
          *)
   | Pexp_send of expression * label loc (*  E # m *)
-  | Pexp_override of (label loc * expression) list
-    (* {< x1 = E1; ...; Xn = En >} *)
   | Pexp_letmodule of string loc * module_expr * expression
     (* let module M = ME in E *)
   | Pexp_letexception of extension_constructor * expression

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -300,11 +300,6 @@ and expression_desc =
        Note: "assert false" is treated in a special way by the
        type-checker. *)
   | Pexp_lazy of expression (* lazy E *)
-  | Pexp_poly of expression * core_type option
-    (* Used for method bodies.
-
-       Can only be used as the expression under Cfk_concrete
-       for methods (not values). *)
   | Pexp_newtype of string loc * expression (* fun (type t) -> E *)
   | Pexp_pack of module_expr
     (* (module ME)

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -702,8 +702,6 @@ and expression ctxt f x =
       in
       let lst = sequence_helper [] x in
       pp f "@[<hv>%a@]" (list (expression (under_semi ctxt)) ~sep:";@;") lst
-    | Pexp_setinstvar (s, e) ->
-      pp f "@[<hov2>%s@ <-@ %a@]" s.txt (expression ctxt) e
     | Pexp_override l ->
       (* FIXME *)
       let string_x_expression f (s, e) =

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -711,12 +711,6 @@ and expression ctxt f x =
         cd (expression ctxt) e
     | Pexp_assert e -> pp f "@[<hov2>assert@ %a@]" (simple_expr ctxt) e
     | Pexp_lazy e -> pp f "@[<hov2>lazy@ %a@]" (simple_expr ctxt) e
-    (* Pexp_poly: impossible but we should print it anyway, rather than
-       assert false *)
-    | Pexp_poly (e, None) -> pp f "@[<hov2>!poly!@ %a@]" (simple_expr ctxt) e
-    | Pexp_poly (e, Some ct) ->
-      pp f "@[<hov2>(!poly!@ %a@ : %a)@]" (simple_expr ctxt) e (core_type ctxt)
-        ct
     | Pexp_open (ovf, lid, e) ->
       pp f "@[<2>let open%s %a in@;%a@]" (override ovf) longident_loc lid
         (expression ctxt) e

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -702,7 +702,6 @@ and expression ctxt f x =
       in
       let lst = sequence_helper [] x in
       pp f "@[<hv>%a@]" (list (expression (under_semi ctxt)) ~sep:";@;") lst
-    | Pexp_new li -> pp f "@[<hov2>new@ %a@]" longident_loc li
     | Pexp_setinstvar (s, e) ->
       pp f "@[<hov2>%s@ <-@ %a@]" s.txt (expression ctxt) e
     | Pexp_override l ->

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -702,12 +702,6 @@ and expression ctxt f x =
       in
       let lst = sequence_helper [] x in
       pp f "@[<hv>%a@]" (list (expression (under_semi ctxt)) ~sep:";@;") lst
-    | Pexp_override l ->
-      (* FIXME *)
-      let string_x_expression f (s, e) =
-        pp f "@[<hov2>%s@ =@ %a@]" s.txt (expression ctxt) e
-      in
-      pp f "@[<hov2>{<%a>}@]" (list string_x_expression ~sep:";") l
     | Pexp_letmodule (s, me, e) ->
       pp f "@[<hov2>let@ module@ %s@ =@ %a@ in@ %a@]" s.txt
         (module_expr reset_ctxt) me (expression ctxt) e

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -317,7 +317,6 @@ and expression i ppf x =
   | Pexp_send (e, s) ->
     line i ppf "Pexp_send \"%s\"\n" s.txt;
     expression i ppf e
-  | Pexp_new li -> line i ppf "Pexp_new %a\n" fmt_longident_loc li
   | Pexp_setinstvar (s, e) ->
     line i ppf "Pexp_setinstvar %a\n" fmt_string_loc s;
     expression i ppf e

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -317,9 +317,6 @@ and expression i ppf x =
   | Pexp_send (e, s) ->
     line i ppf "Pexp_send \"%s\"\n" s.txt;
     expression i ppf e
-  | Pexp_override l ->
-    line i ppf "Pexp_override\n";
-    list i string_x_expression ppf l
   | Pexp_letmodule (s, me, e) ->
     line i ppf "Pexp_letmodule %a\n" fmt_string_loc s;
     module_expr i ppf me;
@@ -660,10 +657,6 @@ and value_binding i ppf x =
   attributes (i + 1) ppf x.pvb_attributes;
   pattern (i + 1) ppf x.pvb_pat;
   expression (i + 1) ppf x.pvb_expr
-
-and string_x_expression i ppf (s, e) =
-  line i ppf "<override> %a\n" fmt_string_loc s;
-  expression (i + 1) ppf e
 
 and longident_x_expression i ppf (li, e, opt) =
   line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -331,10 +331,6 @@ and expression i ppf x =
   | Pexp_lazy e ->
     line i ppf "Pexp_lazy\n";
     expression i ppf e
-  | Pexp_poly (e, cto) ->
-    line i ppf "Pexp_poly\n";
-    expression i ppf e;
-    option i core_type ppf cto
   | Pexp_newtype (s, e) ->
     line i ppf "Pexp_newtype \"%s\"\n" s.txt;
     expression i ppf e

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -317,9 +317,6 @@ and expression i ppf x =
   | Pexp_send (e, s) ->
     line i ppf "Pexp_send \"%s\"\n" s.txt;
     expression i ppf e
-  | Pexp_setinstvar (s, e) ->
-    line i ppf "Pexp_setinstvar %a\n" fmt_string_loc s;
-    expression i ppf e
   | Pexp_override l ->
     line i ppf "Pexp_override\n";
     list i string_x_expression ppf l

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -275,7 +275,6 @@ and expression i ppf x =
   in
   match x.exp_desc with
   | Texp_ident (li, _, _) -> line i ppf "Texp_ident %a\n" fmt_path li
-  | Texp_instvar () -> assert false
   | Texp_constant c -> line i ppf "Texp_constant %a\n" fmt_constant c
   | Texp_let (rf, l, e) ->
     line i ppf "Texp_let %a\n" fmt_rec_flag rf;

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -259,10 +259,6 @@ and expression_extra i ppf x attrs =
   | Texp_open (ovf, m, _, _) ->
     line i ppf "Texp_open %a \"%a\"\n" fmt_override_flag ovf fmt_path m;
     attributes i ppf attrs
-  | Texp_poly cto ->
-    line i ppf "Texp_poly\n";
-    attributes i ppf attrs;
-    option i core_type ppf cto
   | Texp_newtype s ->
     line i ppf "Texp_newtype \"%s\"\n" s;
     attributes i ppf attrs
@@ -360,7 +356,6 @@ and expression i ppf x =
     line i ppf "Texp_send \"%s\"\n" s;
     expression i ppf e;
     option i expression ppf eo
-  | Texp_new _ | Texp_setinstvar _ | Texp_override _ -> ()
   | Texp_letmodule (s, _, me, e) ->
     line i ppf "Texp_letmodule \"%a\"\n" fmt_ident s;
     module_expr i ppf me;

--- a/compiler/ml/rec_check.ml
+++ b/compiler/ml/rec_check.ml
@@ -195,9 +195,9 @@ let rec classify_expression : Typedtree.expression -> sd =
   | Texp_sequence (_, e)
   | Texp_letexception (_, e) ->
     classify_expression e
-  | Texp_ident _ | Texp_for _ | Texp_constant _ | Texp_instvar _ | Texp_tuple _
-  | Texp_array _ | Texp_construct _ | Texp_variant _ | Texp_record _
-  | Texp_setfield _ | Texp_while _ | Texp_pack _ | Texp_function _ | Texp_lazy _
+  | Texp_ident _ | Texp_for _ | Texp_constant _ | Texp_tuple _ | Texp_array _
+  | Texp_construct _ | Texp_variant _ | Texp_record _ | Texp_setfield _
+  | Texp_while _ | Texp_pack _ | Texp_function _ | Texp_lazy _
   | Texp_extension_constructor _ ->
     Static
   | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _) when is_ref vd -> Static
@@ -232,7 +232,6 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
            for inclusion in another value *)
         (discard (expression env e3)))
   | Texp_constant _ -> Use.empty
-  | Texp_instvar _ -> Use.empty
   | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, [(_, Some arg)])
     when is_ref vd ->
     Use.guard (expression env arg)

--- a/compiler/ml/rec_check.ml
+++ b/compiler/ml/rec_check.ml
@@ -195,15 +195,14 @@ let rec classify_expression : Typedtree.expression -> sd =
   | Texp_sequence (_, e)
   | Texp_letexception (_, e) ->
     classify_expression e
-  | Texp_ident _ | Texp_for _ | Texp_constant _ | Texp_new _ | Texp_instvar _
-  | Texp_tuple _ | Texp_array _ | Texp_construct _ | Texp_variant _
-  | Texp_record _ | Texp_setfield _ | Texp_while _ | Texp_setinstvar _
-  | Texp_pack _ | Texp_function _ | Texp_lazy _ | Texp_extension_constructor _
-    ->
+  | Texp_ident _ | Texp_for _ | Texp_constant _ | Texp_instvar _ | Texp_tuple _
+  | Texp_array _ | Texp_construct _ | Texp_variant _ | Texp_record _
+  | Texp_setfield _ | Texp_while _ | Texp_pack _ | Texp_function _ | Texp_lazy _
+  | Texp_extension_constructor _ ->
     Static
   | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _) when is_ref vd -> Static
   | Texp_apply _ | Texp_match _ | Texp_ifthenelse _ | Texp_send _ | Texp_field _
-  | Texp_assert _ | Texp_try _ | Texp_override _ ->
+  | Texp_assert _ | Texp_try _ ->
     Dynamic
 
 let rec expression : Env.env -> Typedtree.expression -> Use.t =
@@ -233,7 +232,6 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
            for inclusion in another value *)
         (discard (expression env e3)))
   | Texp_constant _ -> Use.empty
-  | Texp_new _ -> assert false
   | Texp_instvar _ -> Use.empty
   | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, [(_, Some arg)])
     when is_ref vd ->
@@ -283,7 +281,6 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
     Use.(
       join (inspect (expression env e1)) (inspect (option expression env eo)))
   | Texp_field (e, _, _) -> Use.(inspect (expression env e))
-  | Texp_setinstvar () -> assert false
   | Texp_letexception (_, e) -> expression env e
   | Texp_assert e -> Use.inspect (expression env e)
   | Texp_pack m -> modexp env m
@@ -291,7 +288,6 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
     (* This is more permissive than the old check. *)
     let case env {Typedtree.c_rhs} = expression env c_rhs in
     Use.join (expression env e) (list case env cases)
-  | Texp_override () -> assert false
   | Texp_function {case = case_} ->
     Use.delay (list (case ~scrutinee:Use.empty) env [case_])
   | Texp_lazy e -> (

--- a/compiler/ml/tast_iterator.ml
+++ b/compiler/ml/tast_iterator.ml
@@ -197,7 +197,6 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_send (exp, _, expo) ->
     sub.expr sub exp;
     Option.iter (sub.expr sub) expo
-  | Texp_instvar _ -> ()
   | Texp_letmodule (_, _, mexpr, exp) ->
     sub.module_expr sub mexpr;
     sub.expr sub exp

--- a/compiler/ml/tast_iterator.ml
+++ b/compiler/ml/tast_iterator.ml
@@ -144,7 +144,6 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
     | Texp_constraint cty -> sub.typ sub cty
     | Texp_coerce ((), cty2) -> sub.typ sub cty2
     | Texp_newtype _ -> ()
-    | Texp_poly cto -> Option.iter (sub.typ sub) cto
     | Texp_open (_, _, _, _) -> ()
   in
   List.iter (fun (e, _, _) -> extra e) exp_extra;
@@ -198,10 +197,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_send (exp, _, expo) ->
     sub.expr sub exp;
     Option.iter (sub.expr sub) expo
-  | Texp_new _ -> ()
   | Texp_instvar _ -> ()
-  | Texp_setinstvar _ -> ()
-  | Texp_override _ -> ()
   | Texp_letmodule (_, _, mexpr, exp) ->
     sub.module_expr sub mexpr;
     sub.expr sub exp

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -189,7 +189,6 @@ let expr sub x =
     | Texp_open (ovf, path, loc, env) ->
       Texp_open (ovf, path, loc, sub.env sub env)
     | Texp_newtype _ as d -> d
-    | Texp_poly cto -> Texp_poly (opt (sub.typ sub) cto)
   in
   let exp_extra = List.map (tuple3 extra id id) x.exp_extra in
   let exp_env = sub.env sub x.exp_env in
@@ -244,8 +243,7 @@ let expr sub x =
         (id, p, sub.expr sub exp1, sub.expr sub exp2, dir, sub.expr sub exp3)
     | Texp_send (exp, meth, expo) ->
       Texp_send (sub.expr sub exp, meth, opt (sub.expr sub) expo)
-    | (Texp_new _ | Texp_instvar _) as d -> d
-    | Texp_setinstvar _ | Texp_override _ -> assert false
+    | Texp_instvar _ as d -> d
     | Texp_letmodule (id, s, mexpr, exp) ->
       Texp_letmodule (id, s, sub.module_expr sub mexpr, sub.expr sub exp)
     | Texp_letexception (cd, exp) ->

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -243,7 +243,6 @@ let expr sub x =
         (id, p, sub.expr sub exp1, sub.expr sub exp2, dir, sub.expr sub exp3)
     | Texp_send (exp, meth, expo) ->
       Texp_send (sub.expr sub exp, meth, opt (sub.expr sub) expo)
-    | Texp_instvar _ as d -> d
     | Texp_letmodule (id, s, mexpr, exp) ->
       Texp_letmodule (id, s, sub.module_expr sub mexpr, sub.expr sub exp)
     | Texp_letexception (cd, exp) ->

--- a/compiler/ml/translcore.ml
+++ b/compiler/ml/translcore.ml
@@ -911,7 +911,6 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
   | Texp_send (expr, Tmeth_name nm, _) ->
     let obj = transl_exp expr in
     Lsend (nm, obj, e.exp_loc)
-  | Texp_instvar _ -> assert false
   | Texp_letmodule (id, _loc, modl, body) ->
     let defining_expr = !transl_module Tcoerce_none None modl in
     Llet (Strict, Pgenval, id, defining_expr, transl_exp body)

--- a/compiler/ml/translcore.ml
+++ b/compiler/ml/translcore.ml
@@ -911,8 +911,7 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
   | Texp_send (expr, Tmeth_name nm, _) ->
     let obj = transl_exp expr in
     Lsend (nm, obj, e.exp_loc)
-  | Texp_new _ | Texp_instvar _ | Texp_setinstvar _ | Texp_override _ ->
-    assert false
+  | Texp_instvar _ -> assert false
   | Texp_letmodule (id, _loc, modl, body) ->
     let defining_expr = !transl_module Tcoerce_none None modl in
     Llet (Strict, Pgenval, id, defining_expr, transl_exp body)

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -176,7 +176,6 @@ let iter_expression f e =
       expr e1;
       expr e2;
       expr e3
-    | Pexp_override sel -> List.iter (fun (_, e) -> expr e) sel
     | Pexp_letmodule (_, me, e) ->
       expr e;
       module_expr me
@@ -3033,7 +3032,6 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
         (Error
            (e.pexp_loc, env, Undefined_method (obj.exp_type, met, valid_methods)))
     )
-  | Pexp_override _ -> assert false
   | Pexp_letmodule (name, smodl, sbody) ->
     let ty = newvar () in
     (* remember original level *)

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -1820,7 +1820,6 @@ let rec is_nonexpansive exp =
   | Texp_ifthenelse (_cond, ifso, ifnot) ->
     is_nonexpansive ifso && is_nonexpansive_opt ifnot
   | Texp_sequence (_e1, e2) -> is_nonexpansive e2 (* PR#4354 *)
-  | Texp_new _ -> assert false
   (* Note: nonexpansive only means no _observable_ side effects *)
   | Texp_lazy e -> is_nonexpansive e
   | Texp_letmodule (_, _, mexp, e) ->

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -158,7 +158,6 @@ let iter_expression f e =
     | Pexp_poly (e, _)
     | Pexp_lazy e
     | Pexp_assert e
-    | Pexp_setinstvar (_, e)
     | Pexp_send (e, _)
     | Pexp_constraint (e, _)
     | Pexp_coerce (e, _, _)
@@ -3034,7 +3033,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
         (Error
            (e.pexp_loc, env, Undefined_method (obj.exp_type, met, valid_methods)))
     )
-  | Pexp_setinstvar _ | Pexp_override _ -> assert false
+  | Pexp_override _ -> assert false
   | Pexp_letmodule (name, smodl, sbody) ->
     let ty = newvar () in
     (* remember original level *)

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -134,7 +134,7 @@ let iter_expression f e =
     f e;
     match e.pexp_desc with
     | Pexp_extension _ (* we don't iterate under extension point *)
-    | Pexp_ident _ | Pexp_new _ | Pexp_constant _ ->
+    | Pexp_ident _ | Pexp_constant _ ->
       ()
     | Pexp_fun {default = eo; rhs = e} ->
       may expr eo;
@@ -3034,7 +3034,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
         (Error
            (e.pexp_loc, env, Undefined_method (obj.exp_type, met, valid_methods)))
     )
-  | Pexp_new _ | Pexp_setinstvar _ | Pexp_override _ -> assert false
+  | Pexp_setinstvar _ | Pexp_override _ -> assert false
   | Pexp_letmodule (name, smodl, sbody) ->
     let ty = newvar () in
     (* remember original level *)

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -69,7 +69,6 @@ and exp_extra =
   | Texp_constraint of core_type
   | Texp_coerce of unit * core_type
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
-  | Texp_poly of core_type option
   | Texp_newtype of string
 
 and expression_desc =
@@ -115,10 +114,7 @@ and expression_desc =
       * direction_flag
       * expression
   | Texp_send of expression * meth * expression option
-  | Texp_new of unit
   | Texp_instvar of unit
-  | Texp_setinstvar of unit
-  | Texp_override of unit
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -114,7 +114,6 @@ and expression_desc =
       * direction_flag
       * expression
   | Texp_send of expression * meth * expression option
-  | Texp_instvar of unit
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -216,7 +216,6 @@ and expression_desc =
       * direction_flag
       * expression
   | Texp_send of expression * meth * expression option
-  | Texp_instvar of unit
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -117,7 +117,6 @@ and exp_extra =
       (** let open[!] M in    [Texp_open (!, P, M, env)]
                                 where [env] is the environment after opening [P]
          *)
-  | Texp_poly of core_type option  (** Used for method bodies. *)
   | Texp_newtype of string  (** fun (type t) ->  *)
 
 and expression_desc =
@@ -217,10 +216,7 @@ and expression_desc =
       * direction_flag
       * expression
   | Texp_send of expression * meth * expression option
-  | Texp_new of unit
   | Texp_instvar of unit
-  | Texp_setinstvar of unit
-  | Texp_override of unit
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression

--- a/compiler/ml/typedtreeIter.ml
+++ b/compiler/ml/typedtreeIter.ml
@@ -286,7 +286,6 @@ end = struct
       match expo with
       | None -> ()
       | Some exp -> iter_expression exp)
-    | Texp_instvar _ -> ()
     | Texp_letmodule (_id, _, mexpr, exp) ->
       iter_module_expr mexpr;
       iter_expression exp

--- a/compiler/ml/typedtreeIter.ml
+++ b/compiler/ml/typedtreeIter.ml
@@ -221,7 +221,6 @@ end = struct
           | Texp_constraint ct -> iter_core_type ct
           | Texp_coerce ((), cty2) -> iter_core_type cty2
           | Texp_open _ -> ()
-          | Texp_poly cto -> option iter_core_type cto
           | Texp_newtype _ -> ()))
       exp.exp_extra;
     (match exp.exp_desc with
@@ -287,7 +286,7 @@ end = struct
       match expo with
       | None -> ()
       | Some exp -> iter_expression exp)
-    | Texp_new _ | Texp_instvar _ | Texp_setinstvar _ | Texp_override _ -> ()
+    | Texp_instvar _ -> ()
     | Texp_letmodule (_id, _, mexpr, exp) ->
       iter_module_expr mexpr;
       iter_expression exp

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -679,7 +679,6 @@ module SexpAst = struct
       | Pexp_coerce (expr, (), typexpr) ->
         Sexp.list [Sexp.atom "Pexp_coerce"; expression expr; core_type typexpr]
       | Pexp_send _ -> Sexp.list [Sexp.atom "Pexp_send"]
-      | Pexp_setinstvar _ -> Sexp.list [Sexp.atom "Pexp_setinstvar"]
       | Pexp_override _ -> Sexp.list [Sexp.atom "Pexp_override"]
       | Pexp_letmodule (mod_name, mod_expr, expr) ->
         Sexp.list

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -696,7 +696,6 @@ module SexpAst = struct
           ]
       | Pexp_assert expr -> Sexp.list [Sexp.atom "Pexp_assert"; expression expr]
       | Pexp_lazy expr -> Sexp.list [Sexp.atom "Pexp_lazy"; expression expr]
-      | Pexp_poly _ -> Sexp.list [Sexp.atom "Pexp_poly"]
       | Pexp_newtype (lbl, expr) ->
         Sexp.list
           [Sexp.atom "Pexp_newtype"; string lbl.Asttypes.txt; expression expr]

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -679,7 +679,6 @@ module SexpAst = struct
       | Pexp_coerce (expr, (), typexpr) ->
         Sexp.list [Sexp.atom "Pexp_coerce"; expression expr; core_type typexpr]
       | Pexp_send _ -> Sexp.list [Sexp.atom "Pexp_send"]
-      | Pexp_new _ -> Sexp.list [Sexp.atom "Pexp_new"]
       | Pexp_setinstvar _ -> Sexp.list [Sexp.atom "Pexp_setinstvar"]
       | Pexp_override _ -> Sexp.list [Sexp.atom "Pexp_override"]
       | Pexp_letmodule (mod_name, mod_expr, expr) ->

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -679,7 +679,6 @@ module SexpAst = struct
       | Pexp_coerce (expr, (), typexpr) ->
         Sexp.list [Sexp.atom "Pexp_coerce"; expression expr; core_type typexpr]
       | Pexp_send _ -> Sexp.list [Sexp.atom "Pexp_send"]
-      | Pexp_override _ -> Sexp.list [Sexp.atom "Pexp_override"]
       | Pexp_letmodule (mod_name, mod_expr, expr) ->
         Sexp.list
           [

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -3390,7 +3390,6 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
         Doc.concat [Doc.text "\""; member_doc; Doc.text "\""]
       in
       Doc.group (Doc.concat [parent_doc; Doc.lbracket; member; Doc.rbracket])
-    | Pexp_new _ -> Doc.text "Pexp_new not implemented in printer"
     | Pexp_setinstvar _ -> Doc.text "Pexp_setinstvar not implemented in printer"
     | Pexp_override _ -> Doc.text "Pexp_override not implemented in printer"
     | Pexp_poly _ -> Doc.text "Pexp_poly not implemented in printer"

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -3390,7 +3390,6 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
         Doc.concat [Doc.text "\""; member_doc; Doc.text "\""]
       in
       Doc.group (Doc.concat [parent_doc; Doc.lbracket; member; Doc.rbracket])
-    | Pexp_poly _ -> Doc.text "Pexp_poly not implemented in printer"
   in
   let expr_with_await =
     if ParsetreeViewer.has_await_attribute e.pexp_attributes then

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -3390,7 +3390,6 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
         Doc.concat [Doc.text "\""; member_doc; Doc.text "\""]
       in
       Doc.group (Doc.concat [parent_doc; Doc.lbracket; member; Doc.rbracket])
-    | Pexp_override _ -> Doc.text "Pexp_override not implemented in printer"
     | Pexp_poly _ -> Doc.text "Pexp_poly not implemented in printer"
   in
   let expr_with_await =

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -3390,7 +3390,6 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
         Doc.concat [Doc.text "\""; member_doc; Doc.text "\""]
       in
       Doc.group (Doc.concat [parent_doc; Doc.lbracket; member; Doc.rbracket])
-    | Pexp_setinstvar _ -> Doc.text "Pexp_setinstvar not implemented in printer"
     | Pexp_override _ -> Doc.text "Pexp_override not implemented in printer"
     | Pexp_poly _ -> Doc.text "Pexp_poly not implemented in printer"
   in


### PR DESCRIPTION
Pexp_new is not used in the untyped tree.