### PR TITLE
Use GitHub Linux ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
             rust-target: x86_64-apple-darwin
           - os: macos-14 # ARM
             rust-target: aarch64-apple-darwin
-          - os: ubuntu-latest # x64
+          - os: ubuntu-22.04 # x64
             rust-target: x86_64-unknown-linux-musl
-          - os: buildjet-2vcpu-ubuntu-2204-arm # ARM
+          - os: ubuntu-22.04-arm # ARM
             rust-target: aarch64-unknown-linux-musl
           - os: windows-latest
             rust-target: x86_64-pc-windows-gnu
@@ -86,14 +86,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest # x64
+          - os: ubuntu-22.04 # x64
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
             # Build the playground compiler and run the benchmarks on the fastest runner
             build_playground: true
             benchmarks: true
-          - os: buildjet-2vcpu-ubuntu-2204-arm # ARM
+          - os: ubuntu-22.04-arm # ARM
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
           - os: macos-13 # x64
@@ -107,11 +107,11 @@ jobs:
             upload_binaries: true
 
           # Verify that the compiler still builds with older OCaml versions
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             ocaml_compiler: ocaml-variants.5.0.0+options,ocaml-option-static
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             ocaml_compiler: ocaml-variants.4.14.2+options,ocaml-option-static
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             ocaml_compiler: ocaml-variants.4.13.0+options,ocaml-option-static
 
     runs-on: ${{matrix.os}}
@@ -142,11 +142,11 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           # See https://github.com/ocaml/setup-ocaml/blob/b2105f9/packages/setup-ocaml/src/unix.ts#L9
           packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync
-          version: v2
+          version: v3
 
       # matrix.ocaml_compiler may contain commas
       - name: Get OPAM cache key
@@ -167,7 +167,7 @@ jobs:
           key: ${{ env.opam_cache_key }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
-        uses: ocaml/setup-ocaml@v3.2.2
+        uses: ocaml/setup-ocaml@v3.2.5
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
@@ -316,7 +316,7 @@ jobs:
         run: git diff --ignore-cr-at-eol --exit-code tests
 
       - name: Run analysis / tools tests
-        if: runner.os != 'Windows' && matrix.os != 'buildjet-2vcpu-ubuntu-2204-arm'
+        if: runner.os != 'Windows' && matrix.os != 'ubuntu-22.04-arm'
         run: opam exec -- make -C tests/analysis_tests test && make -C tests/tools_tests test
 
       - name: Run gentype tests
@@ -392,7 +392,7 @@ jobs:
       - build-compiler
       - build-rewatch
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -447,8 +447,8 @@ jobs:
         os: [
             macos-13, # x64
             macos-14, # ARM
-            ubuntu-latest,
-            buildjet-2vcpu-ubuntu-2204-arm,
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
             windows-latest,
           ]
 
@@ -486,7 +486,7 @@ jobs:
 
     if: startsWith(github.ref, 'refs/tags/v')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
             rust-target: x86_64-apple-darwin
           - os: macos-14 # ARM
             rust-target: aarch64-apple-darwin
-          - os: ubuntu-22.04 # x64
+          - os: ubuntu-24.04 # x64
             rust-target: x86_64-unknown-linux-musl
-          - os: ubuntu-22.04-arm # ARM
+          - os: ubuntu-24.04-arm # ARM
             rust-target: aarch64-unknown-linux-musl
           - os: windows-latest
             rust-target: x86_64-pc-windows-gnu
@@ -86,11 +86,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04 # x64
+          - os: ubuntu-24.04 # x64
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
-          - os: ubuntu-22.04-arm # ARM
+          - os: ubuntu-24.04-arm # ARM
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
             # Build the playground compiler and run the benchmarks on the fastest runner
@@ -107,11 +107,11 @@ jobs:
             upload_binaries: true
 
           # Verify that the compiler still builds with older OCaml versions
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.5.0.0+options,ocaml-option-static
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.4.14.2+options,ocaml-option-static
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.4.13.0+options,ocaml-option-static
 
     runs-on: ${{matrix.os}}
@@ -316,7 +316,7 @@ jobs:
         run: git diff --ignore-cr-at-eol --exit-code tests
 
       - name: Run analysis / tools tests
-        if: runner.os != 'Windows' && matrix.os != 'ubuntu-22.04-arm'
+        if: runner.os != 'Windows' && matrix.os != 'ubuntu-24.04-arm'
         run: opam exec -- make -C tests/analysis_tests test && make -C tests/tools_tests test
 
       - name: Run gentype tests
@@ -392,7 +392,7 @@ jobs:
       - build-compiler
       - build-rewatch
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -447,8 +447,8 @@ jobs:
         os: [
             macos-13, # x64
             macos-14, # ARM
-            ubuntu-22.04,
-            ubuntu-22.04-arm,
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
             windows-latest,
           ]
 
@@ -486,7 +486,7 @@ jobs:
 
     if: startsWith(github.ref, 'refs/tags/v')
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         if: steps.ninja-build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Setup MSVC for ninja build (Windows)
         if: steps.ninja-build-cache.outputs.cache-hit != 'true' && runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
-            # Build the playground compiler and run the benchmarks on the fastest runner
-            build_playground: true
-            benchmarks: true
           - os: ubuntu-22.04-arm # ARM
             ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
             upload_binaries: true
+            # Build the playground compiler and run the benchmarks on the fastest runner
+            build_playground: true
+            benchmarks: true
           - os: macos-13 # x64
             ocaml_compiler: 5.2.1
             upload_binaries: true


### PR DESCRIPTION
Now that [Linux arm64 hosted runners are available for free in public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/), we can get rid of the BuildJet runners. 🎉 