### PR TITLE
Store the label loc in the application ast node.

### DIFF
--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -465,20 +465,22 @@ let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
   in
   let rec processProps ~acc args =
     match args with
-    | (Asttypes.Labelled "children", {Parsetree.pexp_loc}) :: _ ->
+    | (Asttypes.Labelled "children", _, {Parsetree.pexp_loc}) :: _ ->
       {
         compName;
         props = List.rev acc;
         childrenStart =
           (if pexp_loc.loc_ghost then None else Some (Loc.start pexp_loc));
       }
-    | ((Labelled s | Optional s), (eProp : Parsetree.expression)) :: rest -> (
+    | ((Labelled s | Optional s), lbl_loc, (eProp : Parsetree.expression))
+      :: rest -> (
       let namedArgLoc =
         eProp.pexp_attributes
         |> List.find_opt (fun ({Asttypes.txt}, _) -> txt = "res.namedArgLoc")
       in
       match namedArgLoc with
       | Some ({loc}, _) ->
+        assert (loc = lbl_loc);
         processProps
           ~acc:
             ({

--- a/analysis/src/SemanticTokens.ml
+++ b/analysis/src/SemanticTokens.ml
@@ -266,7 +266,7 @@ let command ~debug ~emitter ~path =
 
       let posOfGreatherthanAfterProps =
         let rec loop = function
-          | (Asttypes.Labelled "children", {Parsetree.pexp_loc}) :: _ ->
+          | (Asttypes.Labelled "children", _, {Parsetree.pexp_loc}) :: _ ->
             Loc.start pexp_loc
           | _ :: args -> loop args
           | [] -> (* should not happen *) (-1, -1)
@@ -297,7 +297,7 @@ let command ~debug ~emitter ~path =
            emitter (* <foo> ... </foo> <-- *)
            |> emitJsxTag ~debug ~name:">" ~pos:posOfFinalGreatherthan));
 
-      args |> List.iter (fun (_lbl, arg) -> iterator.expr iterator arg)
+      args |> List.iter (fun (_lbl, _, arg) -> iterator.expr iterator arg)
     | Pexp_apply
         {
           funct =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -898,7 +898,9 @@ type arg = {label: label; exp: Parsetree.expression}
 let extractExpApplyArgs ~args =
   let rec processArgs ~acc args =
     match args with
-    | (((Asttypes.Labelled s | Optional s) as label), (e : Parsetree.expression))
+    | ( ((Asttypes.Labelled s | Optional s) as label),
+        _,
+        (e : Parsetree.expression) )
       :: rest -> (
       let namedArgLoc =
         e.pexp_attributes
@@ -919,7 +921,7 @@ let extractExpApplyArgs ~args =
         in
         processArgs ~acc:({label = Some labelled; exp = e} :: acc) rest
       | None -> processArgs ~acc rest)
-    | (Asttypes.Nolabel, (e : Parsetree.expression)) :: rest ->
+    | (Asttypes.Nolabel, _, (e : Parsetree.expression)) :: rest ->
       if e.pexp_loc.loc_ghost then processArgs ~acc rest
       else processArgs ~acc:({label = None; exp = e} :: acc) rest
     | [] -> List.rev acc

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -371,6 +371,7 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                  [
                    _;
                    ( _,
+                     _,
                      {
                        pexp_desc =
                          Pexp_apply

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -941,7 +941,11 @@ module Codegen = struct
   let mkFailWithExp () =
     Ast_helper.Exp.apply
       (Ast_helper.Exp.ident {txt = Lident "failwith"; loc = Location.none})
-      [(Nolabel, Ast_helper.Exp.constant (Pconst_string ("TODO", None)))]
+      [
+        ( Nolabel,
+          Location.none,
+          Ast_helper.Exp.constant (Pconst_string ("TODO", None)) );
+      ]
 
   let mkConstructPat ?payload name =
     Ast_helper.Pat.construct

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -95,7 +95,7 @@ module IfThenElse = struct
                             Pexp_ident
                               {txt = Longident.Lident (("==" | "!=") as op)};
                         };
-                      args = [(Nolabel, arg1); (Nolabel, arg2)];
+                      args = [(Nolabel, _, arg1); (Nolabel, _, arg2)];
                     };
               },
               e1,

--- a/compiler/frontend/ast_compatible.ml
+++ b/compiler/frontend/ast_compatible.ml
@@ -42,7 +42,8 @@ let apply_simple ?(loc = default_loc) ?(attrs = []) (fn : expression)
       Pexp_apply
         {
           funct = fn;
-          args = Ext_list.map args (fun x -> (Asttypes.Nolabel, x));
+          args =
+            Ext_list.map args (fun x -> (Asttypes.Nolabel, Location.none, x));
           partial = false;
         };
   }
@@ -52,7 +53,8 @@ let app1 ?(loc = default_loc) ?(attrs = []) fn arg1 : expression =
     pexp_loc = loc;
     pexp_attributes = attrs;
     pexp_desc =
-      Pexp_apply {funct = fn; args = [(Nolabel, arg1)]; partial = false};
+      Pexp_apply
+        {funct = fn; args = [(Nolabel, Location.none, arg1)]; partial = false};
   }
 
 let app2 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 : expression =
@@ -61,7 +63,12 @@ let app2 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 : expression =
     pexp_attributes = attrs;
     pexp_desc =
       Pexp_apply
-        {funct = fn; args = [(Nolabel, arg1); (Nolabel, arg2)]; partial = false};
+        {
+          funct = fn;
+          args =
+            [(Nolabel, Location.none, arg1); (Nolabel, Location.none, arg2)];
+          partial = false;
+        };
   }
 
 let app3 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 arg3 : expression =
@@ -72,7 +79,12 @@ let app3 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 arg3 : expression =
       Pexp_apply
         {
           funct = fn;
-          args = [(Nolabel, arg1); (Nolabel, arg2); (Nolabel, arg3)];
+          args =
+            [
+              (Nolabel, Location.none, arg1);
+              (Nolabel, Location.none, arg2);
+              (Nolabel, Location.none, arg3);
+            ];
           partial = false;
         };
   }
@@ -118,7 +130,9 @@ let apply_labels ?(loc = default_loc) ?(attrs = []) fn
       Pexp_apply
         {
           funct = fn;
-          args = Ext_list.map args (fun (l, a) -> (Asttypes.Labelled l, a));
+          args =
+            Ext_list.map args (fun (l, a) ->
+                (Asttypes.Labelled l, Location.none, a));
           partial = false;
         };
   }
@@ -167,4 +181,4 @@ type object_field = Parsetree.object_field
 
 let object_field l attrs ty = Parsetree.Otag (l, attrs, ty)
 
-type args = (Asttypes.arg_label * Parsetree.expression) list
+type args = (Asttypes.arg_label * Location.t * Parsetree.expression) list

--- a/compiler/frontend/ast_compatible.mli
+++ b/compiler/frontend/ast_compatible.mli
@@ -137,4 +137,4 @@ type object_field = Parsetree.object_field
 val object_field :
   Asttypes.label Asttypes.loc -> attributes -> core_type -> object_field
 
-type args = (Asttypes.arg_label * Parsetree.expression) list
+type args = (Asttypes.arg_label * Location.t * Parsetree.expression) list

--- a/compiler/frontend/ast_exp_apply.ml
+++ b/compiler/frontend/ast_exp_apply.ml
@@ -45,7 +45,7 @@ let bound (e : exp) (cb : exp -> _) =
 let default_expr_mapper = Bs_ast_mapper.default_mapper.expr
 
 let check_and_discard (args : Ast_compatible.args) =
-  Ext_list.map args (fun (label, x) ->
+  Ext_list.map args (fun (label, _, x) ->
       Bs_syntaxerr.err_if_label x.pexp_loc label;
       x)
 
@@ -92,7 +92,8 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
       Bs_ast_invariant.warn_discarded_unused_attributes fn1.pexp_attributes;
       {
         pexp_desc =
-          Pexp_apply {funct = fn1; args = (Nolabel, a) :: args; partial};
+          Pexp_apply
+            {funct = fn1; args = (Nolabel, Location.none, a) :: args; partial};
         pexp_loc = e.pexp_loc;
         pexp_attributes = e.pexp_attributes @ f.pexp_attributes;
       }
@@ -116,7 +117,9 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
                            Pexp_apply
                              {
                                funct = fn;
-                               args = (Nolabel, bounded_obj_arg) :: args;
+                               args =
+                                 (Nolabel, Location.none, bounded_obj_arg)
+                                 :: args;
                                partial = false;
                              };
                          pexp_attributes = [];
@@ -170,7 +173,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
       let arg = self.expr self arg in
       let fn = Exp.send ~loc obj {txt = name ^ Literals.setter_suffix; loc} in
       Exp.constraint_ ~loc
-        (Exp.apply ~loc fn [(Nolabel, arg)])
+        (Exp.apply ~loc fn [(Nolabel, Location.none, arg)])
         (Ast_literal.type_unit ~loc ())
     in
     match obj.pexp_desc with

--- a/compiler/frontend/ast_exp_extension.ml
+++ b/compiler/frontend/ast_exp_extension.ml
@@ -46,6 +46,7 @@ let handle_extension e (self : Bs_ast_mapper.mapper)
       (Exp.ident ~loc {txt = Longident.parse "Js.Exn.raiseError"; loc})
       [
         ( Nolabel,
+          Location.none,
           Exp.constant ~loc
             (Pconst_string
                ( (pretext

--- a/compiler/frontend/ast_uncurry_gen.ml
+++ b/compiler/frontend/ast_uncurry_gen.ml
@@ -58,6 +58,7 @@ let to_method_callback loc (self : Bs_ast_mapper.mapper) label
       args =
         [
           ( Nolabel,
+            Location.none,
             Exp.constraint_ ~loc
               (Exp.record ~loc
                  [

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -71,7 +71,7 @@ type mapper = {
 
 let id x = x
 let map_fst f (x, y) = (f x, y)
-let map_snd f (x, y) = (x, f y)
+let map_3rd f (x, y, z) = (x, y, f z)
 let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
 let map_tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
 let map_opt f = function
@@ -327,7 +327,7 @@ module E = struct
         (sub.pat sub p) (sub.expr sub e)
     | Pexp_apply {funct = e; args = l; partial} ->
       apply ~loc ~attrs ~partial (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) l)
+        (List.map (map_3rd (sub.expr sub)) l)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/ast_async.ml
+++ b/compiler/ml/ast_async.ml
@@ -11,7 +11,7 @@ let add_promise_type ?(loc = Location.none) ~async
       Ast_helper.Exp.ident ~loc
         {txt = Ldot (Lident Primitive_modules.promise, "unsafe_async"); loc}
     in
-    Ast_helper.Exp.apply ~loc unsafe_async [(Nolabel, result)]
+    Ast_helper.Exp.apply ~loc unsafe_async [(Nolabel, Location.none, result)]
   else result
 
 let rec add_promise_to_result ~loc (e : Parsetree.expression) =

--- a/compiler/ml/ast_await.ml
+++ b/compiler/ml/ast_await.ml
@@ -7,7 +7,7 @@ let create_await_expression (e : Parsetree.expression) =
     Ast_helper.Exp.ident ~loc
       {txt = Ldot (Lident Primitive_modules.promise, "unsafe_await"); loc}
   in
-  Ast_helper.Exp.apply ~loc unsafe_await [(Nolabel, e)]
+  Ast_helper.Exp.apply ~loc unsafe_await [(Nolabel, Location.none, e)]
 
 (* Transform `@res.await M` to unpack(@res.await Js.import(module(M: __M0__))) *)
 let create_await_module_expression ~module_type_lid (e : Parsetree.module_expr)
@@ -30,6 +30,7 @@ let create_await_module_expression ~module_type_lid (e : Parsetree.module_expr)
                  })
               [
                 ( Nolabel,
+                  Location.none,
                   Exp.constraint_ ~loc:e.pmod_loc
                     (Exp.pack ~loc:e.pmod_loc
                        {

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -152,7 +152,7 @@ module Exp : sig
     ?attrs:attrs ->
     ?partial:bool ->
     expression ->
-    (arg_label * expression) list ->
+    (arg_label * Location.t * expression) list ->
     expression
   val match_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
   val try_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -62,7 +62,7 @@ type iterator = {
     tree. *)
 
 let iter_fst f (x, _) = f x
-let iter_snd f (_, y) = f y
+let iter_snd f (_, _, y) = f y
 let iter_tuple f1 f2 (x, y) =
   f1 x;
   f2 y

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -63,7 +63,7 @@ type mapper = {
 
 let id x = x
 let map_fst f (x, y) = (f x, y)
-let map_snd f (x, y) = (x, f y)
+let map_3rd f (x, y, z) = (x, y, f z)
 let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
 let map_tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
 let map_opt f = function
@@ -290,7 +290,7 @@ module E = struct
         (sub.pat sub p) (sub.expr sub e)
     | Pexp_apply {funct = e; args = l; partial} ->
       apply ~loc ~attrs ~partial (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) l)
+        (List.map (map_3rd (sub.expr sub)) l)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -349,7 +349,7 @@ module E = struct
       in
       let partial, attrs = process_partial_app_attribute attrs in
       apply ~loc ~attrs ~partial (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) l)
+        (List.map (fun (lbl, e) -> (lbl, Location.none, sub.expr sub e)) l)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -325,22 +325,22 @@ module E = struct
       let e =
         match (e.pexp_desc, args) with
         | ( Pexp_ident ({txt = Longident.Lident "->"} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "|."}}
         | ( Pexp_ident ({txt = Longident.Lident "++"} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "^"}}
         | ( Pexp_ident ({txt = Longident.Lident "!="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "<>"}}
         | ( Pexp_ident ({txt = Longident.Lident "!=="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "!="}}
         | ( Pexp_ident ({txt = Longident.Lident "==="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "=="}}
         | ( Pexp_ident ({txt = Longident.Lident "=="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolabel, _, _); (Nolabel, _, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "="}}
         | _ -> e
       in
@@ -349,7 +349,7 @@ module E = struct
         else []
       in
       apply ~loc ~attrs (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) args)
+        (List.map (fun (lbl, _, e) -> (lbl, sub.expr sub e)) args)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/btype.ml
+++ b/compiler/ml/btype.ml
@@ -605,11 +605,11 @@ let prefixed_label_name = function
   | Labelled s -> "~" ^ s
   | Optional s -> "?" ^ s
 
-type sargs = (Asttypes.arg_label * Parsetree.expression) list
+type sargs = (Asttypes.arg_label * Location.t * Parsetree.expression) list
 
 let rec extract_label_aux hd l = function
   | [] -> None
-  | ((l', t) as p) :: ls ->
+  | ((l', _, t) as p) :: ls ->
     if label_name l' = l then Some (l', t, List.rev_append hd ls)
     else extract_label_aux (p :: hd) l ls
 
@@ -620,7 +620,7 @@ let extract_label l (ls : sargs) :
 let rec label_assoc x (args : sargs) =
   match args with
   | [] -> false
-  | (a, _) :: l -> Asttypes.same_arg_label a x || label_assoc x l
+  | (a, _, _) :: l -> Asttypes.same_arg_label a x || label_assoc x l
 
 (**********************************)
 (*  Utilities for backtracking    *)

--- a/compiler/ml/btype.mli
+++ b/compiler/ml/btype.mli
@@ -186,7 +186,7 @@ val label_name : arg_label -> label
 (* Returns the label name with first character '?' or '~' as appropriate. *)
 val prefixed_label_name : arg_label -> label
 
-type sargs = (arg_label * Parsetree.expression) list
+type sargs = (arg_label * Location.t * Parsetree.expression) list
 
 val extract_label :
   label -> sargs -> (arg_label * Parsetree.expression * sargs) option

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -223,7 +223,7 @@ let rec add_expr bv exp =
     add_expr (add_pattern bv p) e
   | Pexp_apply {funct = e; args = el} ->
     add_expr bv e;
-    List.iter (fun (_, e) -> add_expr bv e) el
+    List.iter (fun (_, _, e) -> add_expr bv e) el
   | Pexp_match (e, pel) ->
     add_expr bv e;
     add_cases bv pel

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -251,7 +251,7 @@ and expression_desc =
     *)
   | Pexp_apply of {
       funct: expression;
-      args: (arg_label * expression) list;
+      args: (arg_label * Location.t * expression) list;
       partial: bool;
     }
     (* E0 ~l1:E1 ... ~ln:En

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -523,7 +523,7 @@ and sugar_expr ctxt f e =
           funct = {pexp_desc = Pexp_ident {txt = id; _}; pexp_attributes = []; _};
           args;
         }
-      when List.for_all (fun (lab, _) -> lab = Nolabel) args -> (
+      when List.for_all (fun (lab, _, _) -> lab = Nolabel) args -> (
       let print_indexop a path_prefix assign left right print_index indices
           rem_args =
         let print_path ppf = function
@@ -544,7 +544,7 @@ and sugar_expr ctxt f e =
           true
         | _ -> false
       in
-      match (id, List.map snd args) with
+      match (id, List.map (fun (_, _, e) -> e) args) with
       | Lident "!", [e] ->
         pp f "@[<hov>!%a@]" (simple_expr ctxt) e;
         true
@@ -636,7 +636,7 @@ and expression ctxt f x =
         match view_fixity_of_exp e with
         | `Infix s -> (
           match l with
-          | [((Nolabel, _) as arg1); ((Nolabel, _) as arg2)] ->
+          | [((Nolabel, _, _) as arg1); ((Nolabel, _, _) as arg2)] ->
             (* FIXME associativity label_x_expression_param *)
             pp f "@[<2>%a@;%s@;%a@]"
               (label_x_expression_param reset_ctxt)
@@ -655,13 +655,13 @@ and expression ctxt f x =
               match l with
               (* See #7200: avoid turning (~- 1) into (- 1) which is
                  parsed as an int literal *)
-              | [(_, {pexp_desc = Pexp_constant _})] -> false
+              | [(_, _, {pexp_desc = Pexp_constant _})] -> false
               | _ -> true
             then String.sub s 1 (String.length s - 1)
             else s
           in
           match l with
-          | [(Nolabel, x)] -> pp f "@[<2>%s@;%a@]" s (simple_expr ctxt) x
+          | [(Nolabel, _, x)] -> pp f "@[<2>%s@;%a@]" s (simple_expr ctxt) x
           | _ ->
             pp f "@[<2>%a %a@]" (simple_expr ctxt) e
               (list (label_x_expression_param ctxt))
@@ -1273,7 +1273,7 @@ and case_list ctxt f l : unit =
   in
   list aux f l ~sep:""
 
-and label_x_expression_param ctxt f (l, e) =
+and label_x_expression_param ctxt f (l, _, e) =
   let simple_name =
     match e with
     | {pexp_desc = Pexp_ident {txt = Lident l; _}; pexp_attributes = []} ->

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -655,7 +655,7 @@ and longident_x_expression i ppf (li, e, opt) =
   line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");
   expression (i + 1) ppf e
 
-and label_x_expression i ppf (l, e) =
+and label_x_expression i ppf (l, _loc, e) =
   line i ppf "<arg>\n";
   arg_label i ppf l;
   expression (i + 1) ppf e

--- a/compiler/syntax/src/jsx_common.ml
+++ b/compiler/syntax/src/jsx_common.ml
@@ -59,5 +59,5 @@ let async_component ~async expr =
            loc = Location.none;
            txt = Ldot (Lident "JsxPPXReactSupport", "asyncComponent");
          })
-      [(Nolabel, expr)]
+      [(Nolabel, Location.none, expr)]
   else expr

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -573,7 +573,7 @@ module SexpAst = struct
             expression expr;
             Sexp.list
               (map_empty
-                 ~f:(fun (arg_lbl, expr) ->
+                 ~f:(fun (arg_lbl, _, expr) ->
                    Sexp.list [arg_label arg_lbl; expression expr])
                  args);
           ]

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -159,7 +159,7 @@ let rhs_binary_expr_operand parent_operator rhs =
             pexp_desc =
               Pexp_ident {txt = Longident.Lident operator; loc = operator_loc};
           };
-        args = [(_, _left); (_, _right)];
+        args = [(_, _, _left); (_, _, _right)];
       }
     when ParsetreeViewer.is_binary_operator operator
          && not (operator_loc.loc_ghost && operator = "++") ->
@@ -177,7 +177,7 @@ let flatten_operand_rhs parent_operator rhs =
             pexp_desc =
               Pexp_ident {txt = Longident.Lident operator; loc = operator_loc};
           };
-        args = [(_, _left); (_, _right)];
+        args = [(_, _, _left); (_, _, _right)];
       }
     when ParsetreeViewer.is_binary_operator operator
          && not (operator_loc.loc_ghost && operator = "++") ->

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -123,9 +123,11 @@ let rewrite_underscore_apply expr =
         (fun arg ->
           match arg with
           | ( lbl,
+              loc,
               ({pexp_desc = Pexp_ident ({txt = Longident.Lident "__x"} as lid)}
                as arg_expr) ) ->
             ( lbl,
+              loc,
               {
                 arg_expr with
                 pexp_desc = Pexp_ident {lid with txt = Longident.Lident "_"};
@@ -287,7 +289,7 @@ let is_unary_expression expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, _arg)];
+        args = [(Nolabel, _loc, _arg)];
       }
     when is_unary_operator operator ->
     true
@@ -311,7 +313,7 @@ let is_binary_expression expr =
             pexp_desc =
               Pexp_ident {txt = Longident.Lident operator; loc = operator_loc};
           };
-        args = [(Nolabel, _operand1); (Nolabel, _operand2)];
+        args = [(Nolabel, _, _operand1); (Nolabel, _, _operand2)];
       }
     when is_binary_operator operator
          && not (operator_loc.loc_ghost && operator = "++")
@@ -386,7 +388,7 @@ let is_array_access expr =
               Pexp_ident
                 {txt = Longident.Ldot (Longident.Lident "Array", "get")};
           };
-        args = [(Nolabel, _parentExpr); (Nolabel, _memberExpr)];
+        args = [(Nolabel, _, _parentExpr); (Nolabel, _, _memberExpr)];
       } ->
     true
   | _ -> false
@@ -518,7 +520,7 @@ let should_indent_binary_expr expr =
        Pexp_apply
          {
            funct = {pexp_desc = Pexp_ident {txt = Longident.Lident sub_operator}};
-           args = [(Nolabel, _lhs); (Nolabel, _rhs)];
+           args = [(Nolabel, _, _lhs); (Nolabel, _, _rhs)];
          };
     }
       when is_binary_operator sub_operator ->
@@ -531,7 +533,7 @@ let should_indent_binary_expr expr =
      Pexp_apply
        {
          funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-         args = [(Nolabel, lhs); (Nolabel, _rhs)];
+         args = [(Nolabel, _, lhs); (Nolabel, _, _)];
        };
   }
     when is_binary_operator operator ->
@@ -644,7 +646,7 @@ let is_template_literal expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"}};
-        args = [(Nolabel, _); (Nolabel, _)];
+        args = [(Nolabel, _, _); (Nolabel, _, _)];
       }
     when has_template_literal_attr expr.pexp_attributes ->
     true
@@ -715,7 +717,7 @@ let is_single_pipe_expr expr =
     | Pexp_apply
         {
           funct = {pexp_desc = Pexp_ident {txt = Longident.Lident ("->" | "|>")}};
-          args = [(Nolabel, _operand1); (Nolabel, _operand2)];
+          args = [(Nolabel, _, _operand1); (Nolabel, _, _operand2)];
         } ->
       true
     | _ -> false
@@ -724,7 +726,7 @@ let is_single_pipe_expr expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident ("->" | "|>")}};
-        args = [(Nolabel, operand1); (Nolabel, _operand2)];
+        args = [(Nolabel, _, operand1); (Nolabel, _, _operand2)];
       }
     when not (is_pipe_expr operand1) ->
     true

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -3150,11 +3150,11 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
       | extension ->
         print_extension ~state ~at_module_lvl:false extension cmt_tbl)
     | Pexp_apply
-        {funct = e; args = [(Nolabel, {pexp_desc = Pexp_array sub_lists})]}
+        {funct = e; args = [(Nolabel, _, {pexp_desc = Pexp_array sub_lists})]}
       when ParsetreeViewer.is_spread_belt_array_concat e ->
       print_belt_array_concat_apply ~state sub_lists cmt_tbl
     | Pexp_apply
-        {funct = e; args = [(Nolabel, {pexp_desc = Pexp_array sub_lists})]}
+        {funct = e; args = [(Nolabel, _, {pexp_desc = Pexp_array sub_lists})]}
       when ParsetreeViewer.is_spread_belt_list_concat e ->
       print_belt_list_concat_apply ~state sub_lists cmt_tbl
     | Pexp_apply {funct = call_expr; args} ->
@@ -3558,7 +3558,7 @@ and print_template_literal ~state expr cmt_tbl =
     | Pexp_apply
         {
           funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"}};
-          args = [(Nolabel, arg1); (Nolabel, arg2)];
+          args = [(Nolabel, _, arg1); (Nolabel, _, arg2)];
         } ->
       let lhs = walk_expr arg1 in
       let rhs = walk_expr arg2 in
@@ -3589,8 +3589,8 @@ and print_tagged_template_literal ~state call_expr args cmt_tbl =
   let strings_list, values_list =
     match args with
     | [
-     (_, {Parsetree.pexp_desc = Pexp_array strings});
-     (_, {Parsetree.pexp_desc = Pexp_array values});
+     (_, _, {Parsetree.pexp_desc = Pexp_array strings});
+     (_, _, {Parsetree.pexp_desc = Pexp_array values});
     ] ->
       (strings, values)
     | _ -> assert false
@@ -3647,7 +3647,7 @@ and print_unary_expression ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, operand)];
+        args = [(Nolabel, _, operand)];
       } ->
     let printed_operand =
       let doc = print_expression_with_comments ~state operand cmt_tbl in
@@ -3685,7 +3685,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
            Pexp_apply
              {
                funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-               args = [(_, left); (_, right)];
+               args = [(_, _, left); (_, _, right)];
              };
         } ->
           if
@@ -3792,7 +3792,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
         | Pexp_apply
             {
               funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"; loc}};
-              args = [(Nolabel, _); (Nolabel, _)];
+              args = [(Nolabel, _, _); (Nolabel, _, _)];
             }
           when loc.loc_ghost ->
           let doc = print_template_literal ~state expr cmt_tbl in
@@ -3806,7 +3806,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
         | Pexp_apply
             {
               funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "#="}};
-              args = [(Nolabel, lhs); (Nolabel, rhs)];
+              args = [(Nolabel, _, lhs); (Nolabel, _, rhs)];
             } ->
           let rhs_doc = print_expression_with_comments ~state rhs cmt_tbl in
           let lhs_doc = print_expression_with_comments ~state lhs cmt_tbl in
@@ -3847,7 +3847,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
           {
             pexp_desc = Pexp_ident {txt = Longident.Lident (("->" | "|>") as op)};
           };
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolabel, _, lhs); (Nolabel, _, rhs)];
       }
     when not
            (ParsetreeViewer.is_binary_expression lhs
@@ -3873,7 +3873,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolabel, _, lhs); (Nolabel, _, rhs)];
       } ->
     let is_multiline =
       lhs.pexp_loc.loc_start.pos_lnum < rhs.pexp_loc.loc_start.pos_lnum
@@ -4045,7 +4045,7 @@ and print_pexp_apply ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "##"}};
-        args = [(Nolabel, parent_expr); (Nolabel, member_expr)];
+        args = [(Nolabel, _, parent_expr); (Nolabel, _, member_expr)];
       } ->
     let parent_doc =
       let doc = print_expression_with_comments ~state parent_expr cmt_tbl in
@@ -4077,7 +4077,7 @@ and print_pexp_apply ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "#="}};
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolabel, _, lhs); (Nolabel, _, rhs)];
       } -> (
     let rhs_doc =
       let doc = print_expression_with_comments ~state rhs cmt_tbl in
@@ -4114,7 +4114,7 @@ and print_pexp_apply ~state expr cmt_tbl =
               Pexp_ident
                 {txt = Longident.Ldot (Lident "Primitive_dict", "make")};
           };
-        args = [(Nolabel, key_values)];
+        args = [(Nolabel, _, key_values)];
       }
     when Res_parsetree_viewer.is_tuple_array key_values ->
     Doc.concat
@@ -4129,7 +4129,7 @@ and print_pexp_apply ~state expr cmt_tbl =
           {
             pexp_desc = Pexp_ident {txt = Longident.Ldot (Lident "Array", "get")};
           };
-        args = [(Nolabel, parent_expr); (Nolabel, member_expr)];
+        args = [(Nolabel, _, parent_expr); (Nolabel, _, member_expr)];
       }
     when not (ParsetreeViewer.is_rewritten_underscore_apply_sugar parent_expr)
     ->
@@ -4176,9 +4176,9 @@ and print_pexp_apply ~state expr cmt_tbl =
           };
         args =
           [
-            (Nolabel, parent_expr);
-            (Nolabel, member_expr);
-            (Nolabel, target_expr);
+            (Nolabel, _, parent_expr);
+            (Nolabel, _, member_expr);
+            (Nolabel, _, target_expr);
           ];
       } ->
     let member =
@@ -4250,7 +4250,8 @@ and print_pexp_apply ~state expr cmt_tbl =
   | Pexp_apply {funct = call_expr; args; partial} ->
     let args =
       List.map
-        (fun (lbl, arg) -> (lbl, ParsetreeViewer.rewrite_underscore_apply arg))
+        (fun (lbl, _, arg) ->
+          (lbl, ParsetreeViewer.rewrite_underscore_apply arg))
         args
     in
     let attrs = expr.pexp_attributes in
@@ -4509,8 +4510,9 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
     match args with
     | [] -> (Doc.nil, None)
     | [
-     (Asttypes.Labelled "children", children);
+     (Asttypes.Labelled "children", _, children);
      ( Asttypes.Nolabel,
+       _,
        {
          Parsetree.pexp_desc =
            Pexp_construct ({txt = Longident.Lident "()"}, None);
@@ -4518,10 +4520,11 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
     ] ->
       let doc = if is_self_closing children then Doc.line else Doc.nil in
       (doc, Some children)
-    | ((_, expr) as last_prop)
+    | ((_, lbl_loc, expr) as last_prop)
       :: [
-           (Asttypes.Labelled "children", children);
+           (Asttypes.Labelled "children", _, children);
            ( Asttypes.Nolabel,
+             _,
              {
                Parsetree.pexp_desc =
                  Pexp_construct ({txt = Longident.Lident "()"}, None);
@@ -4530,6 +4533,7 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
       let loc =
         match expr.Parsetree.pexp_attributes with
         | ({Location.txt = "res.namedArgLoc"; loc}, _) :: _attrs ->
+          let _ = assert (loc = lbl_loc) in
           {loc with loc_end = expr.pexp_loc.loc_end}
         | _ -> expr.pexp_loc
       in
@@ -4563,12 +4567,14 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
 and print_jsx_prop ~state arg cmt_tbl =
   match arg with
   | ( ((Asttypes.Labelled lbl_txt | Optional lbl_txt) as lbl),
+      lbl_loc,
       {
         Parsetree.pexp_attributes =
           [({Location.txt = "res.namedArgLoc"; loc = arg_loc}, _)];
         pexp_desc = Pexp_ident {txt = Longident.Lident ident};
       } )
     when lbl_txt = ident (* jsx punning *) -> (
+    let () = assert (arg_loc = lbl_loc) in
     match lbl with
     | Nolabel -> Doc.nil
     | Labelled _lbl -> print_comments (print_ident_like ident) cmt_tbl arg_loc
@@ -4576,6 +4582,7 @@ and print_jsx_prop ~state arg cmt_tbl =
       let doc = Doc.concat [Doc.question; print_ident_like ident] in
       print_comments doc cmt_tbl arg_loc)
   | ( ((Asttypes.Labelled lbl_txt | Optional lbl_txt) as lbl),
+      _,
       {
         Parsetree.pexp_attributes = [];
         pexp_desc = Pexp_ident {txt = Longident.Lident ident};
@@ -4585,13 +4592,14 @@ and print_jsx_prop ~state arg cmt_tbl =
     | Nolabel -> Doc.nil
     | Labelled _lbl -> print_ident_like ident
     | Optional _lbl -> Doc.concat [Doc.question; print_ident_like ident])
-  | Asttypes.Labelled "_spreadProps", expr ->
+  | Asttypes.Labelled "_spreadProps", _, expr ->
     let doc = print_expression_with_comments ~state expr cmt_tbl in
     Doc.concat [Doc.lbrace; Doc.dotdotdot; doc; Doc.rbrace]
-  | lbl, expr ->
+  | lbl, lbl_loc, expr ->
     let arg_loc, expr =
       match expr.pexp_attributes with
       | ({Location.txt = "res.namedArgLoc"; loc}, _) :: attrs ->
+        assert (loc = lbl_loc);
         (loc, {expr with pexp_attributes = attrs})
       | _ -> (Location.none, expr)
     in


### PR DESCRIPTION
This change is quite invasive.
Should look into storing the location directly in the label (and store no location in the `Nolabel` case). That would introduce two definitions of type `arg_label`: one with and one without location. E.g. a type does not have location information, while a type declaration does.
