### PR TITLE
Store the label loc directly in the label, for application for now.

### DIFF
--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1437,7 +1437,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
             | Some (ctxPath, currentUnlabelledCount) ->
               (processingFun :=
                  match lbl with
-                 | Nolabel -> Some (ctxPath, currentUnlabelledCount + 1)
+                 | Nolbl -> Some (ctxPath, currentUnlabelledCount + 1)
                  | _ -> Some (ctxPath, currentUnlabelledCount));
               if Debug.verbose () then
                 print_endline "[expr_iter] Completing for argument value";
@@ -1447,10 +1447,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
                      functionContextPath = ctxPath;
                      argumentLabel =
                        (match lbl with
-                       | Nolabel ->
+                       | Nolbl ->
                          Unlabelled {argumentPosition = currentUnlabelledCount}
-                       | Optional name -> Optional name
-                       | Labelled name -> Labelled name);
+                       | Opt {txt = name} -> Optional name
+                       | Lbl {txt = name} -> Labelled name);
                    })
           in
           (match defaultExpOpt with

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -268,8 +268,7 @@ let rec exprToContextPathInner (e : Parsetree.expression) =
     (* Transform away pipe with apply call *)
     exprToContextPath
       {
-        pexp_desc =
-          Pexp_apply {funct = d; args = (Nolabel, lhs) :: args; partial};
+        pexp_desc = Pexp_apply {funct = d; args = (Nolbl, lhs) :: args; partial};
         pexp_loc;
         pexp_attributes;
       }
@@ -289,7 +288,7 @@ let rec exprToContextPathInner (e : Parsetree.expression) =
           Pexp_apply
             {
               funct = {pexp_desc = Pexp_ident id; pexp_loc; pexp_attributes};
-              args = [(Nolabel, lhs)];
+              args = [(Nolbl, lhs)];
               partial;
             };
         pexp_loc;
@@ -298,7 +297,11 @@ let rec exprToContextPathInner (e : Parsetree.expression) =
   | Pexp_apply {funct = e1; args} -> (
     match exprToContextPath e1 with
     | None -> None
-    | Some contexPath -> Some (CPApply (contexPath, args |> List.map fst)))
+    | Some contexPath ->
+      Some
+        (CPApply
+           (contexPath, args |> List.map fst |> List.map Asttypes.to_arg_label))
+    )
   | Pexp_tuple exprs ->
     let exprsAsContextPaths = exprs |> List.filter_map exprToContextPath in
     if List.length exprs = List.length exprsAsContextPaths then

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -465,20 +465,18 @@ let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
   in
   let rec processProps ~acc args =
     match args with
-    | (Asttypes.Labelled "children", {Parsetree.pexp_loc}) :: _ ->
+    | (Asttypes.Lbl {txt = "children"}, {Parsetree.pexp_loc}) :: _ ->
       {
         compName;
         props = List.rev acc;
         childrenStart =
           (if pexp_loc.loc_ghost then None else Some (Loc.start pexp_loc));
       }
-    | ((Labelled s | Optional s), (eProp : Parsetree.expression)) :: rest -> (
-      let namedArgLoc =
-        eProp.pexp_attributes
-        |> List.find_opt (fun ({Asttypes.txt}, _) -> txt = "res.namedArgLoc")
-      in
+    | ((Lbl {txt = s; loc} | Opt {txt = s; loc}), (eProp : Parsetree.expression))
+      :: rest -> (
+      let namedArgLoc = if loc = Location.none then None else Some loc in
       match namedArgLoc with
-      | Some ({loc}, _) ->
+      | Some loc ->
         processProps
           ~acc:
             ({

--- a/analysis/src/DumpAst.ml
+++ b/analysis/src/DumpAst.ml
@@ -218,9 +218,9 @@ and printExprItem expr ~pos ~indentation =
     ^ addIndentation (indentation + 1)
     ^ "arg: "
     ^ (match arg with
-      | Nolabel -> "Nolabel"
-      | Labelled name -> "Labelled(" ^ name ^ ")"
-      | Optional name -> "Optional(" ^ name ^ ")")
+      | Nolbl -> "Nolabel"
+      | Lbl {txt = name} -> "Labelled(" ^ name ^ ")"
+      | Opt {txt = name} -> "Optional(" ^ name ^ ")")
     ^ ",\n"
     ^ addIndentation (indentation + 2)
     ^ "pattern: "

--- a/analysis/src/SemanticTokens.ml
+++ b/analysis/src/SemanticTokens.ml
@@ -266,7 +266,7 @@ let command ~debug ~emitter ~path =
 
       let posOfGreatherthanAfterProps =
         let rec loop = function
-          | (Asttypes.Labelled "children", {Parsetree.pexp_loc}) :: _ ->
+          | (Asttypes.Lbl {txt = "children"}, {Parsetree.pexp_loc}) :: _ ->
             Loc.start pexp_loc
           | _ :: args -> loop args
           | [] -> (* should not happen *) (-1, -1)

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -130,7 +130,7 @@ let extractParameters ~signature ~typeStrForParser ~labelPrefixLen =
         (* The AST locations does not account for "=?" of optional arguments, so add that to the offset here if needed. *)
         let endOffset =
           match argumentLabel with
-          | Asttypes.Optional _ -> endOffset + 2
+          | Asttypes.Opt _ -> endOffset + 2
           | _ -> endOffset
         in
         extractParams nextFunctionExpr
@@ -474,6 +474,7 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                     parameters =
                       parameters
                       |> List.map (fun (argLabel, start, end_) ->
+                             let argLabel = Asttypes.to_arg_label argLabel in
                              let paramArgCount = !paramUnlabelledArgCount in
                              paramUnlabelledArgCount := paramArgCount + 1;
                              let unlabelledArgCount = ref 0 in

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -941,7 +941,7 @@ module Codegen = struct
   let mkFailWithExp () =
     Ast_helper.Exp.apply
       (Ast_helper.Exp.ident {txt = Lident "failwith"; loc = Location.none})
-      [(Nolabel, Ast_helper.Exp.constant (Pconst_string ("TODO", None)))]
+      [(Nolbl, Ast_helper.Exp.constant (Pconst_string ("TODO", None)))]
 
   let mkConstructPat ?payload name =
     Ast_helper.Pat.construct

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -95,7 +95,7 @@ module IfThenElse = struct
                             Pexp_ident
                               {txt = Longident.Lident (("==" | "!=") as op)};
                         };
-                      args = [(Nolabel, arg1); (Nolabel, arg2)];
+                      args = [(Nolbl, arg1); (Nolbl, arg2)];
                     };
               },
               e1,

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -300,7 +300,7 @@ module AddTypeAnnotation = struct
       match e.pexp_desc with
       | Pexp_fun {arg_label; lhs = pat; rhs = e} ->
         let isUnlabeledOnlyArg =
-          argNum = 1 && arg_label = Nolabel
+          argNum = 1 && arg_label = Nolbl
           &&
           match e.pexp_desc with
           | Pexp_fun _ -> false

--- a/compiler/frontend/ast_compatible.ml
+++ b/compiler/frontend/ast_compatible.ml
@@ -31,7 +31,7 @@ open Parsetree
 let default_loc = Location.none
 
 let arrow ?loc ?attrs ~arity a b =
-  Ast_helper.Typ.arrow ?loc ?attrs ~arity Nolabel a b
+  Ast_helper.Typ.arrow ?loc ?attrs ~arity Nolbl a b
 
 let apply_simple ?(loc = default_loc) ?(attrs = []) (fn : expression)
     (args : expression list) : expression =
@@ -124,20 +124,20 @@ let apply_labels ?(loc = default_loc) ?(attrs = []) fn
         };
   }
 
-let label_arrow ?(loc = default_loc) ?(attrs = []) ~arity s arg ret : core_type
-    =
+let label_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt arg ret :
+    core_type =
   {
     ptyp_desc =
-      Ptyp_arrow {lbl = Labelled s; lbl_loc = Location.none; arg; ret; arity};
+      Ptyp_arrow {lbl = Asttypes.Lbl {txt; loc = default_loc}; arg; ret; arity};
     ptyp_loc = loc;
     ptyp_attributes = attrs;
   }
 
-let opt_arrow ?(loc = default_loc) ?(attrs = []) ~arity s arg ret : core_type =
+let opt_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt arg ret : core_type
+    =
   {
     ptyp_desc =
-      Ptyp_arrow
-        {lbl = Asttypes.Optional s; lbl_loc = Location.none; arg; ret; arity};
+      Ptyp_arrow {lbl = Asttypes.Opt {txt; loc = default_loc}; arg; ret; arity};
     ptyp_loc = loc;
     ptyp_attributes = attrs;
   }

--- a/compiler/frontend/ast_compatible.ml
+++ b/compiler/frontend/ast_compatible.ml
@@ -42,7 +42,7 @@ let apply_simple ?(loc = default_loc) ?(attrs = []) (fn : expression)
       Pexp_apply
         {
           funct = fn;
-          args = Ext_list.map args (fun x -> (Asttypes.Nolabel, x));
+          args = Ext_list.map args (fun x -> (Asttypes.Nolbl, x));
           partial = false;
         };
   }
@@ -51,8 +51,7 @@ let app1 ?(loc = default_loc) ?(attrs = []) fn arg1 : expression =
   {
     pexp_loc = loc;
     pexp_attributes = attrs;
-    pexp_desc =
-      Pexp_apply {funct = fn; args = [(Nolabel, arg1)]; partial = false};
+    pexp_desc = Pexp_apply {funct = fn; args = [(Nolbl, arg1)]; partial = false};
   }
 
 let app2 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 : expression =
@@ -61,7 +60,7 @@ let app2 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 : expression =
     pexp_attributes = attrs;
     pexp_desc =
       Pexp_apply
-        {funct = fn; args = [(Nolabel, arg1); (Nolabel, arg2)]; partial = false};
+        {funct = fn; args = [(Nolbl, arg1); (Nolbl, arg2)]; partial = false};
   }
 
 let app3 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 arg3 : expression =
@@ -72,7 +71,7 @@ let app3 ?(loc = default_loc) ?(attrs = []) fn arg1 arg2 arg3 : expression =
       Pexp_apply
         {
           funct = fn;
-          args = [(Nolabel, arg1); (Nolabel, arg2); (Nolabel, arg3)];
+          args = [(Nolbl, arg1); (Nolbl, arg2); (Nolbl, arg3)];
           partial = false;
         };
   }
@@ -118,7 +117,9 @@ let apply_labels ?(loc = default_loc) ?(attrs = []) fn
       Pexp_apply
         {
           funct = fn;
-          args = Ext_list.map args (fun (l, a) -> (Asttypes.Labelled l, a));
+          args =
+            Ext_list.map args (fun (l, a) ->
+                (Asttypes.Lbl {txt = l; loc = Location.none}, a));
           partial = false;
         };
   }
@@ -167,4 +168,4 @@ type object_field = Parsetree.object_field
 
 let object_field l attrs ty = Parsetree.Otag (l, attrs, ty)
 
-type args = (Asttypes.arg_label * Parsetree.expression) list
+type args = (Asttypes.arg_label_loc * Parsetree.expression) list

--- a/compiler/frontend/ast_compatible.ml
+++ b/compiler/frontend/ast_compatible.ml
@@ -82,15 +82,7 @@ let fun_ ?(loc = default_loc) ?(attrs = []) ?(async = false) ~arity pat exp =
     pexp_attributes = attrs;
     pexp_desc =
       Pexp_fun
-        {
-          arg_label = Nolabel;
-          label_loc = Location.none;
-          default = None;
-          lhs = pat;
-          rhs = exp;
-          arity;
-          async;
-        };
+        {arg_label = Nolbl; default = None; lhs = pat; rhs = exp; arity; async};
   }
 
 let const_exp_string ?(loc = default_loc) ?(attrs = []) ?delimiter (s : string)

--- a/compiler/frontend/ast_compatible.mli
+++ b/compiler/frontend/ast_compatible.mli
@@ -137,4 +137,4 @@ type object_field = Parsetree.object_field
 val object_field :
   Asttypes.label Asttypes.loc -> attributes -> core_type -> object_field
 
-type args = (Asttypes.arg_label * Parsetree.expression) list
+type args = (Asttypes.arg_label_loc * Parsetree.expression) list

--- a/compiler/frontend/ast_core_type.ml
+++ b/compiler/frontend/ast_core_type.ml
@@ -131,7 +131,7 @@ let get_curry_arity (ty : t) =
 let is_arity_one ty = get_curry_arity ty = 1
 
 type param_type = {
-  label: Asttypes.arg_label;
+  label: Asttypes.arg_label_loc;
   ty: Parsetree.core_type;
   attr: Parsetree.attributes;
   loc: loc;
@@ -142,15 +142,7 @@ let mk_fn_type (new_arg_types_ty : param_type list) (result : t) : t =
     Ext_list.fold_right new_arg_types_ty result
       (fun {label; ty; attr; loc} acc ->
         {
-          ptyp_desc =
-            Ptyp_arrow
-              {
-                lbl = label;
-                lbl_loc = Location.none;
-                arg = ty;
-                ret = acc;
-                arity = None;
-              };
+          ptyp_desc = Ptyp_arrow {lbl = label; arg = ty; ret = acc; arity = None};
           ptyp_loc = loc;
           ptyp_attributes = attr;
         })
@@ -179,5 +171,5 @@ let list_of_arrow (ty : t) : t * param_type list =
 let add_last_obj (ty : t) (obj : t) =
   let result, params = list_of_arrow ty in
   mk_fn_type
-    (params @ [{label = Nolabel; ty = obj; attr = []; loc = obj.ptyp_loc}])
+    (params @ [{label = Nolbl; ty = obj; attr = []; loc = obj.ptyp_loc}])
     result

--- a/compiler/frontend/ast_core_type.mli
+++ b/compiler/frontend/ast_core_type.mli
@@ -48,7 +48,7 @@ val get_uncurry_arity : t -> int option
 *)
 
 type param_type = {
-  label: Asttypes.arg_label;
+  label: Asttypes.arg_label_loc;
   ty: t;
   attr: Parsetree.attributes;
   loc: Location.t;

--- a/compiler/frontend/ast_core_type_class_type.ml
+++ b/compiler/frontend/ast_core_type_class_type.ml
@@ -106,7 +106,7 @@ let typ_mapper (self : Bs_ast_mapper.mapper) (ty : Parsetree.core_type) =
                 | Meth_callback attr, attrs -> (attrs, attr +> ty)
               in
               Ast_compatible.object_field name attrs
-                (Ast_typ_uncurry.to_uncurry_type loc self Nolabel core_type
+                (Ast_typ_uncurry.to_uncurry_type loc self Nolbl core_type
                    (Ast_literal.type_unit ~loc ()))
             in
             let not_getter_setter ty =

--- a/compiler/frontend/ast_exp_apply.ml
+++ b/compiler/frontend/ast_exp_apply.ml
@@ -91,8 +91,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
     | Pexp_apply {funct = fn1; args; partial} ->
       Bs_ast_invariant.warn_discarded_unused_attributes fn1.pexp_attributes;
       {
-        pexp_desc =
-          Pexp_apply {funct = fn1; args = (Nolabel, a) :: args; partial};
+        pexp_desc = Pexp_apply {funct = fn1; args = (Nolbl, a) :: args; partial};
         pexp_loc = e.pexp_loc;
         pexp_attributes = e.pexp_attributes @ f.pexp_attributes;
       }
@@ -116,7 +115,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
                            Pexp_apply
                              {
                                funct = fn;
-                               args = (Nolabel, bounded_obj_arg) :: args;
+                               args = (Nolbl, bounded_obj_arg) :: args;
                                partial = false;
                              };
                          pexp_attributes = [];
@@ -170,7 +169,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) : exp =
       let arg = self.expr self arg in
       let fn = Exp.send ~loc obj {txt = name ^ Literals.setter_suffix; loc} in
       Exp.constraint_ ~loc
-        (Exp.apply ~loc fn [(Nolabel, arg)])
+        (Exp.apply ~loc fn [(Nolbl, arg)])
         (Ast_literal.type_unit ~loc ())
     in
     match obj.pexp_desc with

--- a/compiler/frontend/ast_exp_extension.ml
+++ b/compiler/frontend/ast_exp_extension.ml
@@ -45,7 +45,7 @@ let handle_extension e (self : Bs_ast_mapper.mapper)
     Exp.apply ~loc
       (Exp.ident ~loc {txt = Longident.parse "Js.Exn.raiseError"; loc})
       [
-        ( Nolabel,
+        ( Nolbl,
           Exp.constant ~loc
             (Pconst_string
                ( (pretext

--- a/compiler/frontend/ast_exp_handle_external.ml
+++ b/compiler/frontend/ast_exp_handle_external.ml
@@ -43,8 +43,7 @@ let handle_external loc (x : string) : Parsetree.expression =
       str_exp with
       pexp_desc =
         Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
-          ~pval_type:
-            (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+          ~pval_type:(Typ.arrow ~arity:(Some 1) Nolbl (Typ.any ()) (Typ.any ()))
           [str_exp];
     }
   in
@@ -70,8 +69,7 @@ let handle_debugger loc (payload : Ast_payload.t) =
   | PStr [] ->
     Ast_external_mk.local_external_apply loc ~pval_prim:["%debugger"]
       ~pval_type:
-        (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ())
-           (Ast_literal.type_unit ()))
+        (Typ.arrow ~arity:(Some 1) Nolbl (Typ.any ()) (Ast_literal.type_unit ()))
       [Ast_literal.val_unit ~loc ()]
   | _ ->
     Location.raise_errorf ~loc "%%debugger extension doesn't accept arguments"
@@ -95,8 +93,7 @@ let handle_raw ~kind loc payload =
       exp with
       pexp_desc =
         Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
-          ~pval_type:
-            (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+          ~pval_type:(Typ.arrow ~arity:(Some 1) Nolbl (Typ.any ()) (Typ.any ()))
           [exp];
       pexp_attributes =
         (match !is_function with
@@ -123,11 +120,11 @@ let handle_ffi ~loc ~payload =
       let any = Ast_helper.Typ.any ~loc:e.pexp_loc () in
       let unit = Ast_literal.type_unit ~loc () in
       let rec arrow ~arity =
-        if arity = 0 then Ast_helper.Typ.arrow ~arity:None ~loc Nolabel unit any
+        if arity = 0 then Ast_helper.Typ.arrow ~arity:None ~loc Nolbl unit any
         else if arity = 1 then
-          Ast_helper.Typ.arrow ~arity:None ~loc Nolabel any any
+          Ast_helper.Typ.arrow ~arity:None ~loc Nolbl any any
         else
-          Ast_helper.Typ.arrow ~loc ~arity:None Nolabel any
+          Ast_helper.Typ.arrow ~loc ~arity:None Nolbl any
             (arrow ~arity:(arity - 1))
       in
       match !is_function with
@@ -146,7 +143,7 @@ let handle_ffi ~loc ~payload =
         pexp_desc =
           Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
             ~pval_type:
-              (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+              (Typ.arrow ~arity:(Some 1) Nolbl (Typ.any ()) (Typ.any ()))
             [exp];
         pexp_attributes =
           (match !is_function with
@@ -163,7 +160,7 @@ let handle_raw_structure loc payload =
         pexp_desc =
           Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_stmt"]
             ~pval_type:
-              (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+              (Typ.arrow ~arity:(Some 1) Nolbl (Typ.any ()) (Typ.any ()))
             [exp];
       }
   | None ->

--- a/compiler/frontend/ast_external_process.ml
+++ b/compiler/frontend/ast_external_process.ml
@@ -462,7 +462,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
           let ty = param_type.ty in
           let new_arg_label, new_arg_types, output_tys =
             match arg_label with
-            | Nolabel -> (
+            | Nolbl -> (
               match ty.ptyp_desc with
               | Ptyp_constr ({txt = Lident "unit"}, []) ->
                 ( External_arg_spec.empty_kind Extern_unit,
@@ -471,7 +471,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
               | _ ->
                 Location.raise_errorf ~loc
                   "expect label, optional, or unit here")
-            | Labelled label -> (
+            | Lbl {txt = label} -> (
               let field_name =
                 match
                   Ast_attributes.iter_process_bs_string_as param_type.attr
@@ -530,7 +530,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
               | Unwrap ->
                 Location.raise_errorf ~loc
                   "%@obj label %s does not support %@unwrap arguments" label)
-            | Optional label -> (
+            | Opt {txt = label} -> (
               let field_name =
                 match
                   Ast_attributes.iter_process_bs_string_as param_type.attr
@@ -964,10 +964,10 @@ let handle_attributes (loc : Bs_loc.t) (type_annotation : Parsetree.core_type)
           let ty = param_type.ty in
           (if i = 0 && splice then
              match arg_label with
-             | Optional _ ->
+             | Opt _ ->
                Location.raise_errorf ~loc
                  "%@variadic expect the last type to be a non optional"
-             | Labelled _ | Nolabel -> (
+             | Lbl _ | Nolbl -> (
                if ty.ptyp_desc = Ptyp_any then
                  Location.raise_errorf ~loc
                    "%@variadic expect the last type to be an array";
@@ -983,7 +983,7 @@ let handle_attributes (loc : Bs_loc.t) (type_annotation : Parsetree.core_type)
                 arg_type,
                 new_arg_types ) =
             match arg_label with
-            | Optional s -> (
+            | Opt {txt = s} -> (
               let arg_type = get_opt_arg_type ~nolabel:false ty in
               match arg_type with
               | Poly_var _ ->
@@ -993,14 +993,14 @@ let handle_attributes (loc : Bs_loc.t) (type_annotation : Parsetree.core_type)
                    label %s"
                   s
               | _ -> (Arg_optional, arg_type, param_type :: arg_types))
-            | Labelled _ -> (
+            | Lbl _ -> (
               let arg_type = refine_arg_type ~nolabel:false ty in
               ( Arg_label,
                 arg_type,
                 match arg_type with
                 | Arg_cst _ -> arg_types
                 | _ -> param_type :: arg_types ))
-            | Nolabel -> (
+            | Nolbl -> (
               let arg_type = refine_arg_type ~nolabel:true ty in
               ( Arg_empty,
                 arg_type,

--- a/compiler/frontend/ast_pat.mli
+++ b/compiler/frontend/ast_pat.mli
@@ -30,6 +30,6 @@ val arity_of_fun : t -> Parsetree.expression -> int
 (** [arity_of_fun pat e] tells the arity of 
     expression [fun pat -> e]*)
 
-val labels_of_fun : Parsetree.expression -> Asttypes.arg_label list
+val labels_of_fun : Parsetree.expression -> Asttypes.arg_label_loc list
 
 val is_single_variable_pattern_conservative : t -> string option

--- a/compiler/frontend/ast_typ_uncurry.ml
+++ b/compiler/frontend/ast_typ_uncurry.ml
@@ -24,12 +24,12 @@
 
 type typ = Parsetree.core_type
 type 'a cxt = Ast_helper.loc -> Bs_ast_mapper.mapper -> 'a
-type uncurry_type_gen = (Asttypes.arg_label -> typ -> typ -> typ) cxt
+type uncurry_type_gen = (Asttypes.arg_label_loc -> typ -> typ -> typ) cxt
 
 module Typ = Ast_helper.Typ
 
 let to_method_callback_type loc (mapper : Bs_ast_mapper.mapper)
-    (label : Asttypes.arg_label) (first_arg : Parsetree.core_type)
+    (label : Asttypes.arg_label_loc) (first_arg : Parsetree.core_type)
     (typ : Parsetree.core_type) =
   let first_arg = mapper.typ mapper first_arg in
   let typ = mapper.typ mapper typ in
@@ -46,7 +46,7 @@ let to_method_callback_type loc (mapper : Bs_ast_mapper.mapper)
   | None -> assert false
 
 let to_uncurry_type loc (mapper : Bs_ast_mapper.mapper)
-    (label : Asttypes.arg_label) (first_arg : Parsetree.core_type)
+    (label : Asttypes.arg_label_loc) (first_arg : Parsetree.core_type)
     (typ : Parsetree.core_type) =
   (* no need to error for optional here,
      since we can not make it

--- a/compiler/frontend/ast_typ_uncurry.mli
+++ b/compiler/frontend/ast_typ_uncurry.mli
@@ -40,7 +40,7 @@ type typ = Parsetree.core_type
 type 'a cxt = Ast_helper.loc -> Bs_ast_mapper.mapper -> 'a
 
 type uncurry_type_gen =
-  (Asttypes.arg_label ->
+  (Asttypes.arg_label_loc ->
   (* label for error checking *)
   typ ->
   (* First arg *)

--- a/compiler/frontend/ast_uncurry_gen.ml
+++ b/compiler/frontend/ast_uncurry_gen.ml
@@ -57,7 +57,7 @@ let to_method_callback loc (self : Bs_ast_mapper.mapper) label
           {loc; txt = Ldot (Ast_literal.Lid.js_oo, "unsafe_to_method")};
       args =
         [
-          ( Nolabel,
+          ( Nolbl,
             Exp.constraint_ ~loc
               (Exp.record ~loc
                  [

--- a/compiler/frontend/ast_uncurry_gen.mli
+++ b/compiler/frontend/ast_uncurry_gen.mli
@@ -25,7 +25,7 @@
 val to_method_callback :
   Location.t ->
   Bs_ast_mapper.mapper ->
-  Asttypes.arg_label ->
+  Asttypes.arg_label_loc ->
   Parsetree.pattern ->
   Parsetree.expression ->
   Parsetree.expression_desc

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -101,9 +101,8 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow {lbl; lbl_loc; arg; ret; arity} ->
-      arrow ~loc ~attrs ~label_loc:lbl_loc ~arity lbl (sub.typ sub arg)
-        (sub.typ sub ret)
+    | Ptyp_arrow {lbl; arg; ret; arity} ->
+      arrow ~loc ~attrs ~arity lbl (sub.typ sub arg) (sub.typ sub ret)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) ->
       constr ~loc ~attrs (map_loc sub lid) (List.map (sub.typ sub) tl)

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -311,17 +311,9 @@ module E = struct
            sub vbs)
         (sub.expr sub e)
     (* #end *)
-    | Pexp_fun
-        {
-          arg_label = lab;
-          label_loc;
-          default = def;
-          lhs = p;
-          rhs = e;
-          arity;
-          async;
-        } ->
-      fun_ ~loc ~attrs ~label_loc ~arity ~async lab
+    | Pexp_fun {arg_label = lab; default = def; lhs = p; rhs = e; arity; async}
+      ->
+      fun_ ~loc ~attrs ~arity ~async lab
         (map_opt (sub.expr sub) def)
         (sub.pat sub p) (sub.expr sub e)
     | Pexp_apply {funct = e; args = l; partial} ->

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -104,9 +104,9 @@ let () =
 
 let err loc error = raise (Error (loc, error))
 
-let optional_err loc (lbl : Asttypes.arg_label) =
+let optional_err loc (lbl : Asttypes.arg_label_loc) =
   match lbl with
-  | Optional _ -> raise (Error (loc, Optional_in_uncurried_bs_attribute))
+  | Opt _ -> raise (Error (loc, Optional_in_uncurried_bs_attribute))
   | _ -> ()
 
 let err_if_label loc (lbl : Asttypes.arg_label_loc) =

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -109,5 +109,5 @@ let optional_err loc (lbl : Asttypes.arg_label) =
   | Optional _ -> raise (Error (loc, Optional_in_uncurried_bs_attribute))
   | _ -> ()
 
-let err_if_label loc (lbl : Asttypes.arg_label) =
-  if lbl <> Nolabel then raise (Error (loc, Misplaced_label_syntax))
+let err_if_label loc (lbl : Asttypes.arg_label_loc) =
+  if lbl <> Nolbl then raise (Error (loc, Misplaced_label_syntax))

--- a/compiler/frontend/bs_syntaxerr.mli
+++ b/compiler/frontend/bs_syntaxerr.mli
@@ -54,6 +54,6 @@ type error =
 
 val err : Location.t -> error -> 'a
 
-val optional_err : Location.t -> Asttypes.arg_label -> unit
+val optional_err : Location.t -> Asttypes.arg_label_loc -> unit
 
 val err_if_label : Location.t -> Asttypes.arg_label_loc -> unit

--- a/compiler/frontend/bs_syntaxerr.mli
+++ b/compiler/frontend/bs_syntaxerr.mli
@@ -56,4 +56,4 @@ val err : Location.t -> error -> 'a
 
 val optional_err : Location.t -> Asttypes.arg_label -> unit
 
-val err_if_label : Location.t -> Asttypes.arg_label -> unit
+val err_if_label : Location.t -> Asttypes.arg_label_loc -> unit

--- a/compiler/ml/ast_async.ml
+++ b/compiler/ml/ast_async.ml
@@ -11,7 +11,7 @@ let add_promise_type ?(loc = Location.none) ~async
       Ast_helper.Exp.ident ~loc
         {txt = Ldot (Lident Primitive_modules.promise, "unsafe_async"); loc}
     in
-    Ast_helper.Exp.apply ~loc unsafe_async [(Nolabel, result)]
+    Ast_helper.Exp.apply ~loc unsafe_async [(Nolbl, result)]
   else result
 
 let rec add_promise_to_result ~loc (e : Parsetree.expression) =

--- a/compiler/ml/ast_await.ml
+++ b/compiler/ml/ast_await.ml
@@ -7,7 +7,7 @@ let create_await_expression (e : Parsetree.expression) =
     Ast_helper.Exp.ident ~loc
       {txt = Ldot (Lident Primitive_modules.promise, "unsafe_await"); loc}
   in
-  Ast_helper.Exp.apply ~loc unsafe_await [(Nolabel, e)]
+  Ast_helper.Exp.apply ~loc unsafe_await [(Nolbl, e)]
 
 (* Transform `@res.await M` to unpack(@res.await Js.import(module(M: __M0__))) *)
 let create_await_module_expression ~module_type_lid (e : Parsetree.module_expr)
@@ -29,7 +29,7 @@ let create_await_module_expression ~module_type_lid (e : Parsetree.module_expr)
                    loc = e.pmod_loc;
                  })
               [
-                ( Nolabel,
+                ( Nolbl,
                   Exp.constraint_ ~loc:e.pmod_loc
                     (Exp.pack ~loc:e.pmod_loc
                        {

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -151,11 +151,9 @@ module Exp = struct
   let ident ?loc ?attrs a = mk ?loc ?attrs (Pexp_ident a)
   let constant ?loc ?attrs a = mk ?loc ?attrs (Pexp_constant a)
   let let_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_let (a, b, c))
-  let fun_ ?loc ?attrs ?(async = false) ?(label_loc = Location.none) ~arity a b
-      c d =
+  let fun_ ?loc ?attrs ?(async = false) ~arity a b c d =
     mk ?loc ?attrs
-      (Pexp_fun
-         {arg_label = a; label_loc; default = b; lhs = c; rhs = d; arity; async})
+      (Pexp_fun {arg_label = a; default = b; lhs = c; rhs = d; arity; async})
   let apply ?loc ?attrs ?(partial = false) funct args =
     mk ?loc ?attrs (Pexp_apply {funct; args; partial})
   let match_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_match (a, b))

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -54,8 +54,8 @@ module Typ = struct
 
   let any ?loc ?attrs () = mk ?loc ?attrs Ptyp_any
   let var ?loc ?attrs a = mk ?loc ?attrs (Ptyp_var a)
-  let arrow ?loc ?attrs ?(label_loc = Location.none) ~arity lbl arg ret =
-    mk ?loc ?attrs (Ptyp_arrow {lbl; lbl_loc = label_loc; arg; ret; arity})
+  let arrow ?loc ?attrs ~arity lbl arg ret =
+    mk ?loc ?attrs (Ptyp_arrow {lbl; arg; ret; arity})
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ptyp_tuple a)
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_constr (a, b))
   let object_ ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_object (a, b))

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -139,9 +139,8 @@ module Exp : sig
     ?loc:loc ->
     ?attrs:attrs ->
     ?async:bool ->
-    ?label_loc:loc ->
     arity:int option ->
-    arg_label ->
+    arg_label_loc ->
     expression option ->
     pattern ->
     expression ->

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -152,7 +152,7 @@ module Exp : sig
     ?attrs:attrs ->
     ?partial:bool ->
     expression ->
-    (arg_label * expression) list ->
+    (arg_label_loc * expression) list ->
     expression
   val match_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
   val try_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -57,9 +57,8 @@ module Typ : sig
   val arrow :
     ?loc:loc ->
     ?attrs:attrs ->
-    ?label_loc:loc ->
     arity:arity ->
-    arg_label ->
+    arg_label_loc ->
     core_type ->
     core_type ->
     core_type

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -93,9 +93,8 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow {lbl; lbl_loc; arg; ret; arity} ->
-      arrow ~loc ~attrs ~label_loc:lbl_loc ~arity lbl (sub.typ sub arg)
-        (sub.typ sub ret)
+    | Ptyp_arrow {lbl; arg; ret; arity} ->
+      arrow ~loc ~attrs ~arity lbl (sub.typ sub arg) (sub.typ sub ret)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) ->
       constr ~loc ~attrs (map_loc sub lid) (List.map (sub.typ sub) tl)

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -274,17 +274,9 @@ module E = struct
     | Pexp_constant x -> constant ~loc ~attrs x
     | Pexp_let (r, vbs, e) ->
       let_ ~loc ~attrs r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
-    | Pexp_fun
-        {
-          arg_label = lab;
-          label_loc;
-          default = def;
-          lhs = p;
-          rhs = e;
-          arity;
-          async;
-        } ->
-      fun_ ~loc ~attrs ~label_loc ~arity ~async lab
+    | Pexp_fun {arg_label = lab; default = def; lhs = p; rhs = e; arity; async}
+      ->
+      fun_ ~loc ~attrs ~arity ~async lab
         (map_opt (sub.expr sub) def)
         (sub.pat sub p) (sub.expr sub e)
     | Pexp_apply {funct = e; args = l; partial} ->

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -349,7 +349,9 @@ module E = struct
       in
       let partial, attrs = process_partial_app_attribute attrs in
       apply ~loc ~attrs ~partial (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) l)
+        (List.map
+           (fun (lbl, e) -> (Asttypes.to_arg_label_loc lbl, sub.expr sub e))
+           l)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -99,6 +99,7 @@ module T = struct
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
     | Ptyp_arrow (lab, t1, t2) ->
+      let lab = Asttypes.to_arg_label_loc lab in
       arrow ~loc ~attrs ~arity:None lab (sub.typ sub t1) (sub.typ sub t2)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) -> (

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -305,6 +305,7 @@ module E = struct
     | Pexp_let (r, vbs, e) ->
       let_ ~loc ~attrs r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
     | Pexp_fun (lab, def, p, e) ->
+      let lab = Asttypes.to_arg_label_loc lab in
       let async = Ext_list.exists attrs (fun ({txt}, _) -> txt = "res.async") in
       fun_ ~loc ~attrs ~async ~arity:None lab
         (map_opt (sub.expr sub) def)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -99,6 +99,7 @@ module T = struct
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
     | Ptyp_arrow {lbl; arg; ret; arity} -> (
+      let lbl = Asttypes.to_arg_label lbl in
       let typ0 = arrow ~loc ~attrs lbl (sub.typ sub arg) (sub.typ sub ret) in
       match arity with
       | None -> typ0

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -294,6 +294,7 @@ module E = struct
       let_ ~loc ~attrs r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
     | Pexp_fun {arg_label = lab; default = def; lhs = p; rhs = e; arity; async}
       -> (
+      let lab = Asttypes.to_arg_label lab in
       let attrs =
         if async then
           ({txt = "res.async"; loc = Location.none}, Pt.PStr []) :: attrs

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -325,22 +325,22 @@ module E = struct
       let e =
         match (e.pexp_desc, args) with
         | ( Pexp_ident ({txt = Longident.Lident "->"} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "|."}}
         | ( Pexp_ident ({txt = Longident.Lident "++"} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "^"}}
         | ( Pexp_ident ({txt = Longident.Lident "!="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "<>"}}
         | ( Pexp_ident ({txt = Longident.Lident "!=="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "!="}}
         | ( Pexp_ident ({txt = Longident.Lident "==="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "=="}}
         | ( Pexp_ident ({txt = Longident.Lident "=="} as lid),
-            [(Nolabel, _); (Nolabel, _)] ) ->
+            [(Nolbl, _); (Nolbl, _)] ) ->
           {e with pexp_desc = Pexp_ident {lid with txt = Longident.Lident "="}}
         | _ -> e
       in
@@ -349,7 +349,9 @@ module E = struct
         else []
       in
       apply ~loc ~attrs (sub.expr sub e)
-        (List.map (map_snd (sub.expr sub)) args)
+        (List.map
+           (fun (lbl, e) -> (Asttypes.to_arg_label lbl, sub.expr sub e))
+           args)
     | Pexp_match (e, pel) ->
       match_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)
     | Pexp_try (e, pel) -> try_ ~loc ~attrs (sub.expr sub e) (sub.cases sub pel)

--- a/compiler/ml/asttypes.ml
+++ b/compiler/ml/asttypes.ml
@@ -63,3 +63,31 @@ let same_arg_label (x : arg_label) y =
     match y with
     | Optional s0 -> s = s0
     | _ -> false)
+
+type arg_label_loc =
+  | Nolbl
+  | Lbl of string loc (*  label:T -> ... *)
+  | Opt of string loc (* ?label:T -> ... *)
+
+let to_arg_label_loc ?(loc = Location.none) lbl =
+  match lbl with
+  | Nolabel -> Nolbl
+  | Labelled s -> Lbl {loc; txt = s}
+  | Optional s -> Opt {loc; txt = s}
+
+let to_arg_label = function
+  | Nolbl -> Nolabel
+  | Lbl {txt} -> Labelled txt
+  | Opt {txt} -> Optional txt
+
+let same_arg_label_loc (x : arg_label_loc) y =
+  match x with
+  | Nolbl -> y = Nolbl
+  | Lbl {txt = s} -> (
+    match y with
+    | Lbl {txt = s0} -> s = s0
+    | _ -> false)
+  | Opt {txt = s} -> (
+    match y with
+    | Opt {txt = s0} -> s = s0
+    | _ -> false)

--- a/compiler/ml/asttypes.ml
+++ b/compiler/ml/asttypes.ml
@@ -91,3 +91,7 @@ let same_arg_label_loc (x : arg_label_loc) y =
     match y with
     | Opt {txt = s0} -> s = s0
     | _ -> false)
+
+let get_lbl_loc = function
+  | Nolbl -> Location.none
+  | Lbl {loc} | Opt {loc} -> loc

--- a/compiler/ml/btype.ml
+++ b/compiler/ml/btype.ml
@@ -596,31 +596,39 @@ let is_optional = function
   | Optional _ -> true
   | _ -> false
 
+let is_optional_loc = function
+  | Opt _ -> true
+  | _ -> false
+
 let label_name = function
   | Nolabel -> ""
   | Labelled s | Optional s -> s
+
+let label_loc_name = function
+  | Nolbl -> ""
+  | Lbl {txt} | Opt {txt} -> txt
 
 let prefixed_label_name = function
   | Nolabel -> ""
   | Labelled s -> "~" ^ s
   | Optional s -> "?" ^ s
 
-type sargs = (Asttypes.arg_label * Parsetree.expression) list
+type sargs = (Asttypes.arg_label_loc * Parsetree.expression) list
 
 let rec extract_label_aux hd l = function
   | [] -> None
   | ((l', t) as p) :: ls ->
-    if label_name l' = l then Some (l', t, List.rev_append hd ls)
+    if label_loc_name l' = l then Some (l', t, List.rev_append hd ls)
     else extract_label_aux (p :: hd) l ls
 
 let extract_label l (ls : sargs) :
-    (arg_label * Parsetree.expression * sargs) option =
+    (arg_label_loc * Parsetree.expression * sargs) option =
   extract_label_aux [] l ls
 
 let rec label_assoc x (args : sargs) =
   match args with
   | [] -> false
-  | (a, _) :: l -> Asttypes.same_arg_label a x || label_assoc x l
+  | (a, _) :: l -> Asttypes.same_arg_label_loc a x || label_assoc x l
 
 (**********************************)
 (*  Utilities for backtracking    *)

--- a/compiler/ml/btype.mli
+++ b/compiler/ml/btype.mli
@@ -181,18 +181,20 @@ val forget_abbrev : abbrev_memo ref -> Path.t -> unit
 (**** Utilities for labels ****)
 
 val is_optional : arg_label -> bool
+val is_optional_loc : arg_label_loc -> bool
 val label_name : arg_label -> label
+val label_loc_name : arg_label_loc -> label
 
 (* Returns the label name with first character '?' or '~' as appropriate. *)
 val prefixed_label_name : arg_label -> label
 
-type sargs = (arg_label * Parsetree.expression) list
+type sargs = (arg_label_loc * Parsetree.expression) list
 
 val extract_label :
-  label -> sargs -> (arg_label * Parsetree.expression * sargs) option
+  label -> sargs -> (arg_label_loc * Parsetree.expression * sargs) option
 (* actual label, value, new list with the same order *)
 
-val label_assoc : arg_label -> sargs -> bool
+val label_assoc : arg_label_loc -> sargs -> bool
 (**** Utilities for backtracking ****)
 
 type snapshot

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -230,8 +230,7 @@ and expression_desc =
        let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
     *)
   | Pexp_fun of {
-      arg_label: arg_label;
-      label_loc: Location.t;
+      arg_label: arg_label_loc;
       default: expression option;
       lhs: pattern;
       rhs: expression;

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -77,8 +77,7 @@ and core_type_desc =
   | Ptyp_any (*  _ *)
   | Ptyp_var of string (* 'a *)
   | Ptyp_arrow of {
-      lbl: arg_label;
-      lbl_loc: Location.t;
+      lbl: arg_label_loc;
       arg: core_type;
       ret: core_type;
       arity: arity;

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -251,7 +251,7 @@ and expression_desc =
     *)
   | Pexp_apply of {
       funct: expression;
-      args: (arg_label * expression) list;
+      args: (arg_label_loc * expression) list;
       partial: bool;
     }
     (* E0 ~l1:E1 ... ~ln:En

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -287,9 +287,9 @@ let string_quot f x = pp f "`%s" x
 
 let rec type_with_label ctxt f (label, c) =
   match label with
-  | Nolabel -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (core_type1 ctxt) c
+  | Nolbl -> core_type1 ctxt f c (* otherwise parenthesize *)
+  | Lbl {txt = s} -> pp f "%s:%a" s (core_type1 ctxt) c
+  | Opt {txt = s} -> pp f "?%s:%a" s (core_type1 ctxt) c
 
 and core_type ctxt f x =
   if x.ptyp_attributes <> [] then

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -494,10 +494,10 @@ and simple_pattern ctxt (f : Format.formatter) (x : pattern) : unit =
 
 and label_exp ctxt f (l, opt, p) =
   match l with
-  | Nolabel ->
+  | Nolbl ->
     (* single case pattern parens needed here *)
     pp f "%a@ " (simple_pattern ctxt) p
-  | Optional rest -> (
+  | Opt {txt = rest} -> (
     match p with
     | {ppat_desc = Ppat_var {txt; _}; ppat_attributes = []} when txt = rest -> (
       match opt with
@@ -508,7 +508,7 @@ and label_exp ctxt f (l, opt, p) =
       | Some o ->
         pp f "?%s:(%a=@;%a)@;" rest (pattern1 ctxt) p (expression ctxt) o
       | None -> pp f "?%s:%a@;" rest (simple_pattern ctxt) p))
-  | Labelled l -> (
+  | Lbl {txt = l} -> (
     match p with
     | {ppat_desc = Ppat_var {txt; _}; ppat_attributes = []} when txt = l ->
       pp f "~%s@;" l
@@ -988,7 +988,7 @@ and binding ctxt f {pvb_pat = p; pvb_expr = x; _} =
           | Some arity -> "[arity:" ^ string_of_int arity ^ "]"
         in
         let async_str = if async then "async " else "" in
-        if label = Nolabel then
+        if label = Nolbl then
           pp f "%s%s%a@ %a" async_str arity_str (simple_pattern ctxt) p
             pp_print_pexp_function e
         else

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -523,7 +523,7 @@ and sugar_expr ctxt f e =
           funct = {pexp_desc = Pexp_ident {txt = id; _}; pexp_attributes = []; _};
           args;
         }
-      when List.for_all (fun (lab, _) -> lab = Nolabel) args -> (
+      when List.for_all (fun (lab, _) -> lab = Nolbl) args -> (
       let print_indexop a path_prefix assign left right print_index indices
           rem_args =
         let print_path ppf = function
@@ -636,7 +636,7 @@ and expression ctxt f x =
         match view_fixity_of_exp e with
         | `Infix s -> (
           match l with
-          | [((Nolabel, _) as arg1); ((Nolabel, _) as arg2)] ->
+          | [((Nolbl, _) as arg1); ((Nolbl, _) as arg2)] ->
             (* FIXME associativity label_x_expression_param *)
             pp f "@[<2>%a@;%s@;%a@]"
               (label_x_expression_param reset_ctxt)
@@ -661,7 +661,7 @@ and expression ctxt f x =
             else s
           in
           match l with
-          | [(Nolabel, x)] -> pp f "@[<2>%s@;%a@]" s (simple_expr ctxt) x
+          | [(Nolbl, x)] -> pp f "@[<2>%s@;%a@]" s (simple_expr ctxt) x
           | _ ->
             pp f "@[<2>%a %a@]" (simple_expr ctxt) e
               (list (label_x_expression_param ctxt))
@@ -1281,11 +1281,11 @@ and label_x_expression_param ctxt f (l, e) =
     | _ -> None
   in
   match l with
-  | Nolabel -> expression2 ctxt f e (* level 2*)
-  | Optional str ->
+  | Nolbl -> expression2 ctxt f e (* level 2*)
+  | Opt {txt = str} ->
     if Some str = simple_name then pp f "?%s" str
     else pp f "?%s:%a" str (simple_expr ctxt) e
-  | Labelled lbl ->
+  | Lbl {txt = lbl} ->
     if Some lbl = simple_name then pp f "~%s" lbl
     else pp f "~%s:%a" lbl (simple_expr ctxt) e
 

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -115,6 +115,11 @@ let arg_label i ppf = function
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 
+let arg_label_loc i ppf = function
+  | Nolbl -> line i ppf "Nolabel\n"
+  | Opt {txt = s} -> line i ppf "Optional \"%s\"\n" s
+  | Lbl {txt = s} -> line i ppf "Labelled \"%s\"\n" s
+
 let rec core_type i ppf x =
   line i ppf "core_type %a\n" fmt_location x.ptyp_loc;
   attributes i ppf x.ptyp_attributes;
@@ -657,7 +662,7 @@ and longident_x_expression i ppf (li, e, opt) =
 
 and label_x_expression i ppf (l, e) =
   line i ppf "<arg>\n";
-  arg_label i ppf l;
+  arg_label_loc i ppf l;
   expression (i + 1) ppf e
 
 and label_x_bool_x_core_type_list i ppf x =

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -134,7 +134,7 @@ let rec core_type i ppf x =
       | None -> ()
       | Some n -> line i ppf "arity = %d\n" n
     in
-    arg_label i ppf lbl;
+    arg_label_loc i ppf lbl;
     core_type i ppf arg;
     core_type i ppf ret
   | Ptyp_tuple l ->

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -110,10 +110,6 @@ let option i f ppf x =
 let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li
 let string i ppf s = line i ppf "\"%s\"\n" s
 let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s
-let arg_label i ppf = function
-  | Nolabel -> line i ppf "Nolabel\n"
-  | Optional s -> line i ppf "Optional \"%s\"\n" s
-  | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 
 let arg_label_loc i ppf = function
   | Nolbl -> line i ppf "Nolabel\n"
@@ -251,7 +247,7 @@ and expression i ppf x =
       | None -> ()
       | Some arity -> line i ppf "arity:%d\n" arity
     in
-    arg_label i ppf l;
+    arg_label_loc i ppf l;
     option i expression ppf eo;
     pattern i ppf p;
     expression i ppf e

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -1898,6 +1898,7 @@ let rec type_approx env sexp =
   match sexp.pexp_desc with
   | Pexp_let (_, _, e) -> type_approx env e
   | Pexp_fun {arg_label = p; rhs = e; arity} ->
+    let p = Asttypes.to_arg_label p in
     let ty = if is_optional p then type_option (newvar ()) else newvar () in
     newty (Tarrow (p, ty, type_approx env e, Cok, arity))
   | Pexp_match (_, {pc_rhs = e} :: _) -> type_approx env e
@@ -2363,6 +2364,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
         arity;
         async;
       } ->
+    let l = Asttypes.to_arg_label l in
     assert (is_optional l);
     (* default allowed only with optional argument *)
     let open Ast_helper in
@@ -2405,6 +2407,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg = Rejected) env sexp
       [Exp.case pat body]
   | Pexp_fun
       {arg_label = l; default = None; lhs = spat; rhs = sbody; arity; async} ->
+    let l = Asttypes.to_arg_label l in
     type_function ?in_function ~arity ~async loc sexp.pexp_attributes env
       ty_expected l
       [Ast_helper.Exp.case spat sbody]

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -1879,6 +1879,7 @@ and is_nonexpansive_opt = function
 let rec approx_type env sty =
   match sty.ptyp_desc with
   | Ptyp_arrow {lbl = p; ret = sty; arity} ->
+    let p = Asttypes.to_arg_label p in
     let ty1 = if is_optional p then type_option (newvar ()) else newvar () in
     newty (Tarrow (p, ty1, approx_type env sty, Cok, arity))
   | Ptyp_tuple args -> newty (Ttuple (List.map (approx_type env) args))

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -328,6 +328,7 @@ and transl_type_aux env policy styp =
     in
     ctyp (Ttyp_var name) ty
   | Ptyp_arrow {lbl; arg = st1; ret = st2; arity} ->
+    let lbl = Asttypes.to_arg_label lbl in
     let cty1 = transl_type env policy st1 in
     let cty2 = transl_type env policy st2 in
     let ty1 = cty1.ctyp_type in

--- a/compiler/syntax/src/jsx_common.ml
+++ b/compiler/syntax/src/jsx_common.ml
@@ -59,5 +59,5 @@ let async_component ~async expr =
            loc = Location.none;
            txt = Ldot (Lident "JsxPPXReactSupport", "asyncComponent");
          })
-      [(Nolabel, expr)]
+      [(Nolbl, expr)]
   else expr

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -8,18 +8,28 @@ let module_access_name config value =
   String.capitalize_ascii config.Jsx_common.module_ ^ "." ^ value
   |> Longident.parse
 
-let nolabel = Nolabel
+let nolabel = Nolbl
 
-let labelled str = Labelled str
+let labelled str = Lbl {txt = str; loc = Location.none}
 
-let is_optional str =
+let is_optional0 str =
   match str with
   | Optional _ -> true
   | _ -> false
 
-let is_labelled str =
+let is_optional str =
+  match str with
+  | Opt _ -> true
+  | _ -> false
+
+let is_labelled0 str =
   match str with
   | Labelled _ -> true
+  | _ -> false
+
+let is_labelled str =
+  match str with
+  | Lbl _ -> true
   | _ -> false
 
 let is_forward_ref = function
@@ -27,6 +37,11 @@ let is_forward_ref = function
   | _ -> false
 
 let get_label str =
+  match str with
+  | Opt {txt = str} | Lbl {txt = str} -> str
+  | Nolbl -> ""
+
+let get_label0 str =
   match str with
   | Optional str | Labelled str -> str
   | Nolabel -> ""
@@ -95,9 +110,8 @@ let extract_children ?(remove_last_position_unit = false) ~loc
   let rec allButLast_ lst acc =
     match lst with
     | [] -> []
-    | [(Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)})] ->
-      acc
-    | (Nolabel, {pexp_loc}) :: _rest ->
+    | [(Nolbl, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)})] -> acc
+    | (Nolbl, {pexp_loc}) :: _rest ->
       Jsx_common.raise_error ~loc:pexp_loc
         "JSX: found non-labelled argument before the last position"
     | arg :: rest -> allButLast_ rest (arg :: acc)
@@ -192,14 +206,13 @@ let record_from_props ~loc ~remove_key call_arguments =
   let rec remove_last_position_unit_aux props acc =
     match props with
     | [] -> acc
-    | [(Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)}, _)]
-      ->
+    | [(Nolbl, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)}, _)] ->
       acc
-    | (Nolabel, {pexp_loc}, _) :: _rest ->
+    | (Nolbl, {pexp_loc}, _) :: _rest ->
       Jsx_common.raise_error ~loc:pexp_loc
         "JSX: found non-labelled argument before the last position"
-    | ((Labelled txt, {pexp_loc}, _) as prop) :: rest
-    | ((Optional txt, {pexp_loc}, _) as prop) :: rest ->
+    | ((Lbl {txt}, {pexp_loc}, _) as prop) :: rest
+    | ((Opt {txt}, {pexp_loc}, _) as prop) :: rest ->
       if txt = spread_props_label then
         match acc with
         | [] -> remove_last_position_unit_aux rest (prop :: acc)
@@ -212,7 +225,10 @@ let record_from_props ~loc ~remove_key call_arguments =
   let props, props_to_spread =
     remove_last_position_unit_aux call_arguments []
     |> List.rev
-    |> List.partition (fun (label, _, _) -> label <> labelled "_spreadProps")
+    |> List.partition (fun (label, _, _) ->
+           match label with
+           | Lbl {txt = "_spreadProps"} -> false
+           | _ -> true)
   in
   let props =
     if remove_key then
@@ -253,7 +269,10 @@ let make_props_type_params_tvar named_type_list =
   named_type_list
   |> List.filter_map (fun (_isOptional, label, _, loc, _interiorType) ->
          if label = "key" then None
-         else Some (Typ.var ~loc @@ safe_type_from_value (Labelled label)))
+         else
+           Some
+             (Typ.var ~loc
+             @@ safe_type_from_value (Lbl {txt = label; loc = Location.none})))
 
 let strip_option core_type =
   match core_type with
@@ -322,10 +341,12 @@ let make_label_decls named_type_list =
              interior_type
          else if is_optional then
            Type.field ~loc ~attrs ~optional:true {txt = label; loc}
-             (Typ.var @@ safe_type_from_value @@ Labelled label)
+             (Typ.var @@ safe_type_from_value
+             @@ Lbl {txt = label; loc = Location.none})
          else
            Type.field ~loc ~attrs {txt = label; loc}
-             (Typ.var @@ safe_type_from_value @@ Labelled label))
+             (Typ.var @@ safe_type_from_value
+             @@ Lbl {txt = label; loc = Location.none}))
 
 let make_type_decls ~attrs props_name loc named_type_list =
   let label_decl_list = make_label_decls named_type_list in
@@ -408,7 +429,7 @@ let transform_uppercase_call3 ~config module_path mapper jsx_expr_loc
             Exp.apply
               (Exp.ident
                  {txt = module_access_name config "array"; loc = Location.none})
-              [(Nolabel, expression)],
+              [(Nolbl, expression)],
             false );
         ]
       | _ ->
@@ -540,7 +561,7 @@ let transform_lowercase_call3 ~config mapper jsx_expr_loc call_expr_loc attrs
                    txt = Ldot (element_binding, "someElement");
                    loc = Location.none;
                  })
-              [(Nolabel, children)],
+              [(Nolbl, children)],
             true );
         ]
       | ListLiteral {pexp_desc = Pexp_array list} when list = [] -> []
@@ -552,7 +573,7 @@ let transform_lowercase_call3 ~config mapper jsx_expr_loc call_expr_loc attrs
             Exp.apply
               (Exp.ident
                  {txt = module_access_name config "array"; loc = Location.none})
-              [(Nolabel, expression)],
+              [(Nolbl, expression)],
             false );
         ]
     in
@@ -653,9 +674,9 @@ let rec recursively_transform_named_args_for_make expr args newtypes core_type =
       "Ref cannot be passed as a normal prop. Please use `forwardRef` API \
        instead."
   | Pexp_fun {arg_label = arg; default; lhs = pattern; rhs = expression}
-    when is_optional arg || is_labelled arg ->
+    when is_optional0 arg || is_labelled0 arg ->
     let () =
-      match (is_optional arg, pattern, default) with
+      match (is_optional0 arg, pattern, default) with
       | true, {ppat_desc = Ppat_constraint (_, {ptyp_desc})}, None -> (
         match ptyp_desc with
         | Ptyp_constr ({txt = Lident "option"}, [_]) -> ()
@@ -686,7 +707,7 @@ let rec recursively_transform_named_args_for_make expr args newtypes core_type =
       } ->
         txt
       | {ppat_desc = Ppat_any} -> "_"
-      | _ -> get_label arg
+      | _ -> get_label0 arg
     in
     let type_ =
       match pattern with
@@ -741,19 +762,19 @@ let arg_to_type types
       arg_label * expression option * pattern * label * 'loc * core_type option)
     =
   match (type_, name, default) with
-  | Some type_, name, _ when is_optional name ->
-    (true, get_label name, attrs, loc, type_) :: types
-  | Some type_, name, _ -> (false, get_label name, attrs, loc, type_) :: types
-  | None, name, _ when is_optional name ->
-    (true, get_label name, attrs, loc, Typ.any ~loc ()) :: types
-  | None, name, _ when is_labelled name ->
-    (false, get_label name, attrs, loc, Typ.any ~loc ()) :: types
+  | Some type_, name, _ when is_optional0 name ->
+    (true, get_label0 name, attrs, loc, type_) :: types
+  | Some type_, name, _ -> (false, get_label0 name, attrs, loc, type_) :: types
+  | None, name, _ when is_optional0 name ->
+    (true, get_label0 name, attrs, loc, Typ.any ~loc ()) :: types
+  | None, name, _ when is_labelled0 name ->
+    (false, get_label0 name, attrs, loc, Typ.any ~loc ()) :: types
   | _ -> types
 
 let has_default_value name_arg_list =
   name_arg_list
   |> List.exists (fun (name, default, _, _, _, _) ->
-         Option.is_some default && is_optional name)
+         Option.is_some default && is_optional0 name)
 
 let arg_to_concrete_type types (name, attrs, loc, type_) =
   match name with
@@ -791,8 +812,7 @@ let modified_binding_old binding =
       (* here's where we spelunk! *)
       spelunk_for_fun_expression return_expression
     (* let make = React.forwardRef((~prop) => ...) *)
-    | {pexp_desc = Pexp_apply {args = [(Nolabel, inner_function_expression)]}}
-      ->
+    | {pexp_desc = Pexp_apply {args = [(Nolbl, inner_function_expression)]}} ->
       spelunk_for_fun_expression inner_function_expression
     | {
      pexp_desc = Pexp_sequence (_wrapperExpression, inner_function_expression);
@@ -870,7 +890,7 @@ let modified_binding ~binding_loc ~binding_pat_loc ~fn_name binding =
     | {
      pexp_desc =
        Pexp_apply
-         {funct = wrapper_expression; args = [(Nolabel, internal_expression)]};
+         {funct = wrapper_expression; args = [(Nolbl, internal_expression)]};
     } ->
       let () = has_application := true in
       let _, _, exp = spelunk_for_fun_expression internal_expression in
@@ -893,7 +913,7 @@ let modified_binding ~binding_loc ~binding_pat_loc ~fn_name binding =
   (wrap_expression_with_binding wrap_expression, has_forward_ref, expression)
 
 let vb_match ~expr (name, default, _, alias, loc, _) =
-  let label = get_label name in
+  let label = get_label0 name in
   match default with
   | Some default ->
     let value_binding =
@@ -972,10 +992,10 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
                 (match rec_flag with
                 | Recursive -> internal_fn_name
                 | Nonrecursive -> fn_name)))
-        ([(Nolabel, Exp.ident (Location.mknoloc @@ Lident "props"))]
+        ([(Nolbl, Exp.ident (Location.mknoloc @@ Lident "props"))]
         @
         match has_forward_ref with
-        | true -> [(Nolabel, Exp.ident (Location.mknoloc @@ Lident "ref"))]
+        | true -> [(Nolbl, Exp.ident (Location.mknoloc @@ Lident "ref"))]
         | false -> [])
     in
     let make_props_pattern = function
@@ -994,12 +1014,12 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
       (* let make = React.forwardRef({
            let \"App" = (props, ref) => make({...props, ref: @optional (Js.Nullabel.toOption(ref))})
          })*)
-      Exp.fun_ ~arity:None nolabel None
+      Exp.fun_ ~arity:None Nolabel None
         (match core_type_of_attr with
         | None -> make_props_pattern named_type_list
         | Some _ -> make_props_pattern typ_vars_of_core_type)
         (if has_forward_ref then
-           Exp.fun_ ~arity:None nolabel None
+           Exp.fun_ ~arity:None Nolabel None
              (Pat.var @@ Location.mknoloc "ref")
              inner_expression
          else inner_expression)
@@ -1057,7 +1077,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
             rhs = expr;
           } -> (
         let pattern_without_constraint =
-          strip_constraint_unpack ~label:(get_label arg_label) pattern
+          strip_constraint_unpack ~label:(get_label0 arg_label) pattern
         in
         (*
            If prop has the default value as Ident, it will get a build error
@@ -1069,14 +1089,14 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
           | Some _ -> safe_pattern_label pattern_without_constraint
           | _ -> pattern_without_constraint
         in
-        if is_labelled arg_label || is_optional arg_label then
+        if is_labelled0 arg_label || is_optional0 arg_label then
           returned_expression
-            (( {loc = ppat_loc; txt = Lident (get_label arg_label)},
+            (( {loc = ppat_loc; txt = Lident (get_label0 arg_label)},
                {
                  pattern_with_safe_label with
                  ppat_attributes = pattern.ppat_attributes;
                },
-               is_optional arg_label )
+               is_optional0 arg_label )
             :: patterns_with_label)
             patterns_with_nolabel expr
         else
@@ -1191,7 +1211,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
         match binding.pvb_expr with
         | {
          pexp_desc =
-           Pexp_apply {funct = wrapper_expr; args = [(Nolabel, func_expr)]};
+           Pexp_apply {funct = wrapper_expr; args = [(Nolbl, func_expr)]};
         }
           when is_forward_ref wrapper_expr ->
           (* Case when using React.forwardRef *)
@@ -1239,7 +1259,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
                          | Nonrecursive -> fn_name);
                      loc;
                    })
-                [(Nolabel, Exp.ident {txt = Lident "props"; loc})]))
+                [(Nolbl, Exp.ident {txt = Lident "props"; loc})]))
       in
 
       let wrapper_expr = Ast_uncurried.uncurried_fun ~arity:1 wrapper_expr in
@@ -1305,12 +1325,15 @@ let transform_structure_item ~config item =
       let rec get_prop_types types
           ({ptyp_loc; ptyp_desc; ptyp_attributes} as full_type) =
         match ptyp_desc with
-        | Ptyp_arrow {lbl = name; arg; ret = {ptyp_desc = Ptyp_arrow _} as typ2}
-          when is_labelled name || is_optional name ->
+        | Ptyp_arrow
+            {lbl = name; lbl_loc; arg; ret = {ptyp_desc = Ptyp_arrow _} as typ2}
+          when is_labelled0 name || is_optional0 name ->
+          let name = to_arg_label_loc ~loc:lbl_loc name in
           get_prop_types ((name, ptyp_attributes, ptyp_loc, arg) :: types) typ2
         | Ptyp_arrow {lbl = Nolabel; ret} -> get_prop_types types ret
-        | Ptyp_arrow {lbl = name; arg; ret = return_value}
-          when is_labelled name || is_optional name ->
+        | Ptyp_arrow {lbl = name; lbl_loc; arg; ret = return_value}
+          when is_labelled0 name || is_optional0 name ->
+          let name = to_arg_label_loc ~loc:lbl_loc name in
           ( return_value,
             (name, ptyp_attributes, return_value.ptyp_loc, arg) :: types )
         | _ -> (full_type, types)
@@ -1409,10 +1432,12 @@ let transform_signature_item ~config item =
         | Ptyp_arrow
             {
               lbl;
+              lbl_loc;
               arg = {ptyp_attributes = attrs} as type_;
               ret = {ptyp_desc = Ptyp_arrow _} as rest;
             }
-          when is_optional lbl || is_labelled lbl ->
+          when is_optional0 lbl || is_labelled0 lbl ->
+          let lbl = to_arg_label_loc ~loc:lbl_loc lbl in
           get_prop_types ((lbl, attrs, ptyp_loc, type_) :: types) rest
         | Ptyp_arrow
             {
@@ -1425,10 +1450,12 @@ let transform_signature_item ~config item =
         | Ptyp_arrow
             {
               lbl = name;
+              lbl_loc;
               arg = {ptyp_attributes = attrs} as type_;
               ret = return_value;
             }
-          when is_optional name || is_labelled name ->
+          when is_optional0 name || is_labelled0 name ->
+          let name = to_arg_label_loc ~loc:lbl_loc name in
           (return_value, (name, attrs, return_value.ptyp_loc, type_) :: types)
         | _ -> (full_type, types)
       in
@@ -1561,7 +1588,7 @@ let expr ~config mapper expression =
         Exp.apply
           (Exp.ident
              {txt = module_access_name config "array"; loc = Location.none})
-          [(Nolabel, expr)]
+          [(Nolbl, expr)]
       in
       let count_of_children = function
         | {pexp_desc = Pexp_array children} -> List.length children

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -1325,15 +1325,12 @@ let transform_structure_item ~config item =
       let rec get_prop_types types
           ({ptyp_loc; ptyp_desc; ptyp_attributes} as full_type) =
         match ptyp_desc with
-        | Ptyp_arrow
-            {lbl = name; lbl_loc; arg; ret = {ptyp_desc = Ptyp_arrow _} as typ2}
-          when is_labelled0 name || is_optional0 name ->
-          let name = to_arg_label_loc ~loc:lbl_loc name in
+        | Ptyp_arrow {lbl = name; arg; ret = {ptyp_desc = Ptyp_arrow _} as typ2}
+          when is_labelled name || is_optional name ->
           get_prop_types ((name, ptyp_attributes, ptyp_loc, arg) :: types) typ2
-        | Ptyp_arrow {lbl = Nolabel; ret} -> get_prop_types types ret
-        | Ptyp_arrow {lbl = name; lbl_loc; arg; ret = return_value}
-          when is_labelled0 name || is_optional0 name ->
-          let name = to_arg_label_loc ~loc:lbl_loc name in
+        | Ptyp_arrow {lbl = Nolbl; ret} -> get_prop_types types ret
+        | Ptyp_arrow {lbl = name; arg; ret = return_value}
+          when is_labelled name || is_optional name ->
           ( return_value,
             (name, ptyp_attributes, return_value.ptyp_loc, arg) :: types )
         | _ -> (full_type, types)
@@ -1432,30 +1429,26 @@ let transform_signature_item ~config item =
         | Ptyp_arrow
             {
               lbl;
-              lbl_loc;
               arg = {ptyp_attributes = attrs} as type_;
               ret = {ptyp_desc = Ptyp_arrow _} as rest;
             }
-          when is_optional0 lbl || is_labelled0 lbl ->
-          let lbl = to_arg_label_loc ~loc:lbl_loc lbl in
+          when is_optional lbl || is_labelled lbl ->
           get_prop_types ((lbl, attrs, ptyp_loc, type_) :: types) rest
         | Ptyp_arrow
             {
-              lbl = Nolabel;
+              lbl = Nolbl;
               arg = {ptyp_desc = Ptyp_constr ({txt = Lident "unit"}, _)};
               ret = rest;
             } ->
           get_prop_types types rest
-        | Ptyp_arrow {lbl = Nolabel; ret = rest} -> get_prop_types types rest
+        | Ptyp_arrow {lbl = Nolbl; ret = rest} -> get_prop_types types rest
         | Ptyp_arrow
             {
               lbl = name;
-              lbl_loc;
               arg = {ptyp_attributes = attrs} as type_;
               ret = return_value;
             }
-          when is_optional0 name || is_labelled0 name ->
-          let name = to_arg_label_loc ~loc:lbl_loc name in
+          when is_optional name || is_labelled name ->
           (return_value, (name, attrs, return_value.ptyp_loc, type_) :: types)
         | _ -> (full_type, types)
       in

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -844,7 +844,12 @@ module SexpAst = struct
       | Ptyp_var var -> Sexp.list [Sexp.atom "Ptyp_var"; string var]
       | Ptyp_arrow {lbl; arg; ret} ->
         Sexp.list
-          [Sexp.atom "Ptyp_arrow"; arg_label lbl; core_type arg; core_type ret]
+          [
+            Sexp.atom "Ptyp_arrow";
+            arg_label_loc lbl;
+            core_type arg;
+            core_type ret;
+          ]
       | Ptyp_tuple types ->
         Sexp.list
           [Sexp.atom "Ptyp_tuple"; Sexp.list (map_empty ~f:core_type types)]

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -117,6 +117,12 @@ module SexpAst = struct
     | Labelled txt -> Sexp.list [Sexp.atom "Labelled"; string txt]
     | Optional txt -> Sexp.list [Sexp.atom "Optional"; string txt]
 
+  let arg_label_loc lbl =
+    match lbl with
+    | Asttypes.Nolbl -> Sexp.atom "Nolabel"
+    | Lbl {txt} -> Sexp.list [Sexp.atom "Labelled"; string txt]
+    | Opt {txt} -> Sexp.list [Sexp.atom "Optional"; string txt]
+
   let constant c =
     let sexpr =
       match c with
@@ -574,7 +580,7 @@ module SexpAst = struct
             Sexp.list
               (map_empty
                  ~f:(fun (arg_lbl, expr) ->
-                   Sexp.list [arg_label arg_lbl; expression expr])
+                   Sexp.list [arg_label_loc arg_lbl; expression expr])
                  args);
           ]
       | Pexp_match (expr, cases) ->

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -111,12 +111,6 @@ module SexpAst = struct
     | Contravariant -> Sexp.atom "Contravariant"
     | Invariant -> Sexp.atom "Invariant"
 
-  let arg_label lbl =
-    match lbl with
-    | Asttypes.Nolabel -> Sexp.atom "Nolabel"
-    | Labelled txt -> Sexp.list [Sexp.atom "Labelled"; string txt]
-    | Optional txt -> Sexp.list [Sexp.atom "Optional"; string txt]
-
   let arg_label_loc lbl =
     match lbl with
     | Asttypes.Nolbl -> Sexp.atom "Nolabel"
@@ -565,7 +559,7 @@ module SexpAst = struct
         Sexp.list
           [
             Sexp.atom "Pexp_fun";
-            arg_label arg_lbl;
+            arg_label_loc arg_lbl;
             (match expr_opt with
             | None -> Sexp.atom "None"
             | Some expr -> Sexp.list [Sexp.atom "Some"; expression expr]);

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -11,25 +11,24 @@ let arrow_type ?(max_arity = max_int) ct =
       when acc <> [] ->
       (attrs_before, List.rev acc, typ)
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel as lbl; lbl_loc; arg; ret};
+     ptyp_desc = Ptyp_arrow {lbl = Nolbl as lbl; arg; ret};
      ptyp_attributes = [];
     } ->
-      let arg = ([], lbl, lbl_loc, arg) in
+      let arg = ([], lbl, arg) in
       process attrs_before (arg :: acc) ret (arity - 1)
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel};
+     ptyp_desc = Ptyp_arrow {lbl = Nolbl};
      ptyp_attributes = [({txt = "bs"}, _)];
     } ->
       (* stop here, the uncurried attribute always indicates the beginning of an arrow function
          * e.g. `(. int) => (. int)` instead of `(. int, . int)` *)
       (attrs_before, List.rev acc, typ)
-    | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = _attrs} as
+    | {ptyp_desc = Ptyp_arrow {lbl = Nolbl}; ptyp_attributes = _attrs} as
       return_type ->
       let args = List.rev acc in
       (attrs_before, args, return_type)
     | {
-     ptyp_desc =
-       Ptyp_arrow {lbl = (Labelled _ | Optional _) as lbl; lbl_loc; arg; ret};
+     ptyp_desc = Ptyp_arrow {lbl = (Lbl _ | Opt _) as lbl; arg; ret};
      ptyp_attributes = attrs;
     } ->
       (* Res_core.parse_es6_arrow_type has a workaround that removed an extra arity for the function if the
@@ -44,12 +43,12 @@ let arrow_type ?(max_arity = max_int) ct =
           arity
         | _ -> arity - 1
       in
-      let arg = (attrs, lbl, lbl_loc, arg) in
+      let arg = (attrs, lbl, arg) in
       process attrs_before (arg :: acc) ret arity
     | typ -> (attrs_before, List.rev acc, typ)
   in
   match ct with
-  | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = attrs1} as typ ->
+  | {ptyp_desc = Ptyp_arrow {lbl = Nolbl}; ptyp_attributes = attrs1} as typ ->
     process attrs1 [] {typ with ptyp_attributes = []} max_arity
   | typ -> process [] [] typ max_arity
 

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -201,10 +201,9 @@ let filter_parsing_attrs attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "res.braces" | "ns.braces" | "res.iflet" | "res.namedArgLoc"
-              | "res.ternary" | "res.await" | "res.template"
-              | "res.taggedTemplate" | "res.patVariantSpread"
-              | "res.dictPattern" );
+              ( "res.braces" | "ns.braces" | "res.iflet" | "res.ternary"
+              | "res.await" | "res.template" | "res.taggedTemplate"
+              | "res.patVariantSpread" | "res.dictPattern" );
           },
           _ ) ->
         false
@@ -287,7 +286,7 @@ let is_unary_expression expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, _arg)];
+        args = [(Nolbl, _arg)];
       }
     when is_unary_operator operator ->
     true
@@ -311,7 +310,7 @@ let is_binary_expression expr =
             pexp_desc =
               Pexp_ident {txt = Longident.Lident operator; loc = operator_loc};
           };
-        args = [(Nolabel, _operand1); (Nolabel, _operand2)];
+        args = [(Nolbl, _operand1); (Nolbl, _operand2)];
       }
     when is_binary_operator operator
          && not (operator_loc.loc_ghost && operator = "++")
@@ -386,7 +385,7 @@ let is_array_access expr =
               Pexp_ident
                 {txt = Longident.Ldot (Longident.Lident "Array", "get")};
           };
-        args = [(Nolabel, _parentExpr); (Nolabel, _memberExpr)];
+        args = [(Nolbl, _parentExpr); (Nolbl, _memberExpr)];
       } ->
     true
   | _ -> false
@@ -518,7 +517,7 @@ let should_indent_binary_expr expr =
        Pexp_apply
          {
            funct = {pexp_desc = Pexp_ident {txt = Longident.Lident sub_operator}};
-           args = [(Nolabel, _lhs); (Nolabel, _rhs)];
+           args = [(Nolbl, _lhs); (Nolbl, _rhs)];
          };
     }
       when is_binary_operator sub_operator ->
@@ -531,7 +530,7 @@ let should_indent_binary_expr expr =
      Pexp_apply
        {
          funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-         args = [(Nolabel, lhs); (Nolabel, _rhs)];
+         args = [(Nolbl, lhs); (Nolbl, _rhs)];
        };
   }
     when is_binary_operator operator ->
@@ -644,7 +643,7 @@ let is_template_literal expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"}};
-        args = [(Nolabel, _); (Nolabel, _)];
+        args = [(Nolbl, _); (Nolbl, _)];
       }
     when has_template_literal_attr expr.pexp_attributes ->
     true
@@ -715,7 +714,7 @@ let is_single_pipe_expr expr =
     | Pexp_apply
         {
           funct = {pexp_desc = Pexp_ident {txt = Longident.Lident ("->" | "|>")}};
-          args = [(Nolabel, _operand1); (Nolabel, _operand2)];
+          args = [(Nolbl, _operand1); (Nolbl, _operand2)];
         } ->
       true
     | _ -> false
@@ -724,7 +723,7 @@ let is_single_pipe_expr expr =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident ("->" | "|>")}};
-        args = [(Nolabel, operand1); (Nolabel, _operand2)];
+        args = [(Nolbl, operand1); (Nolbl, _operand2)];
       }
     when not (is_pipe_expr operand1) ->
     true

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -112,7 +112,7 @@ let rewrite_underscore_apply expr =
   match expr_fun.pexp_desc with
   | Pexp_fun
       {
-        arg_label = Nolabel;
+        arg_label = Nolbl;
         default = None;
         lhs = {ppat_desc = Ppat_var {txt = "__x"}};
         rhs = {pexp_desc = Pexp_apply {funct = call_expr; args}} as e;
@@ -142,8 +142,7 @@ let rewrite_underscore_apply expr =
 type fun_param_kind =
   | Parameter of {
       attrs: Parsetree.attributes;
-      lbl: Asttypes.arg_label;
-      lbl_loc: Location.t;
+      lbl: Asttypes.arg_label_loc;
       default_expr: Parsetree.expression option;
       pat: Parsetree.pattern;
     }
@@ -158,7 +157,6 @@ let fun_expr expr_ =
        Pexp_fun
          {
            arg_label = lbl;
-           label_loc;
            default = default_expr;
            lhs = pattern;
            rhs = return_expr;
@@ -167,9 +165,7 @@ let fun_expr expr_ =
      pexp_attributes = attrs;
     }
       when arity = None || n_fun = 0 ->
-      let parameter =
-        Parameter {attrs; lbl; lbl_loc = label_loc; default_expr; pat = pattern}
-      in
+      let parameter = Parameter {attrs; lbl; default_expr; pat = pattern} in
       collect_params ~n_fun:(n_fun + 1) ~params:(parameter :: params)
         return_expr
     | _ -> (async, List.rev params, expr)
@@ -458,7 +454,7 @@ let collect_ternary_parts expr =
 
 let parameters_should_hug parameters =
   match parameters with
-  | [Parameter {attrs = []; lbl = Asttypes.Nolabel; default_expr = None; pat}]
+  | [Parameter {attrs = []; lbl = Nolbl; default_expr = None; pat}]
     when is_huggable_pattern pat ->
     true
   | _ -> false
@@ -732,7 +728,7 @@ let is_underscore_apply_sugar expr =
   match expr.pexp_desc with
   | Pexp_fun
       {
-        arg_label = Nolabel;
+        arg_label = Nolbl;
         default = None;
         lhs = {ppat_desc = Ppat_var {txt = "__x"}};
         rhs = {pexp_desc = Pexp_apply _};

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -5,11 +5,7 @@ val arrow_type :
   ?max_arity:int ->
   Parsetree.core_type ->
   Parsetree.attributes
-  * (Parsetree.attributes
-    * Asttypes.arg_label
-    * Location.t
-    * Parsetree.core_type)
-    list
+  * (Parsetree.attributes * Asttypes.arg_label_loc * Parsetree.core_type) list
   * Parsetree.core_type
 
 val functor_type :

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -103,9 +103,9 @@ val partition_printable_attributes :
   Parsetree.attributes -> Parsetree.attributes * Parsetree.attributes
 
 val requires_special_callback_printing_last_arg :
-  (Asttypes.arg_label * Parsetree.expression) list -> bool
+  (Asttypes.arg_label_loc * Parsetree.expression) list -> bool
 val requires_special_callback_printing_first_arg :
-  (Asttypes.arg_label * Parsetree.expression) list -> bool
+  (Asttypes.arg_label_loc * Parsetree.expression) list -> bool
 
 val mod_expr_apply :
   Parsetree.module_expr -> Parsetree.module_expr list * Parsetree.module_expr

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -41,8 +41,7 @@ val collect_list_expressions :
 type fun_param_kind =
   | Parameter of {
       attrs: Parsetree.attributes;
-      lbl: Asttypes.arg_label;
-      lbl_loc: Location.t;
+      lbl: Asttypes.arg_label_loc;
       default_expr: Parsetree.expression option;
       pat: Parsetree.pattern;
     }

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4553,7 +4553,10 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
 and print_jsx_prop ~state arg cmt_tbl =
   match arg with
   | ( ((Asttypes.Lbl {txt = lbl_txt} | Opt {txt = lbl_txt}) as lbl),
-      {pexp_desc = Pexp_ident {txt = Longident.Lident ident}} )
+      {
+        pexp_attributes = [];
+        pexp_desc = Pexp_ident {txt = Longident.Lident ident};
+      } )
     when lbl_txt = ident (* jsx punning *) -> (
     match lbl with
     | Nolbl -> Doc.nil
@@ -4878,7 +4881,10 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
   match (arg_lbl, arg) with
   (* ~a (punned)*)
   | ( Lbl {txt = lbl; loc = l0},
-      {pexp_desc = Pexp_ident {txt = Longident.Lident name}} )
+      {
+        pexp_attributes = [];
+        pexp_desc = Pexp_ident {txt = Longident.Lident name};
+      } )
     when lbl = name && not (ParsetreeViewer.is_braced_expr arg) ->
     let loc = {l0 with loc_end = arg.pexp_loc.loc_end} in
     let doc = Doc.concat [Doc.tilde; print_ident_like lbl] in
@@ -4890,6 +4896,7 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
           Pexp_constraint
             ( ({pexp_desc = Pexp_ident {txt = Longident.Lident name}} as arg_expr),
               typ );
+        pexp_attributes = [];
       } )
     when lbl = name && not (ParsetreeViewer.is_braced_expr arg_expr) ->
     let loc = {l0 with loc_end = arg.pexp_loc.loc_end} in
@@ -4904,7 +4911,11 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
     in
     print_comments doc cmt_tbl loc
   (* ~a? (optional lbl punned)*)
-  | Opt {txt = lbl; loc}, {pexp_desc = Pexp_ident {txt = Longident.Lident name}}
+  | ( Opt {txt = lbl; loc},
+      {
+        pexp_desc = Pexp_ident {txt = Longident.Lident name};
+        pexp_attributes = [];
+      } )
     when lbl = name ->
     let doc = Doc.concat [Doc.tilde; print_ident_like lbl; Doc.question] in
     print_comments doc cmt_tbl loc

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -2770,7 +2770,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
     match e_fun.pexp_desc with
     | Pexp_fun
         {
-          arg_label = Nolabel;
+          arg_label = Nolbl;
           default = None;
           lhs = {ppat_desc = Ppat_var {txt = "__x"}};
           rhs = {pexp_desc = Pexp_apply _};
@@ -5041,7 +5041,7 @@ and print_expr_fun_parameters ~state ~in_callback ~async ~has_constraint
    ParsetreeViewer.Parameter
      {
        attrs = [];
-       lbl = Asttypes.Nolabel;
+       lbl = Nolbl;
        default_expr = None;
        pat = {Parsetree.ppat_desc = Ppat_any; ppat_loc};
      };
@@ -5056,7 +5056,7 @@ and print_expr_fun_parameters ~state ~in_callback ~async ~has_constraint
    ParsetreeViewer.Parameter
      {
        attrs = [];
-       lbl = Asttypes.Nolabel;
+       lbl = Nolbl;
        default_expr = None;
        pat =
          {
@@ -5082,7 +5082,7 @@ and print_expr_fun_parameters ~state ~in_callback ~async ~has_constraint
    ParsetreeViewer.Parameter
      {
        attrs = [];
-       lbl = Asttypes.Nolabel;
+       lbl = Nolbl;
        default_expr = None;
        pat =
          {ppat_desc = Ppat_construct ({txt = Longident.Lident "()"; loc}, None)};
@@ -5148,7 +5148,7 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
                     cmt_tbl lbl.Asttypes.loc)
                 lbls);
          ])
-  | Parameter {attrs; lbl; lbl_loc; default_expr; pat = pattern} ->
+  | Parameter {attrs; lbl; default_expr; pat = pattern} ->
     let attrs = print_attributes ~state attrs cmt_tbl in
     (* =defaultValue *)
     let default_expr_doc =
@@ -5162,8 +5162,8 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
      * ~from                   ->  punning *)
     let label_with_pattern =
       match (lbl, pattern) with
-      | Asttypes.Nolabel, pattern -> print_pattern ~state pattern cmt_tbl
-      | ( (Asttypes.Labelled lbl | Optional lbl),
+      | Nolbl, pattern -> print_pattern ~state pattern cmt_tbl
+      | ( (Lbl {txt = lbl} | Opt {txt = lbl}),
           {ppat_desc = Ppat_var string_loc; ppat_attributes} )
         when lbl = string_loc.txt ->
         (* ~d *)
@@ -5173,7 +5173,7 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
             Doc.text "~";
             print_ident_like lbl;
           ]
-      | ( (Asttypes.Labelled lbl | Optional lbl),
+      | ( (Lbl {txt = lbl} | Opt {txt = lbl}),
           {
             ppat_desc = Ppat_constraint ({ppat_desc = Ppat_var {txt}}, typ);
             ppat_attributes;
@@ -5188,7 +5188,7 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
             Doc.text ": ";
             print_typ_expr ~state typ cmt_tbl;
           ]
-      | (Asttypes.Labelled lbl | Optional lbl), pattern ->
+      | (Lbl {txt = lbl} | Opt {txt = lbl}), pattern ->
         (* ~b as c *)
         Doc.concat
           [
@@ -5200,7 +5200,7 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
     in
     let optional_label_suffix =
       match (lbl, default_expr) with
-      | Asttypes.Optional _, None -> Doc.text "=?"
+      | Opt _, None -> Doc.text "=?"
       | _ -> Doc.nil
     in
     let doc =
@@ -5208,6 +5208,7 @@ and print_exp_fun_parameter ~state parameter cmt_tbl =
         (Doc.concat
            [attrs; label_with_pattern; default_expr_doc; optional_label_suffix])
     in
+    let lbl_loc = Asttypes.get_lbl_loc lbl in
     let cmt_loc =
       match default_expr with
       | None -> {lbl_loc with loc_end = pattern.ppat_loc.loc_end}

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1606,7 +1606,7 @@ and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
     in
     match args with
     | [] -> Doc.nil
-    | [([], Nolabel, _, n)] ->
+    | [([], Nolbl, n)] ->
       let has_attrs_before = not (attrs_before = []) in
       let attrs =
         if has_attrs_before then
@@ -1931,23 +1931,23 @@ and print_object_field ~state (field : Parsetree.object_field) cmt_tbl =
 (* es6 arrow type arg
  * type t = (~foo: string, ~bar: float=?, unit) => unit
  * i.e. ~foo: string, ~bar: float *)
-and print_type_parameter ~state (attrs, lbl, lbl_loc, typ) cmt_tbl =
+and print_type_parameter ~state (attrs, lbl, typ) cmt_tbl =
   (* Converting .ml code to .res requires processing uncurried attributes *)
   let attrs = print_attributes ~state attrs cmt_tbl in
   let label =
     match lbl with
-    | Asttypes.Nolabel -> Doc.nil
-    | Labelled lbl ->
+    | Asttypes.Nolbl -> Doc.nil
+    | Lbl {txt = lbl} ->
       Doc.concat [Doc.text "~"; print_ident_like lbl; Doc.text ": "]
-    | Optional lbl ->
+    | Opt {txt = lbl} ->
       Doc.concat [Doc.text "~"; print_ident_like lbl; Doc.text ": "]
   in
   let optional_indicator =
     match lbl with
-    | Asttypes.Nolabel | Labelled _ -> Doc.nil
-    | Optional _lbl -> Doc.text "=?"
+    | Nolbl | Lbl _ -> Doc.nil
+    | Opt _ -> Doc.text "=?"
   in
-  let loc = {lbl_loc with loc_end = typ.ptyp_loc.loc_end} in
+  let loc = {(Asttypes.get_lbl_loc lbl) with loc_end = typ.ptyp_loc.loc_end} in
   let doc =
     Doc.group
       (Doc.concat

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1947,12 +1947,6 @@ and print_type_parameter ~state (attrs, lbl, lbl_loc, typ) cmt_tbl =
     | Asttypes.Nolabel | Labelled _ -> Doc.nil
     | Optional _lbl -> Doc.text "=?"
   in
-  let typ =
-    match typ.ptyp_attributes with
-    | ({Location.txt = "res.namedArgLoc"}, _) :: attrs ->
-      {typ with ptyp_attributes = attrs}
-    | _ -> typ
-  in
   let loc = {lbl_loc with loc_end = typ.ptyp_loc.loc_end} in
   let doc =
     Doc.group
@@ -3150,11 +3144,11 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
       | extension ->
         print_extension ~state ~at_module_lvl:false extension cmt_tbl)
     | Pexp_apply
-        {funct = e; args = [(Nolabel, {pexp_desc = Pexp_array sub_lists})]}
+        {funct = e; args = [(Nolbl, {pexp_desc = Pexp_array sub_lists})]}
       when ParsetreeViewer.is_spread_belt_array_concat e ->
       print_belt_array_concat_apply ~state sub_lists cmt_tbl
     | Pexp_apply
-        {funct = e; args = [(Nolabel, {pexp_desc = Pexp_array sub_lists})]}
+        {funct = e; args = [(Nolbl, {pexp_desc = Pexp_array sub_lists})]}
       when ParsetreeViewer.is_spread_belt_list_concat e ->
       print_belt_list_concat_apply ~state sub_lists cmt_tbl
     | Pexp_apply {funct = call_expr; args} ->
@@ -3558,7 +3552,7 @@ and print_template_literal ~state expr cmt_tbl =
     | Pexp_apply
         {
           funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"}};
-          args = [(Nolabel, arg1); (Nolabel, arg2)];
+          args = [(Nolbl, arg1); (Nolbl, arg2)];
         } ->
       let lhs = walk_expr arg1 in
       let rhs = walk_expr arg2 in
@@ -3647,7 +3641,7 @@ and print_unary_expression ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, operand)];
+        args = [(Nolbl, operand)];
       } ->
     let printed_operand =
       let doc = print_expression_with_comments ~state operand cmt_tbl in
@@ -3792,7 +3786,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
         | Pexp_apply
             {
               funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "++"; loc}};
-              args = [(Nolabel, _); (Nolabel, _)];
+              args = [(Nolbl, _); (Nolbl, _)];
             }
           when loc.loc_ghost ->
           let doc = print_template_literal ~state expr cmt_tbl in
@@ -3806,7 +3800,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
         | Pexp_apply
             {
               funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "#="}};
-              args = [(Nolabel, lhs); (Nolabel, rhs)];
+              args = [(Nolbl, lhs); (Nolbl, rhs)];
             } ->
           let rhs_doc = print_expression_with_comments ~state rhs cmt_tbl in
           let lhs_doc = print_expression_with_comments ~state lhs cmt_tbl in
@@ -3847,7 +3841,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
           {
             pexp_desc = Pexp_ident {txt = Longident.Lident (("->" | "|>") as op)};
           };
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolbl, lhs); (Nolbl, rhs)];
       }
     when not
            (ParsetreeViewer.is_binary_expression lhs
@@ -3873,7 +3867,7 @@ and print_binary_expression ~state (expr : Parsetree.expression) cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident operator}};
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolbl, lhs); (Nolbl, rhs)];
       } ->
     let is_multiline =
       lhs.pexp_loc.loc_start.pos_lnum < rhs.pexp_loc.loc_start.pos_lnum
@@ -4045,7 +4039,7 @@ and print_pexp_apply ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "##"}};
-        args = [(Nolabel, parent_expr); (Nolabel, member_expr)];
+        args = [(Nolbl, parent_expr); (Nolbl, member_expr)];
       } ->
     let parent_doc =
       let doc = print_expression_with_comments ~state parent_expr cmt_tbl in
@@ -4077,7 +4071,7 @@ and print_pexp_apply ~state expr cmt_tbl =
   | Pexp_apply
       {
         funct = {pexp_desc = Pexp_ident {txt = Longident.Lident "#="}};
-        args = [(Nolabel, lhs); (Nolabel, rhs)];
+        args = [(Nolbl, lhs); (Nolbl, rhs)];
       } -> (
     let rhs_doc =
       let doc = print_expression_with_comments ~state rhs cmt_tbl in
@@ -4114,7 +4108,7 @@ and print_pexp_apply ~state expr cmt_tbl =
               Pexp_ident
                 {txt = Longident.Ldot (Lident "Primitive_dict", "make")};
           };
-        args = [(Nolabel, key_values)];
+        args = [(Nolbl, key_values)];
       }
     when Res_parsetree_viewer.is_tuple_array key_values ->
     Doc.concat
@@ -4129,7 +4123,7 @@ and print_pexp_apply ~state expr cmt_tbl =
           {
             pexp_desc = Pexp_ident {txt = Longident.Ldot (Lident "Array", "get")};
           };
-        args = [(Nolabel, parent_expr); (Nolabel, member_expr)];
+        args = [(Nolbl, parent_expr); (Nolbl, member_expr)];
       }
     when not (ParsetreeViewer.is_rewritten_underscore_apply_sugar parent_expr)
     ->
@@ -4175,11 +4169,7 @@ and print_pexp_apply ~state expr cmt_tbl =
             pexp_desc = Pexp_ident {txt = Longident.Ldot (Lident "Array", "set")};
           };
         args =
-          [
-            (Nolabel, parent_expr);
-            (Nolabel, member_expr);
-            (Nolabel, target_expr);
-          ];
+          [(Nolbl, parent_expr); (Nolbl, member_expr); (Nolbl, target_expr)];
       } ->
     let member =
       let member_doc =
@@ -4257,7 +4247,7 @@ and print_pexp_apply ~state expr cmt_tbl =
     let args =
       if partial then
         let dummy = Ast_helper.Exp.constant ~attrs (Ast_helper.Const.int 0) in
-        args @ [(Asttypes.Labelled "...", dummy)]
+        args @ [(Asttypes.Lbl {txt = "..."; loc = Location.none}, dummy)]
       else args
     in
     let call_expr_doc =
@@ -4509,8 +4499,8 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
     match args with
     | [] -> (Doc.nil, None)
     | [
-     (Asttypes.Labelled "children", children);
-     ( Asttypes.Nolabel,
+     (Asttypes.Lbl {txt = "children"}, children);
+     ( Asttypes.Nolbl,
        {
          Parsetree.pexp_desc =
            Pexp_construct ({txt = Longident.Lident "()"}, None);
@@ -4518,20 +4508,20 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
     ] ->
       let doc = if is_self_closing children then Doc.line else Doc.nil in
       (doc, Some children)
-    | ((_, expr) as last_prop)
+    | ((e_lbl, expr) as last_prop)
       :: [
-           (Asttypes.Labelled "children", children);
-           ( Asttypes.Nolabel,
+           (Asttypes.Lbl {txt = "children"}, children);
+           ( Asttypes.Nolbl,
              {
                Parsetree.pexp_desc =
                  Pexp_construct ({txt = Longident.Lident "()"}, None);
              } );
          ] ->
       let loc =
-        match expr.Parsetree.pexp_attributes with
-        | ({Location.txt = "res.namedArgLoc"; loc}, _) :: _attrs ->
+        match e_lbl with
+        | Asttypes.Lbl {loc} | Asttypes.Opt {loc} ->
           {loc with loc_end = expr.pexp_loc.loc_end}
-        | _ -> expr.pexp_loc
+        | Nolbl -> expr.pexp_loc
       in
       let trailing_comments_present = has_trailing_comments cmt_tbl loc in
       let prop_doc = print_jsx_prop ~state last_prop cmt_tbl in
@@ -4562,48 +4552,38 @@ and print_jsx_props ~state args cmt_tbl : Doc.t * Parsetree.expression option =
 
 and print_jsx_prop ~state arg cmt_tbl =
   match arg with
-  | ( ((Asttypes.Labelled lbl_txt | Optional lbl_txt) as lbl),
-      {
-        Parsetree.pexp_attributes =
-          [({Location.txt = "res.namedArgLoc"; loc = arg_loc}, _)];
-        pexp_desc = Pexp_ident {txt = Longident.Lident ident};
-      } )
+  | ( ((Asttypes.Lbl {txt = lbl_txt} | Opt {txt = lbl_txt}) as lbl),
+      {pexp_desc = Pexp_ident {txt = Longident.Lident ident}} )
     when lbl_txt = ident (* jsx punning *) -> (
     match lbl with
-    | Nolabel -> Doc.nil
-    | Labelled _lbl -> print_comments (print_ident_like ident) cmt_tbl arg_loc
-    | Optional _lbl ->
+    | Nolbl -> Doc.nil
+    | Lbl {loc} -> print_comments (print_ident_like ident) cmt_tbl loc
+    | Opt {loc} ->
       let doc = Doc.concat [Doc.question; print_ident_like ident] in
-      print_comments doc cmt_tbl arg_loc)
-  | ( ((Asttypes.Labelled lbl_txt | Optional lbl_txt) as lbl),
+      print_comments doc cmt_tbl loc)
+  | ( ((Asttypes.Lbl {txt = lbl_txt} | Opt {txt = lbl_txt}) as lbl),
       {
         Parsetree.pexp_attributes = [];
         pexp_desc = Pexp_ident {txt = Longident.Lident ident};
       } )
     when lbl_txt = ident (* jsx punning when printing from Reason *) -> (
     match lbl with
-    | Nolabel -> Doc.nil
-    | Labelled _lbl -> print_ident_like ident
-    | Optional _lbl -> Doc.concat [Doc.question; print_ident_like ident])
-  | Asttypes.Labelled "_spreadProps", expr ->
+    | Nolbl -> Doc.nil
+    | Lbl _lbl -> print_ident_like ident
+    | Opt _lbl -> Doc.concat [Doc.question; print_ident_like ident])
+  | Asttypes.Lbl {txt = "_spreadProps"}, expr ->
     let doc = print_expression_with_comments ~state expr cmt_tbl in
     Doc.concat [Doc.lbrace; Doc.dotdotdot; doc; Doc.rbrace]
   | lbl, expr ->
-    let arg_loc, expr =
-      match expr.pexp_attributes with
-      | ({Location.txt = "res.namedArgLoc"; loc}, _) :: attrs ->
-        (loc, {expr with pexp_attributes = attrs})
-      | _ -> (Location.none, expr)
-    in
-    let lbl_doc =
+    let arg_loc, lbl_doc =
       match lbl with
-      | Asttypes.Labelled lbl ->
-        let lbl = print_comments (print_ident_like lbl) cmt_tbl arg_loc in
-        Doc.concat [lbl; Doc.equal]
-      | Asttypes.Optional lbl ->
-        let lbl = print_comments (print_ident_like lbl) cmt_tbl arg_loc in
-        Doc.concat [lbl; Doc.equal; Doc.question]
-      | Nolabel -> Doc.nil
+      | Asttypes.Lbl {txt = lbl; loc} ->
+        let lbl = print_comments (print_ident_like lbl) cmt_tbl loc in
+        (loc, Doc.concat [lbl; Doc.equal])
+      | Asttypes.Opt {txt = lbl; loc} ->
+        let lbl = print_comments (print_ident_like lbl) cmt_tbl loc in
+        (loc, Doc.concat [lbl; Doc.equal; Doc.question])
+      | Nolbl -> (Location.none, Doc.nil)
     in
     let expr_doc =
       let leading_line_comment_present =
@@ -4653,10 +4633,10 @@ and print_arguments_with_callback_in_first_position ~state ~partial args cmt_tbl
     | (lbl, expr) :: args ->
       let lbl_doc =
         match lbl with
-        | Asttypes.Nolabel -> Doc.nil
-        | Asttypes.Labelled txt ->
+        | Asttypes.Nolbl -> Doc.nil
+        | Asttypes.Lbl {txt} ->
           Doc.concat [Doc.tilde; print_ident_like txt; Doc.equal]
-        | Asttypes.Optional txt ->
+        | Asttypes.Opt {txt} ->
           Doc.concat [Doc.tilde; print_ident_like txt; Doc.equal; Doc.question]
       in
       let callback =
@@ -4741,10 +4721,10 @@ and print_arguments_with_callback_in_last_position ~state ~partial args cmt_tbl
     | [(lbl, expr)] ->
       let lbl_doc =
         match lbl with
-        | Asttypes.Nolabel -> Doc.nil
-        | Asttypes.Labelled txt ->
+        | Asttypes.Nolbl -> Doc.nil
+        | Asttypes.Lbl {txt} ->
           Doc.concat [Doc.tilde; print_ident_like txt; Doc.equal]
-        | Asttypes.Optional txt ->
+        | Asttypes.Opt {txt} ->
           Doc.concat [Doc.tilde; print_ident_like txt; Doc.equal; Doc.question]
       in
       let callback_fits_on_one_line =
@@ -4833,10 +4813,10 @@ and print_arguments_with_callback_in_last_position ~state ~partial args cmt_tbl
       ]
 
 and print_arguments ~state ~partial
-    (args : (Asttypes.arg_label * Parsetree.expression) list) cmt_tbl =
+    (args : (Asttypes.arg_label_loc * Parsetree.expression) list) cmt_tbl =
   match args with
   | [
-   ( Nolabel,
+   ( Nolbl,
      {
        pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _);
        pexp_loc = loc;
@@ -4851,7 +4831,7 @@ and print_arguments ~state ~partial
           Doc.rparen;
         ]
     else Doc.text "()"
-  | [(Nolabel, arg)] when ParsetreeViewer.is_huggable_expression arg ->
+  | [(Nolbl, arg)] when ParsetreeViewer.is_huggable_expression arg ->
     let arg_doc =
       let doc = print_expression_with_comments ~state arg cmt_tbl in
       match Parens.expr arg with
@@ -4897,37 +4877,22 @@ and print_arguments ~state ~partial
 and print_argument ~state (arg_lbl, arg) cmt_tbl =
   match (arg_lbl, arg) with
   (* ~a (punned)*)
-  | ( Labelled lbl,
-      ({
-         pexp_desc = Pexp_ident {txt = Longident.Lident name};
-         pexp_attributes = [] | [({Location.txt = "res.namedArgLoc"}, _)];
-       } as arg_expr) )
-    when lbl = name && not (ParsetreeViewer.is_braced_expr arg_expr) ->
-    let loc =
-      match arg.pexp_attributes with
-      | ({Location.txt = "res.namedArgLoc"; loc}, _) :: _ -> loc
-      | _ -> arg.pexp_loc
-    in
+  | ( Lbl {txt = lbl; loc = l0},
+      {pexp_desc = Pexp_ident {txt = Longident.Lident name}} )
+    when lbl = name && not (ParsetreeViewer.is_braced_expr arg) ->
+    let loc = {l0 with loc_end = arg.pexp_loc.loc_end} in
     let doc = Doc.concat [Doc.tilde; print_ident_like lbl] in
     print_comments doc cmt_tbl loc
   (* ~a: int (punned)*)
-  | ( Labelled lbl,
+  | ( Lbl {txt = lbl; loc = l0},
       {
         pexp_desc =
           Pexp_constraint
             ( ({pexp_desc = Pexp_ident {txt = Longident.Lident name}} as arg_expr),
               typ );
-        pexp_loc;
-        pexp_attributes =
-          ([] | [({Location.txt = "res.namedArgLoc"}, _)]) as attrs;
       } )
     when lbl = name && not (ParsetreeViewer.is_braced_expr arg_expr) ->
-    let loc =
-      match attrs with
-      | ({Location.txt = "res.namedArgLoc"; loc}, _) :: _ ->
-        {loc with loc_end = pexp_loc.loc_end}
-      | _ -> arg.pexp_loc
-    in
+    let loc = {l0 with loc_end = arg.pexp_loc.loc_end} in
     let doc =
       Doc.concat
         [
@@ -4939,40 +4904,28 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
     in
     print_comments doc cmt_tbl loc
   (* ~a? (optional lbl punned)*)
-  | ( Optional lbl,
-      {
-        pexp_desc = Pexp_ident {txt = Longident.Lident name};
-        pexp_attributes = [] | [({Location.txt = "res.namedArgLoc"}, _)];
-      } )
+  | Opt {txt = lbl; loc}, {pexp_desc = Pexp_ident {txt = Longident.Lident name}}
     when lbl = name ->
-    let loc =
-      match arg.pexp_attributes with
-      | ({Location.txt = "res.namedArgLoc"; loc}, _) :: _ -> loc
-      | _ -> arg.pexp_loc
-    in
     let doc = Doc.concat [Doc.tilde; print_ident_like lbl; Doc.question] in
     print_comments doc cmt_tbl loc
   | _lbl, expr ->
-    let arg_loc, expr =
-      match expr.pexp_attributes with
-      | ({Location.txt = "res.namedArgLoc"; loc}, _) :: attrs ->
-        (loc, {expr with pexp_attributes = attrs})
-      | _ -> (expr.pexp_loc, expr)
-    in
-    let printed_lbl, dotdotdot =
+    let arg_loc, printed_lbl, dotdotdot =
       match arg_lbl with
-      | Nolabel -> (Doc.nil, false)
-      | Labelled "..." ->
+      | Nolbl -> (expr.pexp_loc, Doc.nil, false)
+      | Lbl {txt = "..."; loc} ->
+        let arg_loc = loc in
         let doc = Doc.text "..." in
-        (print_comments doc cmt_tbl arg_loc, true)
-      | Labelled lbl ->
+        (loc, print_comments doc cmt_tbl arg_loc, true)
+      | Lbl {txt = lbl; loc} ->
+        let arg_loc = loc in
         let doc = Doc.concat [Doc.tilde; print_ident_like lbl; Doc.equal] in
-        (print_comments doc cmt_tbl arg_loc, false)
-      | Optional lbl ->
+        (loc, print_comments doc cmt_tbl arg_loc, false)
+      | Opt {txt = lbl; loc} ->
+        let arg_loc = loc in
         let doc =
           Doc.concat [Doc.tilde; print_ident_like lbl; Doc.equal; Doc.question]
         in
-        (print_comments doc cmt_tbl arg_loc, false)
+        (loc, print_comments doc cmt_tbl arg_loc, false)
     in
     let printed_expr =
       let doc = print_expression_with_comments ~state expr cmt_tbl in

--- a/tests/syntax_tests/data/parsing/errors/expressions/expected/jsx.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/expressions/expected/jsx.res.txt
@@ -65,6 +65,4 @@ let x =
     ([%rescript.exprhole ])
 let x =
   ((Foo.bar.createElement ~children:[] ())[@JSX ]) > ([%rescript.exprhole ])
-let x =
-  ((Foo.bar.createElement ~baz:((baz)[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
+let x = ((Foo.bar.createElement ~baz ~children:[] ())[@JSX ])

--- a/tests/syntax_tests/data/parsing/errors/structure/expected/gh16B.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/structure/expected/gh16B.res.txt
@@ -35,6 +35,6 @@ module ClientSet =
                                        (b -> Client.getUniqueId))
                                    [@res.braces ])
                                end)
-    let empty = Belt.Set.make ~id:(((module T))[@res.namedArgLoc ])
+    let empty = Belt.Set.make ~id:(module T)
   end
 ;;Js.log {js|test|js}

--- a/tests/syntax_tests/data/parsing/errors/typexpr/expected/arrow.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/typexpr/expected/arrow.res.txt
@@ -46,6 +46,5 @@ module Error3 =
     type nonrec observation =
       {
       observed: int ;
-      onStep:
-        currentValue:((unit)[@res.namedArgLoc ]) -> [%rescript.typehole ] }
+      onStep: currentValue:unit -> [%rescript.typehole ] }
   end

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/apply.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/apply.res.txt
@@ -5,5 +5,5 @@
 ;;List.map (fun [arity:1]x -> x + 1) myList
 ;;List.reduce (fun [arity:2]acc -> fun curr -> acc + curr) 0 myList
 let unitUncurried = apply ()
-;;call ~a:(((((a)[@res.namedArgLoc ]) : int))[@res.namedArgLoc ])
+;;call ~a:(a : int)
 ;;call_partial 3 ...

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/argument.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/argument.res.txt
@@ -1,11 +1,9 @@
 let foo [arity:1]~a  = (a ()) +. 1.
 let a [arity:1]() = 2
-let bar = foo ~a:((a)[@res.namedArgLoc ])
-let comparisonResult =
-  compare currentNode.value ~targetValue:((targetValue)[@res.namedArgLoc ])
-;;callback firstNode ~y:((y)[@res.namedArgLoc ])
+let bar = foo ~a
+let comparisonResult = compare currentNode.value ~targetValue
+;;callback firstNode ~y
 ;;document.createElementWithOptions {js|div|js}
-    (elementProps ~onClick:((fun [arity:1]_ -> Js.log {js|hello world|js})
-       [@res.namedArgLoc ]))
+    (elementProps ~onClick:(fun [arity:1]_ -> Js.log {js|hello world|js}))
 ;;resolve ()
 ;;resolve ()

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/async.res.txt
@@ -21,11 +21,11 @@ let f =
     then async fun [arity:2]a -> fun b -> (a + b : int)
     else (async fun [arity:2]c -> fun d -> (c - d : int)))
   [@res.ternary ])
-let foo = async ~a:((34)[@res.namedArgLoc ])
+let foo = async ~a:34
 let bar async [arity:1]~a  = a + 1
 let ex1 = ((3)[@res.await ]) + ((4)[@res.await ])
 let ex2 = ((3)[@res.await ]) ** ((4)[@res.await ])
-let ex3 = ((foo -> (bar ~arg:((arg)[@res.namedArgLoc ])))[@res.await ])
+let ex3 = ((foo -> (bar ~arg))[@res.await ])
 let ex4 = (((foo.bar).baz)[@res.await ])
 let attr1 = ((async fun [arity:1]x -> x + 1)[@a ])
 let attr2 = ((fun (type a) ->

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/binaryNoEs6Arrow.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/binaryNoEs6Arrow.res.txt
@@ -29,6 +29,5 @@
                            ({ startTime = (percent *. duration) } : Video.chapter) in
                          { a; b } -> onChange
                      | _ -> ())
-                   [@res.braces ]))[@res.namedArgLoc ][@res.braces ])
-      ~children:[] ())[@JSX ])
+                   [@res.braces ]))[@res.braces ]) ~children:[] ())[@JSX ])
 ;;if inclusions.(index) <- (uid, url) then onChange inclusions

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/firstClassModule.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/firstClassModule.res.txt
@@ -33,13 +33,11 @@ let unique_instance = build_instance (module Unique) 0
 let build_dispatch_table [arity:1]handlers =
   ((let table = Hashtbl.create (module String) in
     List.iter handlers
-      ~f:((fun
-             [arity:1](((module I)  : (module Query_handler_instance)) as
-                         instance)
-             ->
-             Hashtbl.set table ~key:((I.Query_handler.name)
-               [@res.namedArgLoc ]) ~data:((instance)[@res.namedArgLoc ]))
-      [@res.namedArgLoc ]) table)
+      ~f:(fun
+            [arity:1](((module I)  : (module Query_handler_instance)) as
+                        instance)
+            -> Hashtbl.set table ~key:I.Query_handler.name ~data:instance)
+      table)
   [@res.braces ])
 ;;(module Three)
 ;;((module Three) : (module X_int))

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/jsx.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/jsx.res.txt
@@ -1,29 +1,23 @@
 let _ = ((div ~children:[] ())[@JSX ])
 let _ = ((div ~children:[] ())[@JSX ])
-let _ = ((div ~className:(({js|menu|js})[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
-let _ = ((div ~className:(({js|menu|js})[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
-let _ = ((div ~className:(({js|menu|js})[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
-let _ = ((div ~className:(({js|menu|js})[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
+let _ = ((div ~className:{js|menu|js} ~children:[] ())[@JSX ])
+let _ = ((div ~className:{js|menu|js} ~children:[] ())[@JSX ])
+let _ = ((div ~className:{js|menu|js} ~children:[] ())[@JSX ])
+let _ = ((div ~className:{js|menu|js} ~children:[] ())[@JSX ])
 let _ =
-  ((div ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~onClick:((fun [arity:1]_ -> Js.log {js|click|js})
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
-  [@JSX ])
-let _ =
-  ((div ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~onClick:((fun [arity:1]_ -> Js.log {js|click|js})
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
-  [@JSX ])
-let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
-let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
-let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
-let _ =
-  ((Navbar.createElement ~className:(({js|menu|js})[@res.namedArgLoc ])
+  ((div ~className:{js|menu|js}
+      ~onClick:((fun [arity:1]_ -> Js.log {js|click|js})[@res.braces ])
       ~children:[] ())
+  [@JSX ])
+let _ =
+  ((div ~className:{js|menu|js}
+      ~onClick:((fun [arity:1]_ -> Js.log {js|click|js})[@res.braces ])
+      ~children:[] ())
+  [@JSX ])
+let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Navbar.createElement ~className:{js|menu|js} ~children:[] ())
   [@JSX ])
 let _ = ((Dot.Up.createElement ~children:[] ())[@JSX ])
 let _ = ((Dot.Up.createElement ~children:[] ())[@JSX ])
@@ -36,9 +30,7 @@ let _ =
   ((Dot.Up.createElement
       ~children:[((Dot.Up.createElement ~children:[] ())[@JSX ])] ())
   [@JSX ])
-let _ =
-  ((Dot.Up.createElement ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~children:[] ())
+let _ = ((Dot.Up.createElement ~className:{js|menu|js} ~children:[] ())
   [@JSX ])
 let _ = ((Dot.low.createElement ~children:[] ())[@JSX ])
 let _ = ((Dot.low.createElement ~children:[] ())[@JSX ])
@@ -51,34 +43,28 @@ let _ =
   ((Dot.low.createElement
       ~children:[((Dot.low.createElement ~children:[] ())[@JSX ])] ())
   [@JSX ])
-let _ =
-  ((Dot.low.createElement ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~children:[] ())
+let _ = ((Dot.low.createElement ~className:{js|menu|js} ~children:[] ())
   [@JSX ])
-let _ = ((el ~punned:((punned)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
-let _ = ((el ?punned:((punned)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
-let _ = ((el ~punned:((punned)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
-let _ = ((el ?punned:((punned)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
-let _ = ((el ?a:((b)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
-let _ = ((el ?a:((b)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
+let _ = ((el ~punned ~children:[] ())[@JSX ])
+let _ = ((el ?punned ~children:[] ())[@JSX ])
+let _ = ((el ~punned ~children:[] ())[@JSX ])
+let _ = ((el ?punned ~children:[] ())[@JSX ])
+let _ = ((el ?a:b ~children:[] ())[@JSX ])
+let _ = ((el ?a:b ~children:[] ())[@JSX ])
 let _ = (([])[@JSX ])
 let _ = (([])[@JSX ])
 let _ =
-  ((div ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~children:[((div ~className:(({js|submenu|js})[@res.namedArgLoc ])
-                     ~children:[sub1] ())
+  ((div ~className:{js|menu|js}
+      ~children:[((div ~className:{js|submenu|js} ~children:[sub1] ())
                 [@JSX ]);
-                ((div ~className:(({js|submenu|js})[@res.namedArgLoc ])
-                    ~children:[sub2] ())
+                ((div ~className:{js|submenu|js} ~children:[sub2] ())
                 [@JSX ])] ())
   [@JSX ])
 let _ =
-  ((div ~className:(({js|menu|js})[@res.namedArgLoc ])
-      ~children:[((div ~className:(({js|submenu|js})[@res.namedArgLoc ])
-                     ~children:[sub1] ())
+  ((div ~className:{js|menu|js}
+      ~children:[((div ~className:{js|submenu|js} ~children:[sub1] ())
                 [@JSX ]);
-                ((div ~className:(({js|submenu|js})[@res.namedArgLoc ])
-                    ~children:[sub2] ())
+                ((div ~className:{js|submenu|js} ~children:[sub2] ())
                 [@JSX ])] ())
   [@JSX ])
 let _ = ((div ~children:child ())[@JSX ])
@@ -95,27 +81,23 @@ let _ =
   [@JSX ])
 let _ =
   ((Outer.createElement ~inner:((Inner.createElement ~children:[] ())
-      [@res.namedArgLoc ][@JSX ]) ~children:[] ())
+      [@JSX ]) ~children:[] ())
   [@JSX ])
 let _ =
-  ((div ~onClick:((onClickHandler)[@res.namedArgLoc ])
-      ~children:[(([{js|foobar|js}])[@JSX ])] ())
+  ((div ~onClick:onClickHandler ~children:[(([{js|foobar|js}])[@JSX ])] ())
   [@JSX ])
 let _ =
   ((Window.createElement
-      ~style:(({
-                 width = 10;
-                 height = 10;
-                 paddingTop = 10;
-                 paddingLeft = 10;
-                 paddingRight = 10;
-                 paddingBottom = 10
-               })[@res.namedArgLoc ]) ~children:[] ())
+      ~style:{
+               width = 10;
+               height = 10;
+               paddingTop = 10;
+               paddingLeft = 10;
+               paddingRight = 10;
+               paddingBottom = 10
+             } ~children:[] ())
   [@JSX ])
-let _ =
-  ((OverEager.createElement ~fiber:((Metal.fiber)[@res.namedArgLoc ])
-      ~children:[] ())
-  [@JSX ])
+let _ = ((OverEager.createElement ~fiber:Metal.fiber ~children:[] ())[@JSX ])
 let arrayOfListOfJsx = [|(([])[@JSX ])|]
 let arrayOfListOfJsx =
   [|(([((Foo.createElement ~children:[] ())[@JSX ])])[@JSX ])|]
@@ -146,8 +128,7 @@ let _ = ((a ~children:[] ())[@JSX ]) > ((b ~children:[] ())[@JSX ])
 let _ = ((a ~children:[] ())[@JSX ]) < ((b ~children:[] ())[@JSX ])
 let _ = ((a ~children:[] ())[@JSX ]) > ((b ~children:[] ())[@JSX ])
 let y =
-  ((Routes.createElement ~path:((Routes.stateToPath state)
-      [@res.namedArgLoc ]) ~isHistorical:((true)[@res.namedArgLoc ])
+  ((Routes.createElement ~path:(Routes.stateToPath state) ~isHistorical:true
       ~onHashChange:((fun [arity:3]_oldPath ->
                         fun _oldUrl ->
                           fun newUrl ->
@@ -167,47 +148,37 @@ let y =
                                               currentActualPath)
                                            latestComponentBag ())
                                        [@res.ternary ]))
-                                   [@res.braces ])) ())
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                                   [@res.braces ])) ())[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let z =
   ((div
-      ~style:((ReactDOMRe.Style.make ~width:((width)[@res.namedArgLoc ])
-                 ~height:((height)[@res.namedArgLoc ]) ~color:((color)
-                 [@res.namedArgLoc ]) ~backgroundColor:((backgroundColor)
-                 [@res.namedArgLoc ]) ~margin:((margin)[@res.namedArgLoc ])
-                 ~padding:((padding)[@res.namedArgLoc ]) ~border:((border)
-                 [@res.namedArgLoc ]) ~borderColor:((borderColor)
-                 [@res.namedArgLoc ])
-                 ~someOtherAttribute:((someOtherAttribute)
-                 [@res.namedArgLoc ]) ())[@res.namedArgLoc ])
-      ~key:((string_of_int 1)[@res.namedArgLoc ]) ~children:[] ())
+      ~style:(ReactDOMRe.Style.make ~width ~height ~color ~backgroundColor
+                ~margin ~padding ~border ~borderColor ~someOtherAttribute ())
+      ~key:(string_of_int 1) ~children:[] ())
   [@JSX ])
 let omega =
   ((div
-      ~aList:(([width;
-               height;
-               color;
-               backgroundColor;
-               margin;
-               padding;
-               border;
-               borderColor;
-               someOtherAttribute])[@res.namedArgLoc ])
-      ~key:((string_of_int 1)[@res.namedArgLoc ]) ~children:[] ())
+      ~aList:[width;
+             height;
+             color;
+             backgroundColor;
+             margin;
+             padding;
+             border;
+             borderColor;
+             someOtherAttribute] ~key:(string_of_int 1) ~children:[] ())
   [@JSX ])
 let someArray =
   ((div
-      ~anArray:(([|width;height;color;backgroundColor;margin;padding;border;borderColor;someOtherAttribute|])
-      [@res.namedArgLoc ]) ~key:((string_of_int 1)[@res.namedArgLoc ])
-      ~children:[] ())
+      ~anArray:[|width;height;color;backgroundColor;margin;padding;border;borderColor;someOtherAttribute|]
+      ~key:(string_of_int 1) ~children:[] ())
   [@JSX ])
 let tuples =
   ((div
-      ~aTuple:(((width, height, color, backgroundColor, margin, padding,
-                  border, borderColor, someOtherAttribute,
-                  definitelyBreakere))[@res.namedArgLoc ])
-      ~key:((string_of_int 1)[@res.namedArgLoc ]) ~children:[] ())
+      ~aTuple:(width, height, color, backgroundColor, margin, padding,
+                border, borderColor, someOtherAttribute, definitelyBreakere)
+      ~key:(string_of_int 1) ~children:[] ())
   [@JSX ])
 let icon =
   ((Icon.createElement
@@ -215,124 +186,100 @@ let icon =
               | v when v < 0.1 -> {js|sound-off|js}
               | v when v < 0.11 -> {js|sound-min|js}
               | v when v < 0.51 -> {js|sound-med|js}
-              | _ -> {js|sound-max|js})[@res.namedArgLoc ][@res.braces ])
-      ~children:[] ())
+              | _ -> {js|sound-max|js})[@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((MessengerSharedPhotosAlbumViewPhotoReact.createElement
       ?ref:((if foo#bar === baz
              then Some (foooooooooooooooooooooooo setRefChild)
-             else None)[@res.namedArgLoc ][@res.ternary ])
-      ~key:((node#legacy_attachment_id)[@res.namedArgLoc ]) ~children:[] ())
+             else None)[@res.ternary ]) ~key:(node#legacy_attachment_id)
+      ~children:[] ())
   [@JSX ])
-let _ = ((Foo.createElement ~bar:((bar)[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
-let _ = ((Foo.createElement ?bar:((bar)[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
-let _ =
-  ((Foo.createElement ?bar:((Baz.bar)[@res.namedArgLoc ]) ~children:[] ())
-  [@JSX ])
+let _ = ((Foo.createElement ~bar ~children:[] ())[@JSX ])
+let _ = ((Foo.createElement ?bar ~children:[] ())[@JSX ])
+let _ = ((Foo.createElement ?bar:Baz.bar ~children:[] ())[@JSX ])
 let x = ((div ~children:[] ())[@JSX ])
-let _ = ((div ~asd:((1)[@res.namedArgLoc ]) ~children:[] ())[@JSX ])
+let _ = ((div ~asd:1 ~children:[] ())[@JSX ])
 ;;foo#bar #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 let x = [|((div ~children:[] ())[@JSX ])|]
 let z = ((div ~children:[] ())[@JSX ])
 let z =
-  (((Button.createElement ~onClick:((handleStaleClick)[@res.namedArgLoc ])
-       ~children:[] ())[@JSX ]),
-    ((Button.createElement ~onClick:((handleStaleClick)[@res.namedArgLoc ])
-        ~children:[] ())[@JSX ]))
+  (((Button.createElement ~onClick:handleStaleClick ~children:[] ())[@JSX ]),
+    ((Button.createElement ~onClick:handleStaleClick ~children:[] ())
+    [@JSX ]))
 let y = [|((div ~children:[] ())[@JSX ]);((div ~children:[] ())[@JSX ])|]
 let y =
-  [|((Button.createElement ~onClick:((handleStaleClick)[@res.namedArgLoc ])
-        ~children:[] ())
-    [@JSX ]);((Button.createElement ~onClick:((handleStaleClick)
-                 [@res.namedArgLoc ]) ~children:[] ())
+  [|((Button.createElement ~onClick:handleStaleClick ~children:[] ())
+    [@JSX ]);((Button.createElement ~onClick:handleStaleClick ~children:[] ())
     [@JSX ])|]
 let _ =
   ((Description.createElement
-      ~term:((Text.createElement ~text:(({js|Age|js})[@res.namedArgLoc ])
-                ~children:[] ())[@res.namedArgLoc ][@res.braces ][@JSX ])
+      ~term:((Text.createElement ~text:{js|Age|js} ~children:[] ())
+      [@res.braces ][@JSX ]) ~children:[child] ())
+  [@JSX ])
+let _ =
+  ((Description.createElement
+      ~term:((Text.createElement ~text:{js|Age|js} ~children:[||] ())
+      [@res.braces ]) ~children:[child] ())
+  [@JSX ])
+let _ =
+  ((Description.createElement
+      ~term:((Text.createElement ~text:{js|Age|js} ())[@res.braces ][@JSX ])
       ~children:[child] ())
   [@JSX ])
 let _ =
   ((Description.createElement
-      ~term:((Text.createElement ~text:(({js|Age|js})[@res.namedArgLoc ])
-                ~children:(([||])[@res.namedArgLoc ]) ())
-      [@res.namedArgLoc ][@res.braces ]) ~children:[child] ())
-  [@JSX ])
-let _ =
-  ((Description.createElement
-      ~term:((Text.createElement ~text:(({js|Age|js})[@res.namedArgLoc ]) ())
-      [@res.namedArgLoc ][@res.braces ][@JSX ]) ~children:[child] ())
-  [@JSX ])
-let _ =
-  ((Description.createElement
-      ~term:((Text.createElement ~superLongPunnedProp:((superLongPunnedProp)
-                [@res.namedArgLoc ])
-                ~anotherSuperLongOneCrazyLongThingHere:((anotherSuperLongOneCrazyLongThingHere)
-                [@res.namedArgLoc ]) ~text:(({js|Age|js})[@res.namedArgLoc ])
-                ~children:[] ())[@res.namedArgLoc ][@res.braces ][@JSX ])
-      ~children:[child] ())
+      ~term:((Text.createElement ~superLongPunnedProp
+                ~anotherSuperLongOneCrazyLongThingHere ~text:{js|Age|js}
+                ~children:[] ())[@res.braces ][@JSX ]) ~children:[child] ())
   [@JSX ])
 let _ =
   ((Foo.createElement
-      ~bar:((Baz.createElement ~superLongPunnedProp:((superLongPunnedProp)
-               [@res.namedArgLoc ])
-               ~anotherSuperLongOneCrazyLongThingHere:((anotherSuperLongOneCrazyLongThingHere)
-               [@res.namedArgLoc ]) ~children:[] ())
-      [@res.namedArgLoc ][@res.braces ][@JSX ]) ~children:[] ())
+      ~bar:((Baz.createElement ~superLongPunnedProp
+               ~anotherSuperLongOneCrazyLongThingHere ~children:[] ())
+      [@res.braces ][@JSX ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((div ~children:[((span ~children:[str {js|hello|js}] ())[@JSX ])] ())
   [@JSX ])
 let _ =
-  ((description
-      ~term:((text ~text:(({js|Age|js})[@res.namedArgLoc ]) ~children:[] ())
-      [@res.namedArgLoc ][@res.braces ][@JSX ]) ~children:[child] ())
+  ((description ~term:((text ~text:{js|Age|js} ~children:[] ())
+      [@res.braces ][@JSX ]) ~children:[child] ())
   [@JSX ])
 let _ =
-  ((description
-      ~term:((text ~text:(({js|Age|js})[@res.namedArgLoc ]) ~children:((
-                [||])[@res.namedArgLoc ]) ())
-      [@res.namedArgLoc ][@res.braces ]) ~children:[child] ())
+  ((description ~term:((text ~text:{js|Age|js} ~children:[||] ())
+      [@res.braces ]) ~children:[child] ())
   [@JSX ])
 let _ =
-  ((description
-      ~term:((text ~text:(({js|Age|js})[@res.namedArgLoc ]) ~children:((
-                [||])[@res.namedArgLoc ]))
-      [@res.namedArgLoc ][@res.braces ][@JSX ]) ~children:[child] ())
+  ((description ~term:((text ~text:{js|Age|js} ~children:[||])
+      [@res.braces ][@JSX ]) ~children:[child] ())
   [@JSX ])
 let _ =
-  ((description ~term:((text ~text:(({js|Age|js})[@res.namedArgLoc ]) ())
-      [@res.namedArgLoc ][@res.braces ][@JSX ]) ~children:[child] ())
-  [@JSX ])
-let _ =
-  ((description
-      ~term:((div ~superLongPunnedProp:((superLongPunnedProp)
-                [@res.namedArgLoc ])
-                ~anotherSuperLongOneCrazyLongThingHere:((anotherSuperLongOneCrazyLongThingHere)
-                [@res.namedArgLoc ]) ~text:(({js|Age|js})[@res.namedArgLoc ])
-                ~children:[] ())[@res.namedArgLoc ][@res.braces ][@JSX ])
+  ((description ~term:((text ~text:{js|Age|js} ())[@res.braces ][@JSX ])
       ~children:[child] ())
   [@JSX ])
 let _ =
-  ((div ~onClick:((fun [arity:1]event -> handleChange event)
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+  ((description
+      ~term:((div ~superLongPunnedProp ~anotherSuperLongOneCrazyLongThingHere
+                ~text:{js|Age|js} ~children:[] ())[@res.braces ][@JSX ])
+      ~children:[child] ())
+  [@JSX ])
+let _ =
+  ((div ~onClick:((fun [arity:1]event -> handleChange event)[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let _ =
   ((div
       ~onClick:((fun [arity:1]eventWithLongIdent ->
-                   handleChange eventWithLongIdent)
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                   handleChange eventWithLongIdent)[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let _ =
   ((div
       ~onClick:((fun [arity:1]event -> ((Js.log event; handleChange event)
-                   [@res.braces ]))[@res.namedArgLoc ][@res.braces ])
-      ~children:[] ())
+                   [@res.braces ]))[@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((StaticDiv.createElement
@@ -342,19 +289,18 @@ let _ =
                        fun lineBreak ->
                          fun identifier ->
                            ((doStuff foo bar baz; bar lineBreak identifier)
-                           [@res.braces ]))[@res.namedArgLoc ][@res.braces ])
-      ~children:[] ())
+                           [@res.braces ]))[@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((AttrDiv.createElement
       ~onClick:((fun [arity:1]event -> handleChange event)
-      [@res.namedArgLoc ][@res.braces ][@bar ]) ~children:[] ())
+      [@res.braces ][@bar ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((AttrDiv.createElement
       ~onClick:((fun [arity:1]eventLongIdentifier ->
-                   handleChange eventLongIdentifier)
-      [@res.namedArgLoc ][@res.braces ][@bar ]) ~children:[] ())
+                   handleChange eventLongIdentifier)[@res.braces ][@bar ])
+      ~children:[] ())
   [@JSX ])
 let _ =
   ((StaticDivNamed.createElement
@@ -363,20 +309,19 @@ let _ =
                      fun ~baz ->
                        fun ~lineBreak ->
                          fun ~identifier ->
-                           fun () -> bar lineBreak identifier)
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                           fun () -> bar lineBreak identifier)[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let _ =
   ((div
       ~onClick:((fun [arity:1]e -> (((doStuff (); bar foo)
-                   [@res.braces ]) : event))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                   [@res.braces ]) : event))[@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((div
       ~onClick:((fun [arity:2]e ->
                    fun e2 -> (((doStuff (); bar foo)[@res.braces ]) : event))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+      [@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((div
@@ -387,7 +332,7 @@ let _ =
                          fun breakLine -> (((doStuff (); bar foo)
                            [@res.braces ]) : (event * event2 * event3 *
                                                event4 * event5)))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+      [@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
   ((div
@@ -397,8 +342,8 @@ let _ =
                        fun superLongIdent ->
                          fun breakLine ->
                            (doStuff () : (event * event2 * event3 * event4 *
-                                           event5)))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                                           event5)))[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let _ =
   ((div
@@ -409,126 +354,91 @@ let _ =
   [@JSX ])
 let _ =
   ((div
-      ~style:((ReactDOMRe.Style.make ~width:(({js|20px|js})
-                 [@res.namedArgLoc ]) ~height:(({js|20px|js})
-                 [@res.namedArgLoc ]) ~borderRadius:(({js|100%|js})
-                 [@res.namedArgLoc ]) ~backgroundColor:(({js|red|js})
-                 [@res.namedArgLoc ]))
-      [@res.namedArgLoc ][@res.braces ][@foo ]) ~children:[] ())
+      ~style:((ReactDOMRe.Style.make ~width:{js|20px|js} ~height:{js|20px|js}
+                 ~borderRadius:{js|100%|js} ~backgroundColor:{js|red|js})
+      [@res.braces ][@foo ]) ~children:[] ())
   [@JSX ])
 let _ =
-  ((Animated.createElement ~initialValue:((0.0)[@res.namedArgLoc ])
-      ~value:((value)[@res.namedArgLoc ])
-      ~children:((ReactDOMRe.Style.make ~width:(({js|20px|js})
-                    [@res.namedArgLoc ]) ~height:(({js|20px|js})
-                    [@res.namedArgLoc ]) ~borderRadius:(({js|100%|js})
-                    [@res.namedArgLoc ]) ~backgroundColor:(({js|red|js})
-                    [@res.namedArgLoc ]))[@res.braces ]) ())
+  ((Animated.createElement ~initialValue:0.0 ~value
+      ~children:((ReactDOMRe.Style.make ~width:{js|20px|js}
+                    ~height:{js|20px|js} ~borderRadius:{js|100%|js}
+                    ~backgroundColor:{js|red|js})[@res.braces ]) ())
   [@JSX ])
 let _ =
-  ((Animated.createElement ~initialValue:((0.0)[@res.namedArgLoc ])
-      ~value:((value)[@res.namedArgLoc ])
+  ((Animated.createElement ~initialValue:0.0 ~value
       ~children:((fun [arity:1]value ->
                     ((div
-                        ~style:((ReactDOMRe.Style.make ~width:(({js|20px|js})
-                                   [@res.namedArgLoc ])
-                                   ~height:(({js|20px|js})
-                                   [@res.namedArgLoc ])
-                                   ~borderRadius:(({js|100%|js})
-                                   [@res.namedArgLoc ])
-                                   ~backgroundColor:(({js|red|js})
-                                   [@res.namedArgLoc ]))
-                        [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                        ~style:((ReactDOMRe.Style.make ~width:{js|20px|js}
+                                   ~height:{js|20px|js}
+                                   ~borderRadius:{js|100%|js}
+                                   ~backgroundColor:{js|red|js})
+                        [@res.braces ]) ~children:[] ())
                     [@JSX ]))[@res.braces ]) ())
   [@JSX ])
 let _ =
-  ((Animated.createElement ~initialValue:((0.0)[@res.namedArgLoc ])
-      ~value:((value)[@res.namedArgLoc ])
+  ((Animated.createElement ~initialValue:0.0 ~value
       ~children:((fun [arity:1]value ->
                     (((div
-                         ~style:((ReactDOMRe.Style.make
-                                    ~width:(({js|20px|js})
-                                    [@res.namedArgLoc ])
-                                    ~height:(({js|20px|js})
-                                    [@res.namedArgLoc ])
-                                    ~borderRadius:(({js|100%|js})
-                                    [@res.namedArgLoc ])
-                                    ~backgroundColor:(({js|red|js})
-                                    [@res.namedArgLoc ]))
-                         [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                         ~style:((ReactDOMRe.Style.make ~width:{js|20px|js}
+                                    ~height:{js|20px|js}
+                                    ~borderRadius:{js|100%|js}
+                                    ~backgroundColor:{js|red|js})
+                         [@res.braces ]) ~children:[] ())
                     [@JSX ]) : ReasonReact.element))[@res.braces ]) ())
   [@JSX ])
 let _ =
-  ((Animated.createElement ~initialValue:((0.0)[@res.namedArgLoc ])
-      ~value:((value)[@res.namedArgLoc ])
+  ((Animated.createElement ~initialValue:0.0 ~value
       ~children:((fun [arity:1]value ->
                     ((div
-                        ~style:((ReactDOMRe.Style.make ~width:(({js|20px|js})
-                                   [@res.namedArgLoc ])
-                                   ~height:(({js|20px|js})
-                                   [@res.namedArgLoc ])
-                                   ~borderRadius:(({js|100%|js})
-                                   [@res.namedArgLoc ])
-                                   ~backgroundColor:(({js|red|js})
-                                   [@res.namedArgLoc ]))
-                        [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                        ~style:((ReactDOMRe.Style.make ~width:{js|20px|js}
+                                   ~height:{js|20px|js}
+                                   ~borderRadius:{js|100%|js}
+                                   ~backgroundColor:{js|red|js})
+                        [@res.braces ]) ~children:[] ())
                     [@res.braces ][@JSX ]))[@res.braces ][@foo ]) ())
   [@JSX ])
 let _ =
-  ((Animated.createElement ~initialValue:((0.0)[@res.namedArgLoc ])
-      ~value:((value)[@res.namedArgLoc ])
+  ((Animated.createElement ~initialValue:0.0 ~value
       ~children:((fun [arity:1]value ->
                     ((let width = {js|20px|js} in
                       let height = {js|20px|js} in
                       ((div
-                          ~style:((ReactDOMRe.Style.make ~width:((width)
-                                     [@res.namedArgLoc ]) ~height:((height)
-                                     [@res.namedArgLoc ])
-                                     ~borderRadius:(({js|100%|js})
-                                     [@res.namedArgLoc ])
-                                     ~backgroundColor:(({js|red|js})
-                                     [@res.namedArgLoc ]))
-                          [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+                          ~style:((ReactDOMRe.Style.make ~width ~height
+                                     ~borderRadius:{js|100%|js}
+                                     ~backgroundColor:{js|red|js})
+                          [@res.braces ]) ~children:[] ())
                         [@JSX ]))
                     [@res.braces ]))[@res.braces ]) ())
   [@JSX ])
 let _ =
-  ((div ~callback:((reduce (fun [arity:1]() -> not state))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+  ((div ~callback:((reduce (fun [arity:1]() -> not state))[@res.braces ])
+      ~children:[] ())
   [@JSX ])
 let _ =
-  ((button ?id:((id)[@res.namedArgLoc ])
-      ~className:((Cn.make [|{js|button|js};{js|is-fullwidth|js}|])
-      [@res.namedArgLoc ][@res.braces ]) ~onClick:((onClick)
-      [@res.namedArgLoc ]) ~children:[((ste {js|Submit|js})[@res.braces ])]
-      ())
+  ((button ?id ~className:((Cn.make [|{js|button|js};{js|is-fullwidth|js}|])
+      [@res.braces ]) ~onClick
+      ~children:[((ste {js|Submit|js})[@res.braces ])] ())
   [@JSX ])
 let _ =
-  ((button ?id:((id)[@res.namedArgLoc ])
-      ~className:((Cn.make [{js|button|js}; {js|is-fullwidth|js}])
-      [@res.namedArgLoc ][@res.braces ]) ~onClick:((onClick)
-      [@res.namedArgLoc ]) ~children:[((ste {js|Submit|js})[@res.braces ])]
-      ())
+  ((button ?id ~className:((Cn.make [{js|button|js}; {js|is-fullwidth|js}])
+      [@res.braces ]) ~onClick
+      ~children:[((ste {js|Submit|js})[@res.braces ])] ())
   [@JSX ])
 let _ =
-  ((button ?id:((id)[@res.namedArgLoc ])
-      ~className:((Cn.make ({js|button|js}, {js|is-fullwidth|js}))
-      [@res.namedArgLoc ][@res.braces ]) ~onClick:((onClick)
-      [@res.namedArgLoc ]) ~children:[((ste {js|Submit|js})[@res.braces ])]
-      ())
+  ((button ?id ~className:((Cn.make ({js|button|js}, {js|is-fullwidth|js}))
+      [@res.braces ]) ~onClick
+      ~children:[((ste {js|Submit|js})[@res.braces ])] ())
   [@JSX ])
 let _ =
-  ((button ?id:((id)[@res.namedArgLoc ]) ~className:((Cn.make { a = b })
-      [@res.namedArgLoc ][@res.braces ]) ~onClick:((onClick)
-      [@res.namedArgLoc ]) ~children:[((ste {js|Submit|js})[@res.braces ])]
-      ())
+  ((button ?id ~className:((Cn.make { a = b })[@res.braces ]) ~onClick
+      ~children:[((ste {js|Submit|js})[@res.braces ])] ())
   [@JSX ])
 let _ =
   ((X.createElement ~y:((z -> (Belt.Option.getWithDefault {js||js}))
-      [@res.namedArgLoc ][@res.braces ]) ~children:[] ())
+      [@res.braces ]) ~children:[] ())
   [@JSX ])
 let _ =
-  ((div ~style:((getStyle ())[@res.namedArgLoc ][@res.braces ])
+  ((div ~style:((getStyle ())[@res.braces ])
       ~children:[((ReasonReact.string {js|BugTest|js})[@res.braces ])] ())
   [@JSX ])
 let _ =
@@ -541,13 +451,10 @@ let _ =
                 [@res.braces ])] ())
   [@JSX ])
 let _ =
-  ((View.createElement ~style:((styles#backgroundImageWrapper)
-      [@res.namedArgLoc ])
+  ((View.createElement ~style:(styles#backgroundImageWrapper)
       ~children:[(((let uri = {js|/images/header-background.png|js} in
-                    ((Image.createElement ~resizeMode:((Contain)
-                        [@res.namedArgLoc ]) ~style:((styles#backgroundImage)
-                        [@res.namedArgLoc ]) ~uri:((uri)[@res.namedArgLoc ])
-                        ~children:[] ())
+                    ((Image.createElement ~resizeMode:Contain
+                        ~style:(styles#backgroundImage) ~uri ~children:[] ())
                       [@JSX ])))
                 [@res.braces ])] ())
   [@JSX ])
@@ -558,9 +465,9 @@ let _ =
                            (fun [arity:1]possibleGradeValue ->
                               ((option
                                   ~key:((string_of_int possibleGradeValue)
-                                  [@res.namedArgLoc ][@res.braces ])
+                                  [@res.braces ])
                                   ~value:((string_of_int possibleGradeValue)
-                                  [@res.namedArgLoc ][@res.braces ])
+                                  [@res.braces ])
                                   ~children:[((str
                                                  (string_of_int
                                                     possibleGradeValue))
@@ -576,7 +483,7 @@ let _ =
                 [@JSX ])] ())[@JSX ])
 ;;((div
       ~children:[((div ~onClick:((fun [arity:1]_ -> Js.log (a <= 10))
-                     [@res.namedArgLoc ][@res.braces ])
+                     [@res.braces ])
                      ~children:[((div
                                     ~children:[((Js.log (a <= 10))
                                               [@res.braces ])] ())
@@ -594,7 +501,5 @@ let _ =
 ;;(([[|a|]])[@JSX ])
 ;;(([(1, 2)])[@JSX ])
 ;;(([((array -> f)[@res.braces ])])[@JSX ])
-let _ =
-  ((A.createElement ~x:(({js|y|js})[@res.namedArgLoc ]) ~_spreadProps:((str)
-      [@res.namedArgLoc ]) ~children:[] ())
+let _ = ((A.createElement ~x:{js|y|js} ~_spreadProps:str ~children:[] ())
   [@JSX ])

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/parenthesized.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/parenthesized.res.txt
@@ -16,9 +16,7 @@ let aTuple = (1, 2)
 let aRecord = { name = {js|steve|js}; age = 30 }
 let blockExpression = ((let a = 1 in let b = 2 in a + b)[@res.braces ])
 let assertSmthing = assert true
-let jsx =
-  ((div ~className:(({js|cx|js})[@res.namedArgLoc ]) ~children:[foo] ())
-  [@JSX ])
+let jsx = ((div ~className:{js|cx|js} ~children:[foo] ())[@JSX ])
 let ifExpr = if true then Js.log true else Js.log false
 let forExpr = for p = 0 to 10 do () done
 let whileExpr = while true do doSomeImperativeThing () done

--- a/tests/syntax_tests/data/parsing/grammar/expressions/expected/primary.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/expressions/expected/primary.res.txt
@@ -18,15 +18,9 @@ let x = (arr.((x : int))).((y : int))
 ;;f (x : int)
 ;;f a b c
 ;;f a b c
-;;f ~a:((a)[@res.namedArgLoc ]) ~b:((bArg)[@res.namedArgLoc ]) ?c:((c)
-    [@res.namedArgLoc ]) ?d:((expr)[@res.namedArgLoc ])
-;;((f ~a:((a)[@res.namedArgLoc ]) ~b:((bArg)[@res.namedArgLoc ]) ?c:((c)
-      [@res.namedArgLoc ]) ?d:((expr)[@res.namedArgLoc ])) ~a:((a)
-     [@res.namedArgLoc ]) ~b:((bArg)[@res.namedArgLoc ]) ?c:((c)
-     [@res.namedArgLoc ]) ?d:((expr)[@res.namedArgLoc ])) ~a:((a)
-    [@res.namedArgLoc ]) ~b:((bArg)[@res.namedArgLoc ]) ?c:((c)
-    [@res.namedArgLoc ]) ?d:((expr)[@res.namedArgLoc ])
-;;f ~a:(((x : int))[@res.namedArgLoc ]) ?b:(((y : int))[@res.namedArgLoc ])
+;;f ~a ~b:bArg ?c ?d:expr
+;;((f ~a ~b:bArg ?c ?d:expr) ~a ~b:bArg ?c ?d:expr) ~a ~b:bArg ?c ?d:expr
+;;f ~a:(x : int) ?b:(y : int)
 ;;connection#platformId
 ;;((connection#left)#account)#accountName
 ;;john#age #= 99

--- a/tests/syntax_tests/data/parsing/grammar/pattern/expected/firstClassModules.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/pattern/expected/firstClassModules.res.txt
@@ -8,7 +8,7 @@ let sort (type s)
 let foo [arity:2](module Foo)  baz = Foo.bar baz
 let bump_list (type a)
   [arity:2]((module B)  : (module Bumpable with type t = a)) (l : a list) =
-  List.map ~f:((B.bump l)[@res.namedArgLoc ])
+  List.map ~f:(B.bump l)
 ;;match x with
   | (module Set)  -> ()
   | ((module Set)  : (module Set.S with type elt = s)) -> ()

--- a/tests/syntax_tests/data/parsing/grammar/typexpr/expected/es6Arrow.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/typexpr/expected/es6Arrow.res.txt
@@ -12,15 +12,15 @@ let (t : a:int -> b:int -> int (a:2)) = xf
 let (t : ?a:int -> ?b:int -> int (a:2)) = xf
 let (t : int -> int -> int -> int (a:1) (a:1) (a:1)) = xf
 let (t : a:int -> b:int -> c:int -> int (a:1) (a:1) (a:1)) = xf
-type nonrec t = f:((int)[@res.namedArgLoc ]) -> string
-type nonrec t = ?f:((int)[@res.namedArgLoc ]) -> string
-let (f : f:((int)[@res.namedArgLoc ]) -> string) = fx
-let (f : ?f:((int)[@res.namedArgLoc ]) -> string) = fx
+type nonrec t = f:int -> string
+type nonrec t = ?f:int -> string
+let (f : f:int -> string) = fx
+let (f : ?f:int -> string) = fx
 type nonrec t = f:int -> string (a:1)
-type nonrec t = f:((int)[@res.namedArgLoc ]) -> string
+type nonrec t = f:int -> string
 type nonrec t = f:(int -> string (a:1)) -> float (a:1)
-type nonrec t = f:((int -> string (a:1))[@res.namedArgLoc ]) -> float
-type nonrec t = f:((int)[@res.namedArgLoc ]) -> string -> float (a:1)
+type nonrec t = f:(int -> string (a:1)) -> float
+type nonrec t = f:int -> string -> float (a:1)
 type nonrec t =
   ((a:int -> ((b:int -> ((float)[@attr ]) -> unit)[@attrBeforeLblB ]) (a:3))
   [@attrBeforeLblA ])
@@ -28,7 +28,7 @@ type nonrec t =
   ((a:int ->
       ((b:int -> ((float)[@attr ]) -> unit (a:1) (a:1))[@attrBeforeLblB ]) (a:1))
   [@attrBeforeLblA ])
-type nonrec t = ((a:((int)[@res.namedArgLoc ]) -> unit)[@attr ])
+type nonrec t = ((a:int -> unit)[@attr ])
 type nonrec 'a getInitialPropsFn =
   < query: string dict  ;req: 'a Js.t Js.Nullable.t   >  ->
     'a Js.t Js.Promise.t (a:1)

--- a/tests/syntax_tests/data/parsing/infiniteLoops/expected/nonRecTypes.res.txt
+++ b/tests/syntax_tests/data/parsing/infiniteLoops/expected/nonRecTypes.res.txt
@@ -141,9 +141,8 @@ include
           match successor with
           | None ->
               let leaf =
-                createNode ~value:((Js.Internal.raw_expr {js|0|js})
-                  [@res.namedArgLoc ]) ~color:((Black)[@res.namedArgLoc ])
-                  ~height:((0.)[@res.namedArgLoc ]) in
+                createNode ~value:(Js.Internal.raw_expr {js|0|js})
+                  ~color:Black ~height:0. in
               let isLeaf = Js.Internal.fn_mk1 (fun [arity:1]x -> x === leaf) in
               (leaf, isLeaf)
           | Some successor ->
@@ -153,8 +152,7 @@ include
         (match nodeParent with
          | None -> ()
          | Some parent ->
-             leftOrRightSet parent ~node:((nodeToRemove)[@res.namedArgLoc ])
-               (Some successor));
+             leftOrRightSet parent ~node:nodeToRemove (Some successor));
         updateSumRecursive rbt successor;
         if (colorGet nodeToRemove) === Black
         then
@@ -276,9 +274,7 @@ include
           (if (rootGet rbt) === (Some successor) then rootSet rbt None;
            (match parentGet successor with
             | None -> ()
-            | Some parent ->
-                leftOrRightSet parent ~node:((successor)[@res.namedArgLoc ])
-                  None)))
+            | Some parent -> leftOrRightSet parent ~node:successor None)))
       [@res.braces ])
     let remove [arity:2]rbt value =
       match _findNode rbt (rootGet rbt) value with
@@ -303,9 +299,7 @@ include
         | None -> None
         | Some node -> Some (valueGet node))
       [@res.braces ])
-    let make [arity:1]~compare  =
-      t ~size:((0)[@res.namedArgLoc ]) ~root:((None)[@res.namedArgLoc ])
-        ~compare:((compare)[@res.namedArgLoc ])
+    let make [arity:1]~compare  = t ~size:0 ~root:None ~compare
     let rec heightOfInterval [arity:4]rbt node lhs rhs =
       match node with
       | None -> 0.
@@ -383,12 +377,10 @@ include
         | Some parent ->
             leftSpine +.
               (sumLeftSpine parent
-                 ~fromRightChild:(((rightGet parent) === (Some node))
-                 [@res.namedArgLoc ])))
+                 ~fromRightChild:((rightGet parent) === (Some node))))
       [@res.braces ])
     let getY [arity:1]node =
-      (sumLeftSpine node ~fromRightChild:((true)[@res.namedArgLoc ])) -.
-        (heightGet node)
+      (sumLeftSpine node ~fromRightChild:true) -. (heightGet node)
     let linearSearch [arity:2]rbt callback =
       ((let rec find [arity:2]node callback =
           if Js.Internal.fn_run1 callback (valueGet node)
@@ -409,9 +401,7 @@ include
            if (!==) firstNode lastNode
            then
              (if not inclusive then Js.Internal.fn_run1 callback node;
-              iterate ~inclusive:((inclusive)[@res.namedArgLoc ])
-                (nextNode node) lastNode ~callback:((callback)
-                [@res.namedArgLoc ])))
+              iterate ~inclusive (nextNode node) lastNode ~callback))
     let rec iterateWithY [arity:5]?y  ~inclusive  firstNode lastNode
       ~callback  =
       match firstNode with
@@ -422,22 +412,20 @@ include
            if (!==) firstNode lastNode
            then
              (if not inclusive then Js.Internal.fn_run2 callback node y;
-              iterateWithY ~y:((y +. (heightGet node))[@res.namedArgLoc ])
-                ~inclusive:((inclusive)[@res.namedArgLoc ]) (nextNode node)
-                lastNode ~callback:((callback)[@res.namedArgLoc ])))
+              iterateWithY ~y:(y +. (heightGet node)) ~inclusive
+                (nextNode node) lastNode ~callback))
     let rec updateSum [arity:2]node ~delta  =
       match node with
       | None -> ()
       | Some node ->
           (sumSet node ((sumGet node) +. delta);
-           updateSum (parentGet node) ~delta:((delta)[@res.namedArgLoc ]))
+           updateSum (parentGet node) ~delta)
     let setHeight [arity:3]rbt value ~height  =
       match _findNode rbt (rootGet rbt) value with
       | None -> ()
       | Some node ->
           let delta = height -. (heightGet node) in
-          (heightSet node height;
-           updateSum (Some node) ~delta:((delta)[@res.namedArgLoc ]))
+          (heightSet node height; updateSum (Some node) ~delta)
     type nonrec 'value oldNewVisibleNodes =
       {
       mutable old: 'value array ;

--- a/tests/syntax_tests/data/ppx/react/expected/externalWithCustomName.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/externalWithCustomName.res.txt
@@ -8,7 +8,7 @@ module Foo = {
   external component: React.componentLike<props<int, string>, React.element> = "component"
 }
 
-let t = React.createElement(Foo.component, {a: 1, b: "1"})
+let t = React.createElement(Foo.component, {a: 1, b: {"1"}})
 
 @@jsxConfig({version: 4, mode: "automatic"})
 
@@ -20,4 +20,4 @@ module Foo = {
   external component: React.componentLike<props<int, string>, React.element> = "component"
 }
 
-let t = React.jsx(Foo.component, {a: 1, b: "1"})
+let t = React.jsx(Foo.component, {a: 1, b: {"1"}})

--- a/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
@@ -21,7 +21,7 @@ module V4C = {
             ~props={
               type_: "text",
               ?className,
-              ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)),
+              ref: ?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)},
             },
             [],
           ),
@@ -78,7 +78,7 @@ module V4CUncurried = {
             ~props={
               type_: "text",
               ?className,
-              ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)),
+              ref: ?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)},
             },
             [],
           ),
@@ -135,7 +135,7 @@ module V4A = {
               {
                 type_: "text",
                 ?className,
-                ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)),
+                ref: ?{Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)},
               },
             ),
             children,
@@ -189,7 +189,7 @@ module V4AUncurried = {
               {
                 type_: "text",
                 ?className,
-                ref: ?(Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)),
+                ref: ?{Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)},
               },
             ),
             children,

--- a/tests/syntax_tests/data/ppx/react/expected/uncurriedProps.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/uncurriedProps.res.txt
@@ -51,7 +51,7 @@ module Bar = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props) => React.jsx(Foo.make, {callback: (_, _, _) => ()})
+  let make = (_: props) => React.jsx(Foo.make, {callback: {(_, _, _) => ()}})
   let make = {
     let \"UncurriedProps$Bar" = props => make(props)
 

--- a/tests/syntax_tests/data/printer/expr/expected/jsx.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/jsx.res.txt
@@ -51,7 +51,7 @@ let x =
 let x = <div className="container" className2="container2" className3="container3" onClick />
 
 let nav =
-  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       <WidescreenMenu
         menuItems={props.items} trial={props.trial} user={props.user} viewer={props.viewer}
@@ -60,14 +60,14 @@ let nav =
   </Nav>
 
 let nav2 =
-  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       {switch isMobile {
       | true =>
         <MobileMenu
           handleOpenToggle={_ => setOpen(open_ => !open_)}
           menuItems={props.items}
-          isOpen
+          isOpen={isOpen}
           forceOpen={_ => setOpen(true)}
           forceClose={_ => setOpen(false)}
           user={props.user}
@@ -82,13 +82,13 @@ let nav2 =
   </Nav>
 
 let nav3 =
-  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       {isMobile
         ? <MobileMenu
             handleOpenToggle={_ => setOpen(open_ => !open_)}
             menuItems={props.items}
-            isOpen
+            isOpen={isOpen}
             forceOpen={_ => setOpen(true)}
             forceClose={_ => setOpen(false)}
             user={props.user}
@@ -102,7 +102,7 @@ let nav3 =
 let avatarSection =
   <>
     <div style={{"zIndex": "1", "opacity": opacityUser}}>
-      <Avatar user size={45} />
+      <Avatar user={user} size={45} />
     </div>
     {user.email !== viewer.email
       ? <div

--- a/tests/syntax_tests/data/printer/expr/expected/jsx.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/jsx.res.txt
@@ -51,7 +51,7 @@ let x =
 let x = <div className="container" className2="container2" className3="container3" onClick />
 
 let nav =
-  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       <WidescreenMenu
         menuItems={props.items} trial={props.trial} user={props.user} viewer={props.viewer}
@@ -60,14 +60,14 @@ let nav =
   </Nav>
 
 let nav2 =
-  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       {switch isMobile {
       | true =>
         <MobileMenu
           handleOpenToggle={_ => setOpen(open_ => !open_)}
           menuItems={props.items}
-          isOpen={isOpen}
+          isOpen
           forceOpen={_ => setOpen(true)}
           forceClose={_ => setOpen(false)}
           user={props.user}
@@ -82,13 +82,13 @@ let nav2 =
   </Nav>
 
 let nav3 =
-  <Nav isMobile={isMobile} fullScreen={!isMobile ? false : isOpen}>
+  <Nav isMobile fullScreen={!isMobile ? false : isOpen}>
     <NavContent>
       {isMobile
         ? <MobileMenu
             handleOpenToggle={_ => setOpen(open_ => !open_)}
             menuItems={props.items}
-            isOpen={isOpen}
+            isOpen
             forceOpen={_ => setOpen(true)}
             forceClose={_ => setOpen(false)}
             user={props.user}
@@ -102,7 +102,7 @@ let nav3 =
 let avatarSection =
   <>
     <div style={{"zIndex": "1", "opacity": opacityUser}}>
-      <Avatar user={user} size={45} />
+      <Avatar user size={45} />
     </div>
     {user.email !== viewer.email
       ? <div


### PR DESCRIPTION
Create type `arg_label_loc` alongside `arg_label` to store location in the label.
This is only used by application for the moment.