### PR TITLE
Fix issue with ppx and await.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Editor: Fix issue where completions would not show up inside of object bodies. https://github.com/rescript-lang/rescript/pull/7230
 - Fix issue with pattern matching empty list which interferes with boolean optimisations. https://github.com/rescript-lang/rescript/pull/7237
 - Fix Cannot combine @react.component and @directive. https://github.com/rescript-lang/rescript/pull/7260
+- Fix issue where attributes on an application were not preserved by the AST conversion for ppx. https://github.com/rescript-lang/rescript/pull/7262
 
 #### :house: Internal
 

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -346,7 +346,7 @@ module E = struct
       in
       let attrs =
         if partial then (Location.mknoloc "res.partial", Pt.PStr []) :: attrs
-        else []
+        else attrs
       in
       apply ~loc ~attrs (sub.expr sub e)
         (List.map (map_snd (sub.expr sub)) args)

--- a/tests/tools_tests/ppx/TestPpx.res
+++ b/tests/tools_tests/ppx/TestPpx.res
@@ -38,8 +38,8 @@ module Uncurried = {
 
 let async_succ = async x => x + 1
 let async_foo = async (x, y) => {
-  let a: promise<int> = async_succ(x)
-  let b: promise<int> = async_succ(y)
+  let a = async_succ(x)
+  let b = async_succ(y)
   (await a) + (await b)
 }
 
@@ -58,3 +58,6 @@ let neq2 = 3 !== 3
 
 let eq = 3 == 3
 let eq2 = 3 === 3
+
+let test = async () => 12
+let f = async () => (await test()) + 1

--- a/tests/tools_tests/src/expected/TestPpx.res.jsout
+++ b/tests/tools_tests/src/expected/TestPpx.res.jsout
@@ -72,6 +72,14 @@ let Pipe = {
 
 let concat = "ab";
 
+async function test() {
+  return 12;
+}
+
+async function f() {
+  return await test() + 1 | 0;
+}
+
 let a = "A";
 
 let b = "B";
@@ -104,4 +112,6 @@ exports.neq = neq;
 exports.neq2 = neq2;
 exports.eq = eq;
 exports.eq2 = eq2;
+exports.test = test;
+exports.f = f;
 /*  Not a pure module */


### PR DESCRIPTION
Fix issue where attributes on an application were not preserved by the AST conversion for ppx.

Fixes https://github.com/rescript-lang/rescript/issues/7261