### PR TITLE
Clean list API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 12.0.0-alpha.9 (Unreleased)
 
+#### :boom: Breaking Change
+
+- Clean list API. https://github.com/rescript-lang/rescript/pull/7290
+
 #### :nail_care: Polish
 
 - Allow single newline in JSX. https://github.com/rescript-lang/rescript/pull/7269

--- a/lib/es6/Stdlib_List.js
+++ b/lib/es6/Stdlib_List.js
@@ -646,7 +646,7 @@ function toArray(x) {
   return arr;
 }
 
-function toShuffled(xs) {
+function shuffle(xs) {
   let v = toArray(xs);
   Stdlib_Array.shuffle(v);
   return fromArray(v);
@@ -1298,6 +1298,8 @@ function zip(l1, l2) {
 
 let size = length;
 
+let toShuffled = shuffle;
+
 export {
   length,
   size,
@@ -1310,6 +1312,7 @@ export {
   getExn,
   make,
   fromInitializer,
+  shuffle,
   toShuffled,
   drop,
   take,

--- a/lib/js/Stdlib_List.js
+++ b/lib/js/Stdlib_List.js
@@ -646,7 +646,7 @@ function toArray(x) {
   return arr;
 }
 
-function toShuffled(xs) {
+function shuffle(xs) {
   let v = toArray(xs);
   Stdlib_Array.shuffle(v);
   return fromArray(v);
@@ -1298,6 +1298,8 @@ function zip(l1, l2) {
 
 let size = length;
 
+let toShuffled = shuffle;
+
 exports.length = length;
 exports.size = size;
 exports.head = head;
@@ -1309,6 +1311,7 @@ exports.get = get;
 exports.getExn = getExn;
 exports.make = make;
 exports.fromInitializer = fromInitializer;
+exports.shuffle = shuffle;
 exports.toShuffled = toShuffled;
 exports.drop = drop;
 exports.take = take;

--- a/runtime/Stdlib_List.res
+++ b/runtime/Stdlib_List.res
@@ -61,8 +61,6 @@
 
 @@config({flags: ["-bs-noassertfalse"]})
 
-type t<'a> = list<'a>
-
 module A = {
   @new external makeUninitializedUnsafe: int => array<'a> = "Array"
   external min: ('a, 'a) => 'a = "%bs_min"
@@ -85,7 +83,7 @@ module A = {
   }
 }
 
-external mutableCell: ('a, t<'a>) => t<'a> = "#makemutablelist"
+external mutableCell: ('a, list<'a>) => list<'a> = "#makemutablelist"
 
 /*
   `mutableCell x []` == `x`
@@ -94,7 +92,7 @@ external mutableCell: ('a, t<'a>) => t<'a> = "#makemutablelist"
    dont inline a binding to mutable cell, it is mutable
 */
 /* INVARIANT: relies on Literals.tl (internal representation) */
-@set external unsafeMutateTail: (t<'a>, t<'a>) => unit = "tl"
+@set external unsafeMutateTail: (list<'a>, list<'a>) => unit = "tl"
 
 /*
    - the cell is not empty
@@ -480,7 +478,7 @@ let rec fromArrayAux = (a, i, res) =>
 
 let fromArray = a => fromArrayAux(a, Stdlib_Array.length(a) - 1, list{})
 
-let toArray = (x: t<_>) => {
+let toArray = (x: list<_>) => {
   let len = length(x)
   let arr = A.makeUninitializedUnsafe(len)
   fillAux(arr, 0, x)

--- a/runtime/Stdlib_List.res
+++ b/runtime/Stdlib_List.res
@@ -689,6 +689,7 @@ let rec has = (xs, x, eq) =>
   | list{a, ...l} => eq(a, x) || has(l, x, eq)
   }
 
+@deprecated("Use a `Map` instead")
 let rec getAssoc = (xs, x, eq) =>
   switch xs {
   | list{} => None
@@ -700,12 +701,14 @@ let rec getAssoc = (xs, x, eq) =>
     }
   }
 
+@deprecated("Use a `Map` instead")
 let rec hasAssoc = (xs, x, eq) =>
   switch xs {
   | list{} => false
   | list{(a, _), ...l} => eq(a, x) || hasAssoc(l, x, eq)
   }
 
+@deprecated("Use a `Map` instead")
 let removeAssoc = (xs, x, eq) =>
   switch xs {
   | list{} => list{}
@@ -723,6 +726,7 @@ let removeAssoc = (xs, x, eq) =>
     }
   }
 
+@deprecated("Use a `Map` instead")
 let setAssoc = (xs, x, k, eq) =>
   switch xs {
   | list{} => list{(x, k)}

--- a/runtime/Stdlib_List.res
+++ b/runtime/Stdlib_List.res
@@ -485,11 +485,14 @@ let toArray = (x: list<_>) => {
   arr
 }
 
-let toShuffled = xs => {
+let shuffle = xs => {
   let v = toArray(xs)
   Stdlib_Array.shuffle(v)
   fromArray(v)
 }
+
+@deprecated("Use `shuffle` instead")
+let toShuffled = shuffle
 
 let rec reverseConcat = (l1, l2) =>
   switch l1 {

--- a/runtime/Stdlib_List.resi
+++ b/runtime/Stdlib_List.resi
@@ -822,6 +822,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 // Some("afternoon")
 ```
 */
+@deprecated("Use a `Map` instead")
 let getAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => option<'c>
 
 /**
@@ -837,6 +838,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 ->List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */) // false
 ```
 */
+@deprecated("Use a `Map` instead")
 let hasAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => bool
 
 /**
@@ -854,6 +856,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 // list{(15, "afternoon"), (22, "night")}
 ```
 */
+@deprecated("Use a `Map` instead")
 let removeAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => list<('a, 'c)>
 
 /**
@@ -877,6 +880,7 @@ list{(9, "morning"), (3, "morning?!"), (22, "night")}
 **Please note**: In the last example, since: `15 mod 12` equals `3 mod 12`. Both
 the key _and_ the value are replaced in the list.
 */
+@deprecated("Use a `Map` instead")
 let setAssoc: (list<('a, 'c)>, 'a, 'c, ('a, 'a) => bool) => list<('a, 'c)>
 
 /**

--- a/runtime/Stdlib_List.resi
+++ b/runtime/Stdlib_List.resi
@@ -187,7 +187,7 @@ List.make(~length=3, 1) // list{1, 1, 1}
 let make: (~length: int, 'a) => list<'a>
 
 /**
-`makeBy(length, f)` return a list of length `length` with element initialized
+`fromInitializer(length, f)` return a list of length `length` with element initialized
 with `f`. Returns an empty list if `length` is negative.
 
 ## Examples

--- a/runtime/Stdlib_List.resi
+++ b/runtime/Stdlib_List.resi
@@ -201,6 +201,17 @@ List.fromInitializer(~length=5, i => i * i) // list{0, 1, 4, 9, 16}
 let fromInitializer: (~length: int, int => 'a) => list<'a>
 
 /**
+`shuffle(list)` returns a new list in random order.
+
+## Examples
+
+```rescript
+List.shuffle(list{1, 2, 3}) // list{2, 1, 3}
+```
+*/
+let shuffle: list<'a> => list<'a>
+
+/**
 `toShuffled(list)` returns a new list in random order.
 
 ## Examples
@@ -209,6 +220,7 @@ let fromInitializer: (~length: int, int => 'a) => list<'a>
 List.toShuffled(list{1, 2, 3}) // list{2, 1, 3}
 ```
 */
+@deprecated("Use `shuffle` instead")
 let toShuffled: list<'a> => list<'a>
 
 /**

--- a/runtime/Stdlib_List.resi
+++ b/runtime/Stdlib_List.resi
@@ -31,9 +31,6 @@ Collection functions for manipulating the `list` data structures, a singly-linke
 - Better interop with JavaScript
 - Better memory usage & performance.
 */
-/** `'a t` is compatible with built-in `list` type */
-type t<'a> = list<'a>
-
 /**
 `length(list)` returns the length of `list`.
 
@@ -43,7 +40,7 @@ type t<'a> = list<'a>
 List.length(list{1, 2, 3}) // 3
 ```
 */
-let length: t<'a> => int
+let length: list<'a> => int
 
 /**
 `size(list)`. See [`length`](#length)
@@ -54,7 +51,7 @@ let length: t<'a> => int
 List.size(list{1, 2, 3}) // 3
 ```
 */
-let size: t<'a> => int
+let size: list<'a> => int
 
 /**
 `head(list)` returns `Some(value)` where `value` is the first element in the
@@ -67,7 +64,7 @@ List.head(list{}) // None
 List.head(list{1, 2, 3}) // Some(1)
 ```
 */
-let head: t<'a> => option<'a>
+let head: list<'a> => option<'a>
 
 /**
 `headExn(list)` same as [`head`](#head).
@@ -88,7 +85,7 @@ switch List.headExn(list{}) {
 - Raises an Error if list is empty.
 
 */
-let headExn: t<'a> => 'a
+let headExn: list<'a> => 'a
 
 /**
 `tail(list)` returns `None` if `list` is empty, otherwise it returns `Some(tail)`
@@ -102,7 +99,7 @@ List.tail(list{1, 2, 3}) // Some(list{2, 3})
 List.tail(list{}) // None
 ```
 */
-let tail: t<'a> => option<t<'a>>
+let tail: list<'a> => option<list<'a>>
 
 /**
 `tailExn(list)` same as [`tail`](#tail).
@@ -122,7 +119,7 @@ switch List.tailExn(list{}) {
 
 - Raises an Error if list is empty.
 */
-let tailExn: t<'a> => t<'a>
+let tailExn: list<'a> => list<'a>
 
 /**
 `add(list, value)` adds a `value` to the beginning of list `list`.
@@ -135,7 +132,7 @@ List.add(list{2, 3}, 1) // list{1, 2, 3}
 List.add(list{"World", "!"}, "Hello") // list{"Hello", "World", "!"}
 ```
 */
-let add: (t<'a>, 'a) => t<'a>
+let add: (list<'a>, 'a) => list<'a>
 
 /**
 `get(list, index)` return the `index` element in `list`, or `None` if `index`
@@ -151,7 +148,7 @@ abc->List.get(1) // Some("B")
 abc->List.get(4) // None
 ```
 */
-let get: (t<'a>, int) => option<'a>
+let get: (list<'a>, int) => option<'a>
 
 /**
 `getExn(list, index)` same as [`get`](#get).
@@ -175,7 +172,7 @@ switch abc->List.getExn(4) {
 
 - Raises an Error if `index` is larger than the length of list.
 */
-let getExn: (t<'a>, int) => 'a
+let getExn: (list<'a>, int) => 'a
 
 /**
 `make(length, value)` returns a list of length `length` with each element filled
@@ -187,7 +184,7 @@ with `value`. Returns an empty list if `value` is negative.
 List.make(~length=3, 1) // list{1, 1, 1}
 ```
 */
-let make: (~length: int, 'a) => t<'a>
+let make: (~length: int, 'a) => list<'a>
 
 /**
 `makeBy(length, f)` return a list of length `length` with element initialized
@@ -201,7 +198,7 @@ List.fromInitializer(~length=5, i => i) // list{0, 1, 2, 3, 4}
 List.fromInitializer(~length=5, i => i * i) // list{0, 1, 4, 9, 16}
 ```
 */
-let fromInitializer: (~length: int, int => 'a) => t<'a>
+let fromInitializer: (~length: int, int => 'a) => list<'a>
 
 /**
 `toShuffled(list)` returns a new list in random order.
@@ -212,7 +209,7 @@ let fromInitializer: (~length: int, int => 'a) => t<'a>
 List.toShuffled(list{1, 2, 3}) // list{2, 1, 3}
 ```
 */
-let toShuffled: t<'a> => t<'a>
+let toShuffled: list<'a> => list<'a>
 
 /**
 `drop(list, value)` return a new list, dropping the first `value` element.
@@ -228,7 +225,7 @@ list{1, 2, 3}->List.drop(3) // Some(list{})
 list{1, 2, 3}->List.drop(4) // None
 ```
 */
-let drop: (t<'a>, int) => option<t<'a>>
+let drop: (list<'a>, int) => option<list<'a>>
 
 /**
 `take(list, value)` returns a list with the first `value` elements from `list`,
@@ -244,7 +241,7 @@ list{1, 2, 3}->List.take(2) // Some(list{1, 2})
 list{1, 2, 3}->List.take(4) // None
 ```
 */
-let take: (t<'a>, int) => option<t<'a>>
+let take: (list<'a>, int) => option<list<'a>>
 
 /**
 `splitAt(list, n)` split the list `list` at `n`. Returns `None` when the length
@@ -258,7 +255,7 @@ list{"Hello", "World"}->List.splitAt(1) // Some((list{"Hello"}, list{"World"}))
 list{0, 1, 2, 3, 4}->List.splitAt(2) // Some((list{0, 1}, list{2, 3, 4}))
 ```
 */
-let splitAt: (t<'a>, int) => option<(list<'a>, list<'a>)>
+let splitAt: (list<'a>, int) => option<(list<'a>, list<'a>)>
 
 /**
 `concat(list1, list2)` returns the list obtained by adding `list1` after `list2`.
@@ -269,7 +266,7 @@ let splitAt: (t<'a>, int) => option<(list<'a>, list<'a>)>
 List.concat(list{1, 2, 3}, list{4, 5}) // list{1, 2, 3, 4, 5}
 ```
 */
-let concat: (t<'a>, t<'a>) => t<'a>
+let concat: (list<'a>, list<'a>) => list<'a>
 
 /**
 `concatMany(arr)` returns the list obtained by concatenating all the lists in
@@ -281,7 +278,7 @@ array `arr`, in order.
 List.concatMany([list{1, 2, 3}, list{}, list{3}]) // list{1, 2, 3, 3}
 ```
 */
-let concatMany: array<t<'a>> => t<'a>
+let concatMany: array<list<'a>> => list<'a>
 
 /**
 `reverseConcat(list1, list2)` is equivalent to writing: `concat(reverse(list1, list2)`
@@ -292,7 +289,7 @@ let concatMany: array<t<'a>> => t<'a>
 List.reverseConcat(list{1, 2}, list{3, 4}) // list{2, 1, 3, 4}
 ```
 */
-let reverseConcat: (t<'a>, t<'a>) => t<'a>
+let reverseConcat: (list<'a>, list<'a>) => list<'a>
 
 /**
 `flat(list)` return the list obtained by concatenating all the lists in
@@ -304,7 +301,7 @@ let reverseConcat: (t<'a>, t<'a>) => t<'a>
 List.flat(list{list{1, 2, 3}, list{}, list{3}}) // list{1, 2, 3, 3}
 ```
 */
-let flat: t<t<'a>> => t<'a>
+let flat: list<list<'a>> => list<'a>
 
 /**
 `map(list, f)` returns a new list with `f` applied to each element of `list`.
@@ -315,7 +312,7 @@ let flat: t<t<'a>> => t<'a>
 list{1, 2}->List.map(x => x + 1) // list{3, 4}
 ```
 */
-let map: (t<'a>, 'a => 'b) => t<'b>
+let map: (list<'a>, 'a => 'b) => list<'b>
 
 /**
 `zip(list1, list2)` returns a list of pairs from the two lists with the length
@@ -327,7 +324,7 @@ of the shorter list.
 List.zip(list{1, 2}, list{3, 4, 5}) // list{(1, 3), (2, 4)}
 ```
 */
-let zip: (t<'a>, t<'b>) => t<('a, 'b)>
+let zip: (list<'a>, list<'b>) => list<('a, 'b)>
 
 /**
 `zipBy(list1, list2, f)`. See [`zip`](#zip)
@@ -338,7 +335,7 @@ let zip: (t<'a>, t<'b>) => t<('a, 'b)>
 List.zipBy(list{1, 2, 3}, list{4, 5}, (a, b) => 2 * a + b) // list{6, 9}
 ```
 */
-let zipBy: (t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>
+let zipBy: (list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>
 
 /**
 `mapWithIndex(list, f)` applies `f` to each element of `list`. Function `f`
@@ -351,7 +348,7 @@ that order.
 list{1, 2, 3}->List.mapWithIndex((x, index) => index + x) // list{1, 3, 5}
 ```
 */
-let mapWithIndex: (t<'a>, ('a, int) => 'b) => t<'b>
+let mapWithIndex: (list<'a>, ('a, int) => 'b) => list<'b>
 
 /**
 `fromArray(arr)` converts the given array `arr` to a list.
@@ -362,7 +359,7 @@ let mapWithIndex: (t<'a>, ('a, int) => 'b) => t<'b>
 List.fromArray([1, 2, 3]) // list{1, 2, 3}
 ```
 */
-let fromArray: array<'a> => t<'a>
+let fromArray: array<'a> => list<'a>
 
 /**
 `toArray(list)` converts the given list `list` to an array.
@@ -373,7 +370,7 @@ let fromArray: array<'a> => t<'a>
 List.toArray(list{1, 2, 3}) // [1, 2, 3]
 ```
 */
-let toArray: t<'a> => array<'a>
+let toArray: list<'a> => array<'a>
 
 /**
 `reverse(list)` returns a new list whose elements are those of `list` in
@@ -385,7 +382,7 @@ reversed order.
 List.reverse(list{1, 2, 3}) // list{3, 2, 1}
 ```
 */
-let reverse: t<'a> => t<'a>
+let reverse: list<'a> => list<'a>
 
 /**
 `mapReverse(list, f)` is equivalent to `map` function.
@@ -402,7 +399,7 @@ let withMapReverse = l->List.mapReverse(f)
 Console.log(withMap == withMapReverse) // true
 ```
 */
-let mapReverse: (t<'a>, 'a => 'b) => t<'b>
+let mapReverse: (list<'a>, 'a => 'b) => list<'b>
 
 /**
 `forEach(list, f)` call `f` on each element of `list` from the beginning to end.
@@ -421,7 +418,7 @@ List.forEach(list{"a", "b", "c"}, x => Console.log("Item: " ++ x))
 */
 ```
 */
-let forEach: (t<'a>, 'a => unit) => unit
+let forEach: (list<'a>, 'a => unit) => unit
 
 /**
 `forEachWithIndex(list, f, index)` call `f` on each element of `list` from beginning
@@ -442,7 +439,7 @@ List.forEachWithIndex(list{"a", "b", "c"}, (x, index) => {
 */
 ```
 */
-let forEachWithIndex: (t<'a>, ('a, int) => unit) => unit
+let forEachWithIndex: (list<'a>, ('a, int) => unit) => unit
 
 /**
 `reduce(list, initialValue, f)` applies `f` to each element of `list` from
@@ -460,7 +457,7 @@ list{1, 2, 3, 4}->List.reduce(0, (a, b) => a + b) // 10
 list{1, 2, 3, 4}->List.reduce(0, (acc, item) => acc + item) // 10
 ```
 */
-let reduce: (t<'a>, 'b, ('b, 'a) => 'b) => 'b
+let reduce: (list<'a>, 'b, ('b, 'a) => 'b) => 'b
 
 /**
 `reduceWithIndex(list, initialValue, f)` applies `f` to each element of `list`
@@ -474,7 +471,7 @@ of each element. `reduceWithIndex` returns the final value of the accumulator.
 list{1, 2, 3, 4}->List.reduceWithIndex(0, (acc, item, index) => acc + item + index) // 16
 ```
 */
-let reduceWithIndex: (t<'a>, 'b, ('b, 'a, int) => 'b) => 'b
+let reduceWithIndex: (list<'a>, 'b, ('b, 'a, int) => 'b) => 'b
 
 /**
 `reduceReverse(list, initialValue, f)` works like `reduce`, except that
@@ -490,7 +487,7 @@ list{1, 2, 3, 4}->List.reduceReverse(10, (a, b) => a - b) // 0
 list{1, 2, 3, 4}->List.reduceReverse(list{}, List.add) // list{1, 2, 3, 4}
 ```
 */
-let reduceReverse: (t<'a>, 'b, ('b, 'a) => 'b) => 'b
+let reduceReverse: (list<'a>, 'b, ('b, 'a) => 'b) => 'b
 
 /**
 `mapReverse2(list1, list2, f)` is equivalent to `List.zipBy(list1, list2, f)->List.reverse`.
@@ -501,7 +498,7 @@ let reduceReverse: (t<'a>, 'b, ('b, 'a) => 'b) => 'b
 List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}
 ```
 */
-let mapReverse2: (t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>
+let mapReverse2: (list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>
 
 /**
 `forEach2(list1, list2, f)` is similar to `forEach`, but accepts two lists and
@@ -519,7 +516,7 @@ List.forEach2(list{"Z", "Y"}, list{"A", "B", "C"}, (x, y) => Console.log2(x, y))
 */
 ```
 */
-let forEach2: (t<'a>, t<'b>, ('a, 'b) => 'c) => unit
+let forEach2: (list<'a>, list<'b>, ('a, 'b) => 'c) => unit
 
 /**
 `reduce2(list1, list2, initialValue, f)` applies `f` to each element of `list1`
@@ -534,7 +531,7 @@ accumulator.
 List.reduce2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) // 0 + (1 * 1 + 4) + (2 * 2 + 5)
 ```
 */
-let reduce2: (t<'b>, t<'c>, 'a, ('a, 'b, 'c) => 'a) => 'a
+let reduce2: (list<'b>, list<'c>, 'a, ('a, 'b, 'c) => 'a) => 'a
 
 /**
 `reduceReverse2(list1, list2, initialValue, f)` applies `f` to each element of
@@ -549,7 +546,7 @@ final value of the accumulator.
 List.reduceReverse2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) //  + (1 * 1 + 4) + (2 * 2 + 5)
 ```
 */
-let reduceReverse2: (t<'a>, t<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
+let reduceReverse2: (list<'a>, list<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
 
 /**
 `every(list, f)` returns `true` if all elements in `list` satisfy `f`, where `f`
@@ -565,7 +562,7 @@ list{1, 9, 8, 2}->List.every(isBelow10) // true
 list{1, 99, 8, 2}->List.every(isBelow10) // false
 ```
 */
-let every: (t<'a>, 'a => bool) => bool
+let every: (list<'a>, 'a => bool) => bool
 
 /**
 `some(list, f)` returns `true` if at least _one_ of the elements in `list`
@@ -582,7 +579,7 @@ list{101, 1, 2, 3}->List.some(isAbove100) // true
 list{1, 2, 3, 4}->List.some(isAbove100) // false
 ```
 */
-let some: (t<'a>, 'a => bool) => bool
+let some: (list<'a>, 'a => bool) => bool
 
 /**
 `every2(list1, list2, f)` returns `true` if predicate `f` is `true` for all
@@ -600,7 +597,7 @@ List.every2(list{2, 3}, list{1}, (a, b) => a > b) // true
 List.every2(list{0, 1}, list{5, 0}, (a, b) => a > b) // false
 ```
 */
-let every2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
+let every2: (list<'a>, list<'b>, ('a, 'b) => bool) => bool
 
 /**
 `some2(list1, list2, f)` returns `true` if predicate `f` is `true` for any pair
@@ -618,7 +615,7 @@ List.some2(list{2, 3}, list{1}, (a, b) => a > b) // true
 List.some2(list{0, 1}, list{5, 0}, (a, b) => a > b) // true
 ```
 */
-let some2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
+let some2: (list<'a>, list<'b>, ('a, 'b) => bool) => bool
 
 /**
 `compareLength(list1, list2)` compare two lists solely by length. Returns `-1.` if
@@ -635,7 +632,7 @@ List.compareLength(list{1, 2, 3}, list{4, 5, 6}) // 0.
 List.compareLength(list{1, 2, 3, 4}, list{5, 6}) // 1.
 ```
 */
-let compareLength: (t<'a>, t<'a>) => Stdlib_Ordering.t
+let compareLength: (list<'a>, list<'a>) => Stdlib_Ordering.t
 
 /**
 `compare(list1, list2, f)` compare elements one by one `f`. `f` returns a negative
@@ -662,7 +659,7 @@ List.compare(list{1, 3, 5}, list{1, 3, 5}, (a, b) => Int.compare(a, b)) // 0.
 for Array, we compare the length first and, only if the lengths are equal, elements one by one.
 For lists, we just compare elements one by one.
 */
-let compare: (t<'a>, t<'a>, ('a, 'a) => Stdlib_Ordering.t) => Stdlib_Ordering.t
+let compare: (list<'a>, list<'a>, ('a, 'a) => Stdlib_Ordering.t) => Stdlib_Ordering.t
 
 /**
 `equal(list1, list2, f)` check equality of `list2` and `list2` using `f` for
@@ -680,7 +677,7 @@ List.equal(list{1, 2}, list{1, 2}, (a, b) => a == b) // true
 List.equal(list{1, 2, 3}, list{(-1), (-2), (-3)}, (a, b) => abs(a) == abs(b)) // true
 ```
 */
-let equal: (t<'a>, t<'a>, ('a, 'a) => bool) => bool
+let equal: (list<'a>, list<'a>, ('a, 'a) => bool) => bool
 
 /**
 `has(list, element, f)` returns `true` if the list contains at least one
@@ -696,7 +693,7 @@ list{1, 2, 3}->List.has(4, (a, b) => a == b) // false
 list{(-1), (-2), (-3)}->List.has(2, (a, b) => abs(a) == abs(b)) // true
 ```
 */
-let has: (t<'a>, 'b, ('a, 'b) => bool) => bool
+let has: (list<'a>, 'b, ('a, 'b) => bool) => bool
 
 /**
 `find(list, f)` returns `Some(value)` for the first value in `list` that
@@ -711,7 +708,7 @@ List.find(list{1, 4, 3, 2}, x => x > 3) // Some(4)
 List.find(list{1, 4, 3, 2}, x => x > 4) // None
 ```
 */
-let find: (t<'a>, 'a => bool) => option<'a>
+let find: (list<'a>, 'a => bool) => option<'a>
 
 /**
 `filter(list, f)` returns a list of all elements in `list` which satisfy the
@@ -727,7 +724,7 @@ List.filter(list{1, 2, 3, 4}, isEven) // list{2, 4}
 List.filter(list{None, Some(2), Some(3), None}, Option.isSome) // list{Some(2), Some(3)}
 ```
 */
-let filter: (t<'a>, 'a => bool) => t<'a>
+let filter: (list<'a>, 'a => bool) => list<'a>
 
 /**
 `filterWithIndex(list, f)` returns a list of all elements in `list` which
@@ -741,7 +738,7 @@ let isEven = x => mod(x, 2) == 0
 List.filterWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)) // list{1, 3}
 ```
 */
-let filterWithIndex: (t<'a>, ('a, int) => bool) => t<'a>
+let filterWithIndex: (list<'a>, ('a, int) => bool) => list<'a>
 
 /**
 `filterMap(list, f)` applies `f` to each element of `list`. If `f` returns
@@ -765,7 +762,7 @@ list{1, 2, 3, 4}
 list{Some(1), Some(2), None}->List.filterMap(x => x) // list{1, 2}
 ```
 */
-let filterMap: (t<'a>, 'a => option<'b>) => t<'b>
+let filterMap: (list<'a>, 'a => option<'b>) => list<'b>
 
 /**
 `partition(list, f)` creates a pair of lists; the first list consists of all
@@ -780,7 +777,7 @@ consists of all elements of `list` that _do not_ satisfy `f`.
 List.partition(list{1, 2, 3, 4}, x => x > 2) // (list{3, 4}, list{1, 2})
 ```
 */
-let partition: (t<'a>, 'a => bool) => (t<'a>, t<'a>)
+let partition: (list<'a>, 'a => bool) => (list<'a>, list<'a>)
 
 /**
 `unzip(list)` takes a list of pairs and creates a pair of lists. The first list
@@ -796,7 +793,7 @@ List.unzip(list{("H", "W"), ("e", "o"), ("l", "r"), ("l", "l"), ("o", "d"), (" "
 // (list{"H", "e", "l", "l", "o", " "}, list{"W", "o", "r", "l", "d", "!"})
 ```
 */
-let unzip: t<('a, 'b)> => (t<'a>, t<'b>)
+let unzip: list<('a, 'b)> => (list<'a>, list<'b>)
 
 /**
 `getAssoc(list, k, f)` return the second element of a pair in `list` where
@@ -813,7 +810,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 // Some("afternoon")
 ```
 */
-let getAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => option<'c>
+let getAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => option<'c>
 
 /**
 `hasAssoc(list, k, f)` returns `true` if there is a pair in `list` where the
@@ -828,7 +825,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 ->List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */) // false
 ```
 */
-let hasAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => bool
+let hasAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => bool
 
 /**
 `removeAssoc(list, k, f)` return a list after removing the first pair whose
@@ -845,7 +842,7 @@ list{(9, "morning"), (15, "afternoon"), (22, "night")}
 // list{(15, "afternoon"), (22, "night")}
 ```
 */
-let removeAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => t<('a, 'c)>
+let removeAssoc: (list<('a, 'c)>, 'b, ('a, 'b) => bool) => list<('a, 'c)>
 
 /**
 `setAssoc(list, k, v, f)`. If `k` exists in `list` by satisfying the `f`
@@ -868,7 +865,7 @@ list{(9, "morning"), (3, "morning?!"), (22, "night")}
 **Please note**: In the last example, since: `15 mod 12` equals `3 mod 12`. Both
 the key _and_ the value are replaced in the list.
 */
-let setAssoc: (t<('a, 'c)>, 'a, 'c, ('a, 'a) => bool) => t<('a, 'c)>
+let setAssoc: (list<('a, 'c)>, 'a, 'c, ('a, 'a) => bool) => list<('a, 'c)>
 
 /**
 `sort(list, f)` returns a sorted list.
@@ -879,4 +876,4 @@ let setAssoc: (t<('a, 'c)>, 'a, 'c, ('a, 'a) => bool) => t<('a, 'c)>
 List.sort(list{5, 4, 9, 3, 7}, Int.compare) // list{3, 4, 5, 7, 9}
 ```
 */
-let sort: (t<'a>, ('a, 'a) => Stdlib_Ordering.t) => t<'a>
+let sort: (list<'a>, ('a, 'a) => Stdlib_Ordering.t) => list<'a>

--- a/runtime/Stdlib_Result.resi
+++ b/runtime/Stdlib_Result.resi
@@ -31,7 +31,7 @@
 /**
   The type `Result.t(result, err)` describes a variant of two states:
   `Ok(someResult)` represents a successful operation, whereby
-  ``Error(someError)` signals an erronous operation.
+  ``Error(someError)` signals an erroneous operation.
 
   In this concrete example, we are defining our own `Result` type to reflect an HTTP like
   query operation:

--- a/tests/analysis_tests/tests/src/expected/Auto.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Auto.res.txt
@@ -1,3 +1,3 @@
 Hover src/Auto.res 2:13
-{"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, Stdlib.List.t<'a>) => Stdlib.List.t<'b>\n```\n\n---\n\n```\n \n```\n```rescript\ntype Stdlib.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Stdlib_List.resi%22%2C34%2C0%5D)\n"}}
+{"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```"}}
 

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -1951,7 +1951,7 @@ Path this
     "kind": 12,
     "tags": [],
     "detail": "\\\"Type Not Known\"",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype props<'first, 'zoo, 'second> = {\n  first?: 'first,\n  zoo?: 'zoo,\n  second: 'second,\n}\n```"}
   }]
 
 Hover src/Completion.res 349:14
@@ -2511,7 +2511,7 @@ Path Stdlib.Result.g
     "kind": 12,
     "tags": [],
     "detail": "result<'a, 'b> => 'a",
-    "documentation": {"kind": "markdown", "value": "\n  `getExn(res)`: when `res` is `Ok(n)`, returns `n` when `res` is `Error(m)`, raise an exception\n\n  ```res example\n  Result.getExn(Result.Ok(42)) == 42\n\n  switch Result.getExn(Error(\"Invalid data\")) {\n  | exception Not_found => assert(true)\n  | _ => assert(false)\n  }\n  ```\n"}
+    "documentation": {"kind": "markdown", "value": "\n  Result types are really useful to describe the result of a certain operation\n  without relying on exceptions or `option` types.\n\n  This module gives you useful utilities to create and combine `Result` data.\n"}
   }, {
     "label": "Result.getOr",
     "kind": 12,

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -10,31 +10,31 @@ Path MyList.m
     "label": "mapReverse",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "detail": "(list<'a>, 'a => 'b) => list<'b>",
     "documentation": {"kind": "markdown", "value": "\n`mapReverse(list, f)` is equivalent to `map` function.\n\n## Examples\n\n```rescript\nlet f = x => x * x\nlet l = list{3, 4, 5}\n\nlet withMap = List.map(l, f)->List.reverse\nlet withMapReverse = l->List.mapReverse(f)\n\nConsole.log(withMap == withMapReverse) // true\n```\n"}
   }, {
     "label": "mapReverse2",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>",
+    "detail": "(list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>",
     "documentation": {"kind": "markdown", "value": "\n`mapReverse2(list1, list2, f)` is equivalent to `List.zipBy(list1, list2, f)->List.reverse`.\n\n## Examples\n\n```rescript\nList.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}\n```\n"}
   }, {
     "label": "make",
     "kind": 12,
     "tags": [],
-    "detail": "(~length: int, 'a) => t<'a>",
+    "detail": "(~length: int, 'a) => list<'a>",
     "documentation": {"kind": "markdown", "value": "\n`make(length, value)` returns a list of length `length` with each element filled\nwith `value`. Returns an empty list if `value` is negative.\n\n## Examples\n\n```rescript\nList.make(~length=3, 1) // list{1, 1, 1}\n```\n"}
   }, {
     "label": "mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "detail": "(list<'a>, ('a, int) => 'b) => list<'b>",
     "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(list, f)` applies `f` to each element of `list`. Function `f`\ntakes two arguments: the index starting from 0 and the element from `list`, in\nthat order.\n\n## Examples\n\n```rescript\nlist{1, 2, 3}->List.mapWithIndex((x, index) => index + x) // list{1, 3, 5}\n```\n"}
   }, {
     "label": "map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "detail": "(list<'a>, 'a => 'b) => list<'b>",
     "documentation": {"kind": "markdown", "value": "\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}
   }]
 
@@ -1951,7 +1951,7 @@ Path this
     "kind": 12,
     "tags": [],
     "detail": "\\\"Type Not Known\"",
-    "documentation": {"kind": "markdown", "value": "```rescript\ntype props<'first, 'zoo, 'second> = {\n  first?: 'first,\n  zoo?: 'zoo,\n  second: 'second,\n}\n```"}
+    "documentation": null
   }]
 
 Hover src/Completion.res 349:14
@@ -2511,7 +2511,7 @@ Path Stdlib.Result.g
     "kind": 12,
     "tags": [],
     "detail": "result<'a, 'b> => 'a",
-    "documentation": {"kind": "markdown", "value": "\n  Result types are really useful to describe the result of a certain operation\n  without relying on exceptions or `option` types.\n\n  This module gives you useful utilities to create and combine `Result` data.\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `getExn(res)`: when `res` is `Ok(n)`, returns `n` when `res` is `Error(m)`, raise an exception\n\n  ```res example\n  Result.getExn(Result.Ok(42)) == 42\n\n  switch Result.getExn(Error(\"Invalid data\")) {\n  | exception Not_found => assert(true)\n  | _ => assert(false)\n  }\n  ```\n"}
   }, {
     "label": "Result.getOr",
     "kind": 12,

--- a/tests/analysis_tests/tests/src/expected/Definition.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Definition.res.txt
@@ -5,10 +5,10 @@ Definition src/Definition.res 10:23
 {"uri": "Definition.res", "range": {"start": {"line": 6, "character": 7}, "end": {"line": 6, "character": 13}}}
 
 Hover src/Definition.res 14:14
-{"contents": {"kind": "markdown", "value": "```rescript\n(Stdlib.List.t<'a>, 'a => 'b) => Stdlib.List.t<'b>\n```\n\n---\n\n```\n \n```\n```rescript\ntype Stdlib.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Stdlib_List.resi%22%2C34%2C0%5D)\n\n---\n\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}}
+{"contents": {"kind": "markdown", "value": "```rescript\n(list<'a>, 'a => 'b) => list<'b>\n```\n---\n\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}}
 
 Hover src/Definition.res 18:14
-{"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, Stdlib.List.t<'a>) => Stdlib.List.t<'b>\n```\n\n---\n\n```\n \n```\n```rescript\ntype Stdlib.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Stdlib_List.resi%22%2C34%2C0%5D)\n"}}
+{"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```"}}
 
 Hover src/Definition.res 23:3
 {"contents": {"kind": "markdown", "value": "```rescript\n(int, int) => int\n```"}}


### PR DESCRIPTION
- remove `List.t`
- rename `toShuffled` to `shuffle` and deprecate it
- deprecate `List.*Assoc` functions

I think this solves most issues raised in rescript-lang/rescript-core/issues/192.

I have no good idea for `List.concatMany` so I just kept it.

I'd rather keep `List.has` and `List.length` as it is today and maybe we could add `Array.has` for consistency.