### PR TITLE
Ocaml 5.3

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -2,7 +2,7 @@
 
 # Install dev dependencies from OPAM
 opam init -y --bare --disable-sandboxing
-opam switch create 5.2.1 --packages ocaml-option-static
+opam switch create 5.3.0 --packages ocaml-option-static
 opam install . --deps-only -y
 
 # For IDE support, install the OCaml language server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
 
           # Verify that the compiler still builds with older OCaml versions
           - os: ubuntu-24.04
+            ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
+            # Reanalyze does not work on OCaml 5.3.0 anymore, therefore run it on 5.2.1
+            run_reanalyze: true
+          - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.5.0.0+options,ocaml-option-static
           - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.4.14.2+options,ocaml-option-static
@@ -296,6 +300,12 @@ jobs:
       - name: "Syntax: Run tests (Windows)"
         if: ${{ runner.os == 'Windows' }}
         run: opam exec -- make test-syntax
+
+      - name: "Syntax: Run reanalyze"
+        if: matrix.run_reanalyze
+        run: |
+          opam install reanalyze
+          opam exec -- make reanalyze
 
       - name: Build runtime/stdlib
         run: ./scripts/buildRuntime.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,6 @@ jobs:
             ocaml_compiler: ocaml-variants.5.0.0+options,ocaml-option-static
           - os: ubuntu-24.04
             ocaml_compiler: ocaml-variants.4.14.2+options,ocaml-option-static
-          - os: ubuntu-24.04
-            ocaml_compiler: ocaml-variants.4.13.0+options,ocaml-option-static
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,23 +87,23 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04 # x64
-            ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
+            ocaml_compiler: ocaml-variants.5.3.0+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
           - os: ubuntu-24.04-arm # ARM
-            ocaml_compiler: ocaml-variants.5.2.1+options,ocaml-option-static
+            ocaml_compiler: ocaml-variants.5.3.0+options,ocaml-option-static
             upload_binaries: true
             # Build the playground compiler and run the benchmarks on the fastest runner
             build_playground: true
             benchmarks: true
           - os: macos-13 # x64
-            ocaml_compiler: 5.2.1
+            ocaml_compiler: 5.3.0
             upload_binaries: true
           - os: macos-14 # ARM
-            ocaml_compiler: 5.2.1
+            ocaml_compiler: 5.3.0
             upload_binaries: true
           - os: windows-latest
-            ocaml_compiler: 5.2.1
+            ocaml_compiler: 5.3.0
             upload_binaries: true
 
           # Verify that the compiler still builds with older OCaml versions

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 profile = default
-version = 0.26.2
+version = 0.27.0
 
 field-space = tight-decl
 break-cases = toplevel
@@ -9,3 +9,4 @@ space-around-arrays = false
 space-around-lists = false
 space-around-records = false
 space-around-variants = false
+parse-docstrings = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed on 
 opam init
 
 # Any recent OCaml version works as a development compiler
-opam switch create 5.2.1 # can also create local switch with opam switch create
+opam switch create 5.3.0 # can also create local switch with opam switch create
 
 # Install dev dependencies from OPAM
 opam install . --deps-only --with-test --with-dev-setup -y

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,10 @@ test-tools:
 
 test-syntax:
 	bash ./scripts/test_syntax.sh
-	make reanalyze
 	bash ./scripts/testok.sh
 
 test-syntax-roundtrip:
 	ROUNDTRIP_TEST=1 bash ./scripts/test_syntax.sh
-	make reanalyze
 	bash ./scripts/testok.sh
 
 test-gentype:

--- a/analysis.opam
+++ b/analysis.opam
@@ -7,8 +7,8 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
-  "ocaml" {>= "4.10"}
-  "cppo" {= "1.6.9"}
+  "ocaml" {>= "4.14"}
+  "cppo" {= "1.8.0"}
   "dune"
 ]
 build: [

--- a/analysis/reanalyze/src/DeadCommon.ml
+++ b/analysis/reanalyze/src/DeadCommon.ml
@@ -555,7 +555,8 @@ module Decl = struct
         let refIsBelow (pos : Lexing.position) =
           decl.pos.pos_fname <> pos.pos_fname
           || decl.pos.pos_cnum < pos.pos_cnum
-             && (* not a function defined inside a function, e.g. not a callback *)
+             &&
+             (* not a function defined inside a function, e.g. not a callback *)
              decl.posEnd.pos_cnum < pos.pos_cnum
         in
         refs |> PosSet.exists refIsBelow

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -553,44 +553,44 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                 let offset = ref 0 in
                 Some
                   (`InlineRecord
-                    (fields
-                    |> List.map (fun (field : field) ->
-                           let startOffset = !offset in
-                           let argText =
-                             Printf.sprintf "%s%s: %s" field.fname.txt
-                               (if field.optional then "?" else "")
-                               (Shared.typeToString
-                                  (if field.optional then
-                                     Utils.unwrapIfOption field.typ
-                                   else field.typ))
-                           in
-                           let endOffset =
-                             startOffset + String.length argText
-                           in
-                           offset := endOffset + String.length ", ";
-                           (argText, field, (startOffset, endOffset)))))
+                     (fields
+                     |> List.map (fun (field : field) ->
+                            let startOffset = !offset in
+                            let argText =
+                              Printf.sprintf "%s%s: %s" field.fname.txt
+                                (if field.optional then "?" else "")
+                                (Shared.typeToString
+                                   (if field.optional then
+                                      Utils.unwrapIfOption field.typ
+                                    else field.typ))
+                            in
+                            let endOffset =
+                              startOffset + String.length argText
+                            in
+                            offset := endOffset + String.length ", ";
+                            (argText, field, (startOffset, endOffset)))))
               | Args [(typ, _)] ->
                 Some
                   (`SingleArg
-                    ( typ |> Shared.typeToString,
-                      docsForLabel ~file:full.file ~package:full.package
-                        ~supportsMarkdownLinks typ ))
+                     ( typ |> Shared.typeToString,
+                       docsForLabel ~file:full.file ~package:full.package
+                         ~supportsMarkdownLinks typ ))
               | Args args ->
                 let offset = ref 0 in
                 Some
                   (`TupleArg
-                    (args
-                    |> List.map (fun (typ, _) ->
-                           let startOffset = !offset in
-                           let argText = typ |> Shared.typeToString in
-                           let endOffset =
-                             startOffset + String.length argText
-                           in
-                           offset := endOffset + String.length ", ";
-                           ( argText,
-                             docsForLabel ~file:full.file ~package:full.package
-                               ~supportsMarkdownLinks typ,
-                             (startOffset, endOffset) ))))
+                     (args
+                     |> List.map (fun (typ, _) ->
+                            let startOffset = !offset in
+                            let argText = typ |> Shared.typeToString in
+                            let endOffset =
+                              startOffset + String.length argText
+                            in
+                            offset := endOffset + String.length ", ";
+                            ( argText,
+                              docsForLabel ~file:full.file ~package:full.package
+                                ~supportsMarkdownLinks typ,
+                              (startOffset, endOffset) ))))
             in
             let label =
               constructor.name ^ "("

--- a/compiler/bsb/bsb_exception.ml
+++ b/compiler/bsb/bsb_exception.ml
@@ -40,7 +40,8 @@ let print (fmt : Format.formatter) (x : error) =
   | Conflict_module (modname, dir1, dir2) ->
     Format.fprintf fmt
       "@{<error>Error:@} %s found in two directories: (%s, %s)\n\
-       File names must be unique per project" modname dir1 dir2
+       File names must be unique per project"
+      modname dir1 dir2
   | No_implementation modname ->
     Format.fprintf fmt "@{<error>Error:@} %s does not have implementation file"
       modname
@@ -51,12 +52,14 @@ let print (fmt : Format.formatter) (x : error) =
         "File \"bsconfig.json\", line 1\n\
          @{<error>Error:@} package @{<error>%s@} is not found\n\
          It's the basic, required package. If you have it installed globally,\n\
-         Please run `npm link rescript` to make it available" name
+         Please run `npm link rescript` to make it available"
+        name
     else
       Format.fprintf fmt
         "File \"bsconfig.json\", line 1\n\
          @{<error>Error:@} package @{<error>%s@} not found or built\n\
-         - Did you install it?" name
+         - Did you install it?"
+        name
   | Json_config (pos, s) ->
     Format.fprintf fmt
       "File %S, line %d:\n\

--- a/compiler/bsb/bsb_ninja_check.ml
+++ b/compiler/bsb/bsb_ninja_check.ml
@@ -114,8 +114,9 @@ let record ~(package_kind : Bsb_package_kind.t) ~per_proj_dir ~file
   record_global_atime buf Sys.executable_name;
   Ext_list.iter config.ppx_files (fun {name; args = _} ->
       try record_global_atime buf name
-      with _ -> (* record the ppx files as a best effort *)
-                ());
+      with _ ->
+        (* record the ppx files as a best effort *)
+        ());
   let oc = open_out_bin file in
   Ext_buffer.output_buffer oc buf;
   close_out oc

--- a/compiler/bsb/bsb_ninja_gen.ml
+++ b/compiler/bsb/bsb_ninja_gen.ml
@@ -40,7 +40,8 @@ let emit_bsc_lib_includes (bs_dependencies : Bsb_config_types.dependencies)
   let all_includes source_dirs =
     source_dirs
     @ Ext_list.map bs_dependencies (fun x -> x.package_install_path)
-    @ (* for external includes, if it is absolute path, leave it as is
+    @
+    (* for external includes, if it is absolute path, leave it as is
          for relative path './xx', we need '../.././x' since we are in
          [lib/bs], [build] is different from merlin though
       *)

--- a/compiler/bsb/bsb_parse_sources.ml
+++ b/compiler/bsb/bsb_parse_sources.ml
@@ -322,8 +322,9 @@ and parse_sources (cxt : cxt) (sources : Ext_json_types.t) =
   | Arr file_groups -> parsing_arr_sources cxt file_groups.content
   | _ -> parsing_single_source cxt sources
 
-let scan ~package_kind ~root ~cut_generators ~(* ~namespace  *)
-                                              ignored_dirs x : t =
+let scan ~package_kind ~root ~cut_generators
+    ~(* ~namespace  *)
+     ignored_dirs x : t =
   parse_sources
     {
       ignored_dirs;

--- a/compiler/bsb_helper/bsb_db_decode.ml
+++ b/compiler/bsb_helper/bsb_db_decode.ml
@@ -51,7 +51,10 @@ and decode_single (x : string) (offset : cursor) : group =
     let modules = decode_modules x offset module_number in
     let dir_info_offset = !offset in
     let module_info_offset = String.index_from x dir_info_offset '\n' + 1 in
-    let dir_length = Char.code x.[module_info_offset] - 48 (* Char.code '0'*) in
+    let dir_length =
+      Char.code x.[module_info_offset] - 48
+      (* Char.code '0'*)
+    in
     offset := module_info_offset + 1 + (dir_length * module_number) + 1;
     Group {modules; dir_info_offset; module_info_offset; dir_length})
   else Dummy

--- a/compiler/core/js_analyzer.ml
+++ b/compiler/core/js_analyzer.ml
@@ -58,7 +58,8 @@ let free_variables (stats : idents_stats) =
         | Fun {env}
         (* a optimization to avoid walking into function again
             if it's already comuted
-        *) ->
+        *)
+          ->
           stats.used_idents <-
             Set_ident.union (Js_fun_env.get_unbounded env) stats.used_idents
         | _ -> super.expression self exp);

--- a/compiler/core/js_cmj_format.ml
+++ b/compiler/core/js_cmj_format.ml
@@ -113,7 +113,7 @@ let get_result mid_val =
   match mid_val.persistent_closed_lambda with
   | Some
       (Lconst
-        (Const_js_null | Const_js_undefined _ | Const_js_true | Const_js_false))
+         (Const_js_null | Const_js_undefined _ | Const_js_true | Const_js_false))
   | None ->
     mid_val
   | Some _ ->
@@ -131,8 +131,10 @@ let rec binary_search_aux arr lo hi (key : string) =
       let lo_val = Array.unsafe_get arr lo in
       if lo_val.name = key then get_result lo_val else not_found key
     else binary_search_aux arr lo mid key
-  else if (*  a[lo] =< a[mid] < key <= a[hi] *)
-          lo = mid then
+  else if
+    (*  a[lo] =< a[mid] < key <= a[hi] *)
+    lo = mid
+  then
     let hi_val = Array.unsafe_get arr hi in
     if hi_val.name = key then get_result hi_val else not_found key
   else binary_search_aux arr mid hi key

--- a/compiler/core/js_cmj_format.ml
+++ b/compiler/core/js_cmj_format.ml
@@ -33,7 +33,7 @@ type cmj_value = {
       (** Either constant or closed functor *)
 }
 
-type effect = string option
+type effect_ = string option
 
 let single_na = Single Lam_arity.na
 
@@ -52,7 +52,7 @@ type t = {
   case: Ext_js_file_kind.case;
 }
 
-let make ~(values : cmj_value Map_string.t) ~effect ~package_spec ~case : t =
+let make ~(values : cmj_value Map_string.t) ~effect_ ~package_spec ~case : t =
   {
     values =
       Map_string.to_sorted_array_with_f values (fun k v ->
@@ -61,7 +61,7 @@ let make ~(values : cmj_value Map_string.t) ~effect ~package_spec ~case : t =
             arity = v.arity;
             persistent_closed_lambda = v.persistent_closed_lambda;
           });
-    pure = effect = None;
+    pure = effect_ = None;
     package_spec;
     case;
   }

--- a/compiler/core/js_cmj_format.mli
+++ b/compiler/core/js_cmj_format.mli
@@ -52,7 +52,7 @@ type cmj_value = {
   persistent_closed_lambda: Lam.t option; (* Either constant or closed functor *)
 }
 
-type effect = string option
+type effect_ = string option
 
 type keyed_cmj_value = {
   name: string;
@@ -69,7 +69,7 @@ type t = {
 
 val make :
   values:cmj_value Map_string.t ->
-  effect:effect ->
+  effect_:effect_ ->
   package_spec:Js_packages_info.t ->
   case:Ext_js_file_kind.case ->
   t

--- a/compiler/core/js_dump.ml
+++ b/compiler/core/js_dump.ml
@@ -436,7 +436,7 @@ and pp_function ~return_unit ~async ~is_method ?directive cxt (f : P.t)
     since it can be either [int] or [string]
 *)
 and pp_one_case_clause :
-      'a. _ -> P.t -> (P.t -> 'a -> unit) -> 'a * J.case_clause -> _ =
+    'a. _ -> P.t -> (P.t -> 'a -> unit) -> 'a * J.case_clause -> _ =
  fun cxt f pp_cond
      (switch_case, ({switch_body; should_break; comment} : J.case_clause)) ->
   P.newline f;
@@ -467,8 +467,7 @@ and pp_one_case_clause :
   cxt
 
 and loop_case_clauses :
-      'a. cxt -> P.t -> (P.t -> 'a -> unit) -> ('a * J.case_clause) list -> cxt
-    =
+    'a. cxt -> P.t -> (P.t -> 'a -> unit) -> ('a * J.case_clause) list -> cxt =
  fun cxt f pp_cond cases ->
   Ext_list.fold_left cases cxt (fun acc x -> pp_one_case_clause acc f pp_cond x)
 
@@ -693,7 +692,8 @@ and expression_desc cxt ~(level : int) f x : cxt =
      {[ 0. - x ]}
      {[ 0.00 - x ]}
      {[ 0.000 - x ]}
-  *) ->
+  *)
+    ->
     P.cond_paren_group f (level > 13) (fun _ ->
         P.string f
           (match desc with
@@ -1214,7 +1214,8 @@ and statement_desc top cxt f (s : J.statement_desc) : cxt =
           semi f;
           cxt)
       (* There MUST be a space between the return and its
-         argument. A line return will not work *))
+         argument. A line return will not work *)
+    )
   | Int_switch (e, cc, def) ->
     P.string f L.switch;
     P.space f;

--- a/compiler/core/js_exp_make.mli
+++ b/compiler/core/js_exp_make.mli
@@ -76,16 +76,22 @@ val external_var :
 val ml_module_as_var : ?comment:string -> ?dynamic_import:bool -> Ident.t -> t
 
 val runtime_call :
-  string -> (* module_name *)
-            string -> (* fn_name *)
-                      t list -> (* args *)
-                                t
+  string ->
+  (* module_name *)
+  string ->
+  (* fn_name *)
+  t list ->
+  (* args *)
+  t
 
 val pure_runtime_call :
-  string -> (* module_name *)
-            string -> (* fn_name *)
-                      t list -> (* args *)
-                                t
+  string ->
+  (* module_name *)
+  string ->
+  (* fn_name *)
+  t list ->
+  (* args *)
+  t
 
 val runtime_ref : string -> string -> t
 

--- a/compiler/core/js_pass_scope.ml
+++ b/compiler/core/js_pass_scope.ml
@@ -198,7 +198,8 @@ let record_scope_pass =
                   since it's in the loop
 
                   TODO: we should also
-              *) -> (
+              *)
+                -> (
                 match value with
                 | None ->
                   add_loop_mutable_variable state ident

--- a/compiler/core/lam_compile.ml
+++ b/compiler/core/lam_compile.ml
@@ -509,26 +509,22 @@ let compile output_prefix =
         Ext_list.fold_left rest acc (fun acc x ->
             Js_output.append_output acc (compile_recursive_lets_aux cxt x)))
   and compile_general_cases :
-        'a.
-        make_exp:('a -> J.expression) ->
-        eq_exp:
-          ('a option ->
-          J.expression ->
-          'a option ->
-          J.expression ->
-          J.expression) ->
-        cxt:Lam_compile_context.t ->
-        switch:
-          (?default:J.block ->
-          ?declaration:Lam_compat.let_kind * Ident.t ->
-          _ ->
-          ('a * J.case_clause) list ->
-          J.statement) ->
-        switch_exp:J.expression ->
-        default:default_case ->
-        ?merge_cases:('a -> 'a -> bool) ->
-        ('a * Lam.t) list ->
-        J.block =
+      'a.
+      make_exp:('a -> J.expression) ->
+      eq_exp:
+        ('a option -> J.expression -> 'a option -> J.expression -> J.expression) ->
+      cxt:Lam_compile_context.t ->
+      switch:
+        (?default:J.block ->
+        ?declaration:Lam_compat.let_kind * Ident.t ->
+        _ ->
+        ('a * J.case_clause) list ->
+        J.statement) ->
+      switch_exp:J.expression ->
+      default:default_case ->
+      ?merge_cases:('a -> 'a -> bool) ->
+      ('a * Lam.t) list ->
+      J.block =
    fun (type a) ~(make_exp : a -> J.expression)
        ~(eq_exp :
           a option -> J.expression -> a option -> J.expression -> J.expression)

--- a/compiler/core/lam_compile_main.ml
+++ b/compiler/core/lam_compile_main.ml
@@ -266,13 +266,13 @@ js
           ) 
     in
     Warnings.check_fatal();
-    let effect = 
+    let effect_ = 
       Lam_stats_export.get_dependent_module_effect
         maybe_pure external_module_ids in 
     let v : Js_cmj_format.t = 
       Lam_stats_export.export_to_cmj 
         meta  
-        effect 
+        effect_ 
         coerced_input.export_map          
         (if Ext_char.is_lower_case (Filename.basename output_prefix).[0] then Little else Upper)
     in
@@ -280,7 +280,7 @@ js
        Js_cmj_format.to_file 
          ~check_exists:(not !Js_config.force_cmj)
          (output_prefix ^ Literals.suffix_cmj) v);
-    {J.program = program ; side_effect = effect ; modules = external_module_ids }      
+    {J.program = program ; side_effect = effect_ ; modules = external_module_ids }      
   )
 ;;
 

--- a/compiler/core/lam_compile_primitive.ml
+++ b/compiler/core/lam_compile_primitive.ml
@@ -612,5 +612,6 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
   (* let parm = Ident.create "prim" in
      Lfunction(Curried, [parm],
                Matching.inline_lazy_force (Lvar parm) Location.none)
-     It is inlined, this should not appear here *) ->
+     It is inlined, this should not appear here *)
+    ->
     assert false

--- a/compiler/core/lam_pass_lets_dce.ml
+++ b/compiler/core/lam_pass_lets_dce.ml
@@ -59,7 +59,8 @@ let lets_helper (count_var : Ident.t -> Lam_pass_count.used_info) lam : Lam.t =
          Note for some constant which is not
          inlined, we can still record it and
          do constant folding independently
-      *) ->
+      *)
+        ->
         Hash_ident.add subst v (simplif l1);
         simplif l2
       | _, Lconst (Const_string {s; unicode = false}) ->

--- a/compiler/core/lam_pass_remove_alias.ml
+++ b/compiler/core/lam_pass_remove_alias.ml
@@ -156,12 +156,12 @@ let simplify_alias (meta : Lam_stats.t) (lam : Lam.t) : Lam.t =
       match Hash_ident.find_opt meta.ident_tbl v with
       | Some
           (FunctionId
-            {
-              lambda =
-                Some
-                  ( Lfunction ({params; body; attr = {is_a_functor}} as m),
-                    rec_flag );
-            })
+             {
+               lambda =
+                 Some
+                   ( Lfunction ({params; body; attr = {is_a_functor}} as m),
+                     rec_flag );
+             })
         when Lam_analysis.lfunction_can_be_inlined m ->
         if Ext_list.same_length ap_args params then
           if is_a_functor (* && (Set_ident.mem v meta.export_idents) && false *)
@@ -170,7 +170,6 @@ let simplify_alias (meta : Lam_stats.t) (lam : Lam.t) : Lam.t =
                if so, maybe not since in that case,
                we are going to have two copy?
             *)
-
             (* Check: recursive applying may result in non-termination *)
             (* Ext_log.dwarn __LOC__ "beta .. %s/%d" v.name v.stamp ; *)
             simpl

--- a/compiler/core/lam_stats_export.ml
+++ b/compiler/core/lam_stats_export.ml
@@ -55,8 +55,8 @@ let values_of_export (meta : Lam_stats.t) (export_map : Lam.t Map_ident.t) :
         match optlam with
         | Some
             (Lconst
-              ( Const_js_null | Const_js_undefined _ | Const_js_true
-              | Const_js_false ))
+               ( Const_js_null | Const_js_undefined _ | Const_js_true
+               | Const_js_false ))
         | None ->
           optlam
         | Some lambda ->

--- a/compiler/core/lam_stats_export.ml
+++ b/compiler/core/lam_stats_export.ml
@@ -128,11 +128,11 @@ let get_dependent_module_effect (maybe_pure : string option)
    ]}
    TODO: check that we don't do this in browser environment
 *)
-let export_to_cmj (meta : Lam_stats.t) effect export_map case : Js_cmj_format.t
+let export_to_cmj (meta : Lam_stats.t) effect_ export_map case : Js_cmj_format.t
     =
   let values = values_of_export meta export_map in
 
-  Js_cmj_format.make ~values ~effect
+  Js_cmj_format.make ~values ~effect_
     ~package_spec:(Js_packages_state.get_packages_info ())
     ~case
 (* FIXME: make sure [-o] would not change its case

--- a/compiler/core/lam_stats_export.mli
+++ b/compiler/core/lam_stats_export.mli
@@ -27,7 +27,7 @@ val get_dependent_module_effect :
 
 val export_to_cmj :
   Lam_stats.t ->
-  Js_cmj_format.effect ->
+  Js_cmj_format.effect_ ->
   Lam.t Map_ident.t ->
   Ext_js_file_kind.case ->
   Js_cmj_format.t

--- a/compiler/ext/ext_obj.ml
+++ b/compiler/ext/ext_obj.ml
@@ -61,8 +61,8 @@ let rec dump r =
       "(" ^ String.concat ", " (Ext_list.map fields dump) ^ ")"
     | x when x = Obj.lazy_tag ->
       (* Note that [lazy_tag .. forward_tag] are < no_scan_tag.  Not
-         * clear if very large constructed values could have the same
-         * tag. XXX *)
+       * clear if very large constructed values could have the same
+       * tag. XXX *)
       opaque "lazy"
     | x when x = Obj.closure_tag -> opaque "closure"
     | x when x = Obj.object_tag ->
@@ -73,7 +73,7 @@ let rec dump r =
         | _ -> assert false
       in
       (* No information on decoding the class (first field).  So just print
-         * out the ID and the slots. *)
+       * out the ID and the slots. *)
       "Object #" ^ dump id ^ " ("
       ^ String.concat ", " (Ext_list.map slots dump)
       ^ ")"

--- a/compiler/ext/ext_path.ml
+++ b/compiler/ext/ext_path.ml
@@ -23,8 +23,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 (* [@@@warning "-37"] *)
-type t = (* | File of string  *)
-  | Dir of string [@@unboxed]
+type t =
+  (* | File of string  *)
+  | Dir of string
+[@@unboxed]
 
 let simple_convert_node_path_to_os_path =
   if Sys.unix then fun x -> x

--- a/compiler/ext/ext_string_array.ml
+++ b/compiler/ext/ext_string_array.ml
@@ -37,8 +37,10 @@ let rec binary_search_aux (arr : string array) (lo : int) (hi : int)
       let lo_val = Array.unsafe_get arr lo in
       if lo_val = key then Some lo else None
     else binary_search_aux arr lo mid key
-  else if (*  a[lo] =< a[mid] < key <= a[hi] *)
-          lo = mid then
+  else if
+    (*  a[lo] =< a[mid] < key <= a[hi] *)
+    lo = mid
+  then
     let hi_val = Array.unsafe_get arr hi in
     if hi_val = key then Some hi else None
   else binary_search_aux arr mid hi key
@@ -67,8 +69,10 @@ let rec binary_search_assoc (arr : (string * _) array) (lo : int) (hi : int)
       let lo_val = Array.unsafe_get arr lo in
       if fst lo_val = key then Some (snd lo_val) else None
     else binary_search_assoc arr lo mid key
-  else if (*  a[lo] =< a[mid] < key <= a[hi] *)
-          lo = mid then
+  else if
+    (*  a[lo] =< a[mid] < key <= a[hi] *)
+    lo = mid
+  then
     let hi_val = Array.unsafe_get arr hi in
     if fst hi_val = key then Some (snd hi_val) else None
   else binary_search_assoc arr mid hi key

--- a/compiler/ext/ext_utf8.ml
+++ b/compiler/ext/ext_utf8.ml
@@ -29,19 +29,30 @@ let classify chr =
   let c = int_of_char chr in
   (* Classify byte according to leftmost 0 bit *)
   if c land 0b1000_0000 = 0 then Single c
-  else if (* c 0b0____*)
-          c land 0b0100_0000 = 0 then Cont (c land 0b0011_1111)
-  else if (* c 0b10___*)
-          c land 0b0010_0000 = 0 then Leading (1, c land 0b0001_1111)
-  else if (* c 0b110__*)
-          c land 0b0001_0000 = 0 then Leading (2, c land 0b0000_1111)
-  else if (* c 0b1110_ *)
-          c land 0b0000_1000 = 0 then Leading (3, c land 0b0000_0111)
-  else if (* c 0b1111_0___*)
-          c land 0b0000_0100 = 0 then Leading (4, c land 0b0000_0011)
-  else if (* c 0b1111_10__*)
-          c land 0b0000_0010 = 0 then Leading (5, c land 0b0000_0001)
-    (* c 0b1111_110__ *)
+  else if
+    (* c 0b0____*)
+    c land 0b0100_0000 = 0
+  then Cont (c land 0b0011_1111)
+  else if
+    (* c 0b10___*)
+    c land 0b0010_0000 = 0
+  then Leading (1, c land 0b0001_1111)
+  else if
+    (* c 0b110__*)
+    c land 0b0001_0000 = 0
+  then Leading (2, c land 0b0000_1111)
+  else if
+    (* c 0b1110_ *)
+    c land 0b0000_1000 = 0
+  then Leading (3, c land 0b0000_0111)
+  else if
+    (* c 0b1111_0___*)
+    c land 0b0000_0100 = 0
+  then Leading (4, c land 0b0000_0011)
+  else if
+    (* c 0b1111_10__*)
+    c land 0b0000_0010 = 0
+  then Leading (5, c land 0b0000_0001) (* c 0b1111_110__ *)
   else Invalid
 
 exception Invalid_utf8 of string

--- a/compiler/ext/warnings.ml
+++ b/compiler/ext/warnings.ml
@@ -386,7 +386,8 @@ let message = function
        - Deleting the variable if it's not used anymore.\n\
        - Prepending the variable name with `_` (like `_%s`) to ignore that the \
        variable is unused.\n\
-       - Using the variable somewhere." v v
+       - Using the variable somewhere."
+      v v
   | Wildcard_arg_to_constant_constr ->
     "wildcard pattern given as argument to a constant constructor"
   | Eol_in_string ->
@@ -472,7 +473,8 @@ let message = function
     in
     Printf.sprintf
       "Ambiguous or-pattern variables under guard;\n\
-       %s may match different arguments. (See manual section 8.5)" msg
+       %s may match different arguments. (See manual section 8.5)"
+      msg
   | Unused_module s -> "unused module " ^ s ^ "."
   | Constraint_on_gadt ->
     "Type constraints do not apply to GADT cases of variant types."

--- a/compiler/frontend/ast_core_type_class_type.ml
+++ b/compiler/frontend/ast_core_type_class_type.ml
@@ -70,7 +70,8 @@ let typ_mapper (self : Bs_ast_mapper.mapper) (ty : Parsetree.core_type) =
   | Ptyp_arrow {lbl = label; arg = args; ret = body}
   (* let it go without regard label names,
      it will report error later when the label is not empty
-  *) -> (
+  *)
+    -> (
     match fst (Ast_attributes.process_attributes_rev ty.ptyp_attributes) with
     | Meth_callback _ ->
       Ast_typ_uncurry.to_method_callback_type loc self label args body

--- a/compiler/frontend/ast_derive_abstract.ml
+++ b/compiler/frontend/ast_derive_abstract.ml
@@ -95,7 +95,9 @@ let handle_tdcl light (tdcl : Parsetree.type_declaration) :
                 pld_attributes;
                 pld_loc;
               } :
-               Parsetree.label_declaration) (acc, maker, labels) ->
+               Parsetree.label_declaration)
+             (acc, maker, labels)
+           ->
           let prim_as_name, new_label =
             match Ast_attributes.iter_process_bs_string_as pld_attributes with
             | None -> (label_name, pld_name)

--- a/compiler/frontend/ast_external_process.ml
+++ b/compiler/frontend/ast_external_process.ml
@@ -442,8 +442,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
    set_index = false;
    mk_obj = _;
    scopes =
-     []
-     (* wrapper does not work with @obj
+     [] (* wrapper does not work with @obj
         TODO: better error message *);
   } ->
     if String.length prim_name <> 0 then

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -491,14 +491,8 @@ let default_mapper =
           ~attrs:(this.attributes this pcd_attributes));
     label_declaration =
       (fun this
-           {
-             pld_name;
-             pld_type;
-             pld_loc;
-             pld_mutable;
-             pld_optional;
-             pld_attributes;
-           } ->
+        {pld_name; pld_type; pld_loc; pld_mutable; pld_optional; pld_attributes}
+      ->
         Type.field (map_loc this pld_name) (this.typ this pld_type)
           ~mut:pld_mutable ~optional:pld_optional
           ~loc:(this.location this pld_loc)

--- a/compiler/frontend/bs_builtin_ppx.ml
+++ b/compiler/frontend/bs_builtin_ppx.ml
@@ -517,7 +517,8 @@ let rec structure_mapper ~await_context (self : mapper) (stru : Ast_structure.t)
         {txt = Lident safe_module_type_name; loc = mb.pmb_expr.pmod_loc}
       in
       module_type_decl
-      @ (* module M = @res.await Belt.List *)
+      @
+      (* module M = @res.await Belt.List *)
       {
         item with
         pstr_desc =

--- a/compiler/frontend/external_ffi_types.ml
+++ b/compiler/frontend/external_ffi_types.ml
@@ -247,7 +247,9 @@ let () =
            prim_alloc = _;
            prim_from_constructor = _;
          } :
-          Primitive.description) (p2 : Primitive.description) ->
+          Primitive.description)
+      (p2 : Primitive.description)
+    ->
       let p2_native = p2.prim_native_name in
       prim_name = p2.prim_name && prim_arity = p2.prim_arity
       && prim_native_name = p2_native

--- a/compiler/gentype/GenTypeCommon.ml
+++ b/compiler/gentype/GenTypeCommon.ml
@@ -115,7 +115,8 @@ type dep =
   | Internal of ResolvedName.t
   | Dot of dep * string
 
-module ScopedPackage = (* Taken from ext_namespace.ml in bukclescript *)
+module ScopedPackage =
+(* Taken from ext_namespace.ml in bukclescript *)
 struct
   let namespace_of_package_name (s : string) : string =
     let len = String.length s in

--- a/compiler/jsoo/jsoo_playground_main.ml
+++ b/compiler/jsoo/jsoo_playground_main.ml
@@ -313,7 +313,7 @@ module Compile = struct
   (* Apparently it's not possible to retrieve the loc info from
    * Location.error_of_exn properly, so we need to do some extra
    * overloading action
-   * *)
+   *)
   let warning_infos : LocWarnInfo.t array ref = ref [||]
   let warning_buffer = Buffer.create 512
   let warning_ppf = Format.formatter_of_buffer warning_buffer
@@ -382,7 +382,7 @@ module Compile = struct
    * data to display types on hover etc.
    *
    * Note: start / end positions
-   * *)
+   *)
   let collect_type_hints typed_tree =
     let open Typedtree in
     let create_type_hint_obj loc kind hint =

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -403,7 +403,9 @@ let default_iterator =
     type_extension = T.iter_type_extension;
     extension_constructor = T.iter_extension_constructor;
     value_description =
-      (fun this {pval_name; pval_type; pval_prim = _; pval_loc; pval_attributes} ->
+      (fun this
+        {pval_name; pval_type; pval_prim = _; pval_loc; pval_attributes}
+      ->
         iter_loc this pval_name;
         this.typ this pval_type;
         this.attributes this pval_attributes;
@@ -457,7 +459,9 @@ let default_iterator =
         this.location this pcd_loc;
         this.attributes this pcd_attributes);
     label_declaration =
-      (fun this {pld_name; pld_type; pld_loc; pld_mutable = _; pld_attributes} ->
+      (fun this
+        {pld_name; pld_type; pld_loc; pld_mutable = _; pld_attributes}
+      ->
         iter_loc this pld_name;
         this.typ this pld_type;
         this.location this pld_loc;

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -439,14 +439,8 @@ let default_mapper =
           ~attrs:(this.attributes this pcd_attributes));
     label_declaration =
       (fun this
-           {
-             pld_name;
-             pld_type;
-             pld_loc;
-             pld_mutable;
-             pld_optional;
-             pld_attributes;
-           } ->
+        {pld_name; pld_type; pld_loc; pld_mutable; pld_optional; pld_attributes}
+      ->
         Type.field (map_loc this pld_name) (this.typ this pld_type)
           ~mut:pld_mutable ~optional:pld_optional
           ~loc:(this.location this pld_loc)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -524,14 +524,8 @@ let default_mapper =
           ~attrs:(this.attributes this pcd_attributes));
     label_declaration =
       (fun this
-           {
-             pld_name;
-             pld_type;
-             pld_loc;
-             pld_mutable;
-             pld_optional;
-             pld_attributes;
-           } ->
+        {pld_name; pld_type; pld_loc; pld_mutable; pld_optional; pld_attributes}
+      ->
         Type.field (map_loc this pld_name) (this.typ this pld_type)
           ~mut:pld_mutable
           ~loc:(this.location this pld_loc)

--- a/compiler/ml/bigint_utils.ml
+++ b/compiler/ml/bigint_utils.ml
@@ -89,6 +89,8 @@ let compare (p0, s0) (p1, s1) =
     else if len0 > len1 then
       if p0 then 1
       else -1 (* A longer s0 means it's larger unless it's negative. *)
-    else if (* len0 < len1 *)
-            p0 then -1
+    else if
+      (* len0 < len1 *)
+      p0
+    then -1
     else 1 (* A longer s1 means s0 is smaller unless s1 is negative. *)

--- a/compiler/ml/ctype.ml
+++ b/compiler/ml/ctype.ml
@@ -600,8 +600,9 @@ let get_level env p =
     match (Env.find_type p env).type_newtype_level with
     | None -> Path.binding_time p
     | Some (x, _) -> x
-  with Not_found -> (* no newtypes in predef *)
-                    Path.binding_time p
+  with Not_found ->
+    (* no newtypes in predef *)
+    Path.binding_time p
 
 let rec normalize_package_path env p =
   let t = try (Env.find_modtype p env).mtd_type with Not_found -> None in
@@ -4265,7 +4266,8 @@ let maybe_pointer_type env typ =
       true
       (* This can happen due to e.g. missing -I options,
          causing some .cmi files to be unavailable.
-         Maybe we should emit a warning. *))
+         Maybe we should emit a warning. *)
+    )
   | Tvariant row ->
     let row = Btype.row_repr row in
     (* if all labels are devoid of arguments, not a pointer *)

--- a/compiler/ml/includemod.ml
+++ b/compiler/ml/includemod.ml
@@ -525,8 +525,8 @@ let include_err ppf = function
   | Extension_constructors (id, x1, x2) ->
     fprintf ppf
       "@[<hv 2>Extension declarations do not match:@ %a@;\
-       <1 -2>is not included in@ %a@]" (extension_constructor id) x1
-      (extension_constructor id) x2;
+       <1 -2>is not included in@ %a@]"
+      (extension_constructor id) x1 (extension_constructor id) x2;
     show_locs ppf (x1.ext_loc, x2.ext_loc)
   | Module_types (mty1, mty2) ->
     fprintf ppf
@@ -535,8 +535,8 @@ let include_err ppf = function
   | Modtype_infos (id, d1, d2) ->
     fprintf ppf
       "@[<hv 2>Module type declarations do not match:@ %a@;\
-       <1 -2>does not match@ %a@]" (modtype_declaration id) d1
-      (modtype_declaration id) d2
+       <1 -2>does not match@ %a@]"
+      (modtype_declaration id) d1 (modtype_declaration id) d2
   | Modtype_permutation -> fprintf ppf "Illegal permutation of structure fields"
   | Interface_mismatch (impl_name, intf_name) ->
     fprintf ppf "@[The implementation %s@ does not match the interface %s:"

--- a/compiler/ml/matching.ml
+++ b/compiler/ml/matching.ml
@@ -756,7 +756,8 @@ let insert_or_append p ps act ors no =
             let _, not_e = get_equiv q rem in
             if
               or_ok p ps not_e
-              && (* check append condition for head of O *)
+              &&
+              (* check append condition for head of O *)
               List.for_all (* check insert condition for tail of O *)
                 (fun cl ->
                   match cl with
@@ -2765,7 +2766,8 @@ let check_partial is_mutable is_lazy pat_act_list = function
   | Total ->
     if
       pat_act_list = []
-      || (* allow empty case list *)
+      ||
+      (* allow empty case list *)
       List.exists
         (fun (pats, lam) -> is_mutable pats && (is_guarded lam || is_lazy pats))
         pat_act_list

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -169,8 +169,7 @@ and pattern_desc =
 
        Other forms of interval are recognized by the parser
        but rejected by the type-checker. *)
-  | Ppat_tuple of pattern list
-    (* (P1, ..., Pn)
+  | Ppat_tuple of pattern list (* (P1, ..., Pn)
 
        Invariant: n >= 2
     *)
@@ -215,8 +214,7 @@ and expression = {
 }
 
 and expression_desc =
-  | Pexp_ident of Longident.t loc
-    (* x
+  | Pexp_ident of Longident.t loc (* x
        M.x
     *)
   | Pexp_constant of constant (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)

--- a/compiler/ml/parsetree0.ml
+++ b/compiler/ml/parsetree0.ml
@@ -170,8 +170,7 @@ and pattern_desc =
 
        Other forms of interval are recognized by the parser
        but rejected by the type-checker. *)
-  | Ppat_tuple of pattern list
-    (* (P1, ..., Pn)
+  | Ppat_tuple of pattern list (* (P1, ..., Pn)
 
        Invariant: n >= 2
     *)
@@ -215,8 +214,7 @@ and expression = {
 }
 
 and expression_desc =
-  | Pexp_ident of Longident.t loc
-    (* x
+  | Pexp_ident of Longident.t loc (* x
        M.x
     *)
   | Pexp_constant of constant (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -152,14 +152,14 @@ let reset_pipe ctxt = { ctxt with pipe=false }
 *)
 
 let list :
-      'a.
-      ?sep:space_formatter ->
-      ?first:space_formatter ->
-      ?last:space_formatter ->
-      (Format.formatter -> 'a -> unit) ->
-      Format.formatter ->
-      'a list ->
-      unit =
+    'a.
+    ?sep:space_formatter ->
+    ?first:space_formatter ->
+    ?last:space_formatter ->
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter ->
+    'a list ->
+    unit =
  fun ?sep ?first ?last fu f xs ->
   let first =
     match first with
@@ -193,13 +193,13 @@ let list :
   aux f xs
 
 let option :
-      'a.
-      ?first:space_formatter ->
-      ?last:space_formatter ->
-      (Format.formatter -> 'a -> unit) ->
-      Format.formatter ->
-      'a option ->
-      unit =
+    'a.
+    ?first:space_formatter ->
+    ?last:space_formatter ->
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter ->
+    'a option ->
+    unit =
  fun ?first ?last fu f a ->
   let first =
     match first with
@@ -218,14 +218,14 @@ let option :
     pp f last
 
 let paren :
-      'a.
-      ?first:space_formatter ->
-      ?last:space_formatter ->
-      bool ->
-      (Format.formatter -> 'a -> unit) ->
-      Format.formatter ->
-      'a ->
-      unit =
+    'a.
+    ?first:space_formatter ->
+    ?last:space_formatter ->
+    bool ->
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter ->
+    'a ->
+    unit =
  fun ?(first = ("" : _ format6)) ?(last = ("" : _ format6)) b fu f x ->
   if b then (
     pp f "(";
@@ -437,8 +437,10 @@ and pattern1 ctxt (f : Format.formatter) (x : pattern) : unit =
     | Ppat_construct ({txt = Lident ("()" | "[]"); _}, _) ->
       simple_pattern ctxt f x
     | Ppat_construct (({txt; _} as li), po) -> (
-      if (* FIXME The third field always false *)
-         txt = Lident "::" then pp f "%a" pattern_list_helper x
+      if
+        (* FIXME The third field always false *)
+        txt = Lident "::"
+      then pp f "%a" pattern_list_helper x
       else
         match po with
         | Some x -> pp f "%a@;%a" longident_loc li (simple_pattern ctxt) x

--- a/compiler/ml/rescript_cpp.ml
+++ b/compiler/ml/rescript_cpp.ml
@@ -48,7 +48,10 @@ let () =
      we want to overwrite in some cases with the
      same stdlib
   *)
-  let version = Config.version (* so that it can be overridden*) in
+  let version =
+    Config.version
+    (* so that it can be overridden*)
+  in
   replace_directive_built_in_value "OCAML_VERSION" (Dir_string version);
   replace_directive_built_in_value "OS_TYPE" (Dir_string Sys.os_type)
 

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -363,7 +363,8 @@ let finalize_variant pat =
     (* Force check of well-formedness   WHY? *)
     (* unify_pat pat.pat_env pat
        (newty(Tvariant{row_fields=[]; row_more=newvar(); row_closed=false;
-                       row_bound=(); row_fixed=false; row_name=None})); *))
+                       row_bound=(); row_fixed=false; row_name=None})); *)
+    )
   | _ -> ()
 
 let rec iter_pattern f p =
@@ -782,8 +783,7 @@ let print_expr_type_clash ?type_clash_context env trace ppf =
     Printtyp.super_report_unification_error ppf env trace
       (function
         | ppf -> error_type_text ppf type_clash_context)
-      (function
-        | ppf -> error_expected_type_text ppf type_clash_context);
+      (function ppf -> error_expected_type_text ppf type_clash_context);
     print_extra_type_clash_help ~extract_concrete_typedecl ~env ppf trace
       type_clash_context;
     show_extra_help ppf env trace
@@ -4228,8 +4228,7 @@ let report_error env ppf error =
       (function
         | ppf ->
           fprintf ppf "The record field %a@ belongs to the type" longident lid)
-      (function
-        | ppf -> fprintf ppf "but is mixed here with fields of type")
+      (function ppf -> fprintf ppf "but is mixed here with fields of type")
   | Pattern_type_clash trace ->
     (* modified *)
     super_report_unification_error ppf env trace
@@ -4238,7 +4237,7 @@ let report_error env ppf error =
         | ppf -> fprintf ppf "This pattern matches values of type")
       (function
         | ppf ->
-          fprintf ppf "but a pattern was expected which matches values of type")
+        fprintf ppf "but a pattern was expected which matches values of type")
   | Or_pattern_type_clash (id, trace) ->
     (* modified *)
     super_report_unification_error ppf env trace
@@ -4247,8 +4246,7 @@ let report_error env ppf error =
           fprintf ppf
             "The variable %s on the left-hand side of this or-pattern has type"
             (Ident.name id))
-      (function
-        | ppf -> fprintf ppf "but on the right-hand side it has type")
+      (function ppf -> fprintf ppf "but on the right-hand side it has type")
   | Multiply_bound_variable name ->
     fprintf ppf "Variable %s is bound several times in this matching" name
   | Orpat_vars (id, valid_idents) ->
@@ -4358,7 +4356,7 @@ let report_error env ppf error =
             name longident lid kind)
       (function
         | ppf ->
-          fprintf ppf "but a %s was expected belonging to the %s type" name kind)
+        fprintf ppf "but a %s was expected belonging to the %s type" name kind)
   | Undefined_method (ty, me, valid_methods) -> (
     fprintf ppf
       "@[<v>@[This expression has type@;<1 2>%a@]@,It has no field %s@]"
@@ -4369,8 +4367,10 @@ let report_error env ppf error =
   | Not_subtype (tr1, tr2) ->
     report_subtyping_error ppf env tr1 "is not a subtype of" tr2
   | Too_many_arguments (in_function, ty) ->
-    if (* modified *)
-       in_function then (
+    if
+      (* modified *)
+      in_function
+    then (
       fprintf ppf "@[This function expects too many arguments,@ ";
       fprintf ppf "it should have type@ %a@]" type_expr ty)
     else (
@@ -4416,8 +4416,7 @@ let report_error env ppf error =
     super_report_unification_error ppf env trace
       (function
         | ppf -> fprintf ppf "Recursive local constraint when unifying")
-      (function
-        | ppf -> fprintf ppf "with")
+      (function ppf -> fprintf ppf "with")
   | Unexpected_existential -> fprintf ppf "Unexpected existential"
   | Unqualified_gadt_pattern (tpath, name) ->
     fprintf ppf "@[The GADT constructor %s of type %a@ %s.@]" name Printtyp.path

--- a/compiler/ml/typedecl.ml
+++ b/compiler/ml/typedecl.ml
@@ -1163,11 +1163,14 @@ let compute_variance_type env check (required, loc) decl tyl =
       let v = get_variance ty tvl in
       let tr = decl.type_private in
       (* Use required variance where relevant *)
-      let concr = decl.type_kind <> Type_abstract (*|| tr = Type_new*) in
+      let concr =
+        decl.type_kind <> Type_abstract
+        (*|| tr = Type_new*)
+      in
       let p, n =
         if tr = Private || not (Btype.is_Tvar ty) then (p, n) (* set *)
         else (false, false)
-        (* only check *)
+      (* only check *)
       and i = concr || (i && tr = Private) in
       let v = union v (make p n i) in
       let v =
@@ -2093,8 +2096,7 @@ let report_error ppf = function
     Printtyp.report_unification_error ppf env trace
       (function
         | ppf -> fprintf ppf "This type constructor expands to type")
-      (function
-        | ppf -> fprintf ppf "but is used here with type")
+      (function ppf -> fprintf ppf "but is used here with type")
   | Null_arity_external -> fprintf ppf "External identifiers must be functions"
   | Unbound_type_var (ty, decl) -> (
     fprintf ppf "A type variable is unbound in this type declaration";
@@ -2136,8 +2138,7 @@ let report_error ppf = function
       (function
         | ppf ->
           fprintf ppf "The constructor %a@ has type" Printtyp.longident lid)
-      (function
-        | ppf -> fprintf ppf "but was expected to be of type")
+      (function ppf -> fprintf ppf "but was expected to be of type")
   | Rebind_mismatch (lid, p, p') ->
     fprintf ppf "@[%s@ %a@ %s@ %s@ %s@ %s@ %s@]" "The constructor"
       Printtyp.longident lid "extends type" (Path.name p)
@@ -2201,8 +2202,10 @@ let report_error ppf = function
     fprintf ppf "@[GADT case syntax cannot be used in a 'nonrec' block.@]"
   | Variant_runtime_representation_mismatch
       (Variant_coercion.VariantError
-        {is_spread_context; error = Variant_coercion.Untagged {left_is_unboxed}})
-    ->
+         {
+           is_spread_context;
+           error = Variant_coercion.Untagged {left_is_unboxed};
+         }) ->
     let other_variant_text =
       if is_spread_context then "the variant where this is spread"
       else "the other variant"
@@ -2214,7 +2217,7 @@ let report_error ppf = function
       ^ " is not. Both variants unboxed configuration must match")
   | Variant_runtime_representation_mismatch
       (Variant_coercion.VariantError
-        {is_spread_context; error = Variant_coercion.TagName _}) ->
+         {is_spread_context; error = Variant_coercion.TagName _}) ->
     let other_variant_text =
       if is_spread_context then "the variant where this is spread"
       else "the other variant"
@@ -2237,7 +2240,8 @@ let report_error ppf = function
     fprintf ppf "@[Type parameters are not supported in variant type spreads.@]"
   | Variant_spread_fail
       (Variant_type_spread.DuplicateConstructor
-        {variant_with_overlapping_constructor; overlapping_constructor_name}) ->
+         {variant_with_overlapping_constructor; overlapping_constructor_name})
+    ->
     fprintf ppf
       "@[Variant %s has a constructor named %s, but a constructor named %s \
        already exists in the variant it's spread into.@ You cannot spread \

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -847,14 +847,12 @@ let report_error env ppf = function
     Printtyp.report_unification_error ppf Env.empty trace
       (function
         | ppf -> fprintf ppf "This type")
-      (function
-        | ppf -> fprintf ppf "should be an instance of type")
+      (function ppf -> fprintf ppf "should be an instance of type")
   | Alias_type_mismatch trace ->
     Printtyp.report_unification_error ppf Env.empty trace
       (function
         | ppf -> fprintf ppf "This alias is bound to type")
-      (function
-        | ppf -> fprintf ppf "but is used as an instance of type")
+      (function ppf -> fprintf ppf "but is used as an instance of type")
   | Present_has_conjunction l ->
     fprintf ppf "The present constructor %s has a conjunctive type" l
   | Present_has_no_type l ->

--- a/compiler/ml/variant_coercion.ml
+++ b/compiler/ml/variant_coercion.ml
@@ -40,7 +40,8 @@ let variant_has_same_runtime_representation_as_target ~(target_path : Path.t)
       path_same Predef.path_string
       (* unboxed Number(float) :> float *)
       || path_same Predef.path_float
-      || (* unboxed BigInt(bigint) :> bigint *)
+      ||
+      (* unboxed BigInt(bigint) :> bigint *)
       path_same Predef.path_bigint
     | Cstr_tuple [] -> (
       (* Check that @as payloads match with the target path to coerce to.

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -612,15 +612,15 @@ and walk_list : ?prev_loc:Location.t -> node list -> t -> Comment.t list -> unit
  * closing token of a "list-of-things". This routine visits the whole list,
  * but returns any remaining comments that likely fall after the whole list. *)
 and visit_list_but_continue_with_remaining_comments :
-      'node.
-      ?prev_loc:Location.t ->
-      newline_delimited:bool ->
-      get_loc:('node -> Location.t) ->
-      walk_node:('node -> t -> Comment.t list -> unit) ->
-      'node list ->
-      t ->
-      Comment.t list ->
-      Comment.t list =
+    'node.
+    ?prev_loc:Location.t ->
+    newline_delimited:bool ->
+    get_loc:('node -> Location.t) ->
+    walk_node:('node -> t -> Comment.t list -> unit) ->
+    'node list ->
+    t ->
+    Comment.t list ->
+    Comment.t list =
  fun ?prev_loc ~newline_delimited ~get_loc ~walk_node l t comments ->
   let open Location in
   match l with

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -324,7 +324,7 @@ let is_es6_arrow_expression ~in_ternary p =
              *    || (&Clflags.classic && (l == Nolabel && !is_optional(l'))) => (t1, t2)
              * We'll arrive at the outer rparen just before the =>.
              * This is not an es6 arrow.
-             * *)
+             *)
             false
           | _ -> (
             Parser.next_unsafe state;
@@ -1640,7 +1640,10 @@ and parse_parameter p =
     || Grammar.is_pattern_start p.token
   then
     let start_pos = p.Parser.start_pos in
-    let _ = Parser.optional p Token.Dot (* dot is ignored *) in
+    let _ =
+      Parser.optional p Token.Dot
+      (* dot is ignored *)
+    in
     let attrs = parse_attributes p in
     if p.Parser.token = Typ then (
       Parser.next p;
@@ -2362,7 +2365,7 @@ and parse_template_expr ?prefix p =
  *  }
  *
  *  We want to give a nice error message in these cases
- * *)
+ *)
 and over_parse_constrained_or_coerced_or_arrow_expression p expr =
   match p.Parser.token with
   | ColonGreaterThan -> parse_coerced_expr ~expr p
@@ -4189,17 +4192,17 @@ and parse_type_alias p typ =
   | _ -> typ
 
 (* type_parameter ::=
-   *  | type_expr
-   *  | ~ident: type_expr
-   *  | ~ident: type_expr=?
-   *
-   * note:
-   *  | attrs ~ident: type_expr    -> attrs are on the arrow
-   *  | attrs type_expr            -> attrs are here part of the type_expr
-   *
-   * dotted_type_parameter ::=
-   *  | . type_parameter
-*)
+ *  | type_expr
+ *  | ~ident: type_expr
+ *  | ~ident: type_expr=?
+ *
+ * note:
+ *  | attrs ~ident: type_expr    -> attrs are on the arrow
+ *  | attrs type_expr            -> attrs are here part of the type_expr
+ *
+ * dotted_type_parameter ::=
+ *  | . type_parameter
+ *)
 and parse_type_parameter p =
   let doc_attr : Parsetree.attributes =
     match p.Parser.token with
@@ -4214,7 +4217,10 @@ and parse_type_parameter p =
     || Grammar.is_typ_expr_start p.token
   then
     let start_pos = p.Parser.start_pos in
-    let _ = Parser.optional p Dot (* dot is ignored *) in
+    let _ =
+      Parser.optional p Dot
+      (* dot is ignored *)
+    in
     let attrs = doc_attr @ parse_attributes p in
     match p.Parser.token with
     | Tilde -> (

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -146,7 +146,8 @@ let sub_binary_expr_operand parent_operator child_operator =
   || prec_parent == prec_child
      && not
           (ParsetreeViewer.flattenable_operators parent_operator child_operator)
-  || (* a && b || c, add parens to (a && b) for readability, who knows the difference by heart… *)
+  ||
+  (* a && b || c, add parens to (a && b) for readability, who knows the difference by heart… *)
   (parent_operator = "||" && child_operator = "&&")
 
 let rhs_binary_expr_operand parent_operator rhs =

--- a/compiler/syntax/src/res_parser.ml
+++ b/compiler/syntax/src/res_parser.ml
@@ -60,8 +60,8 @@ let module_comment_to_attribute_token comment =
   Token.ModuleComment (loc, txt)
 
 (* Advance to the next non-comment token and store any encountered comment
-   * in the parser's state. Every comment contains the end position of its
-   * previous token to facilite comment interleaving *)
+ * in the parser's state. Every comment contains the end position of its
+ * previous token to facilite comment interleaving *)
 let rec next ?prev_end_pos p =
   if p.token = Eof then assert false;
   let prev_end_pos =

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -21,7 +21,7 @@ let arrow_type ?(max_arity = max_int) ct =
      ptyp_attributes = [({txt = "bs"}, _)];
     } ->
       (* stop here, the uncurried attribute always indicates the beginning of an arrow function
-         * e.g. `(. int) => (. int)` instead of `(. int, . int)` *)
+       * e.g. `(. int) => (. int)` instead of `(. int, . int)` *)
       (attrs_before, List.rev acc, typ)
     | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = _attrs} as
       return_type ->

--- a/compiler/syntax/src/res_parsetree_viewer.mli
+++ b/compiler/syntax/src/res_parsetree_viewer.mli
@@ -1,6 +1,6 @@
 (* Restructures a nested tree of arrow types into its args & returnType
-   * The parsetree contains: a => b => c => d, for printing purposes
-   * we restructure the tree into (a, b, c) and its returnType d *)
+ * The parsetree contains: a => b => c => d, for printing purposes
+ * we restructure the tree into (a, b, c) and its returnType d *)
 val arrow_type :
   ?max_arity:int ->
   Parsetree.core_type ->
@@ -23,8 +23,8 @@ type if_condition_kind =
   | IfLet of Parsetree.pattern * Parsetree.expression
 
 (* if ... else if ... else ... is represented as nested expressions: if ... else { if ... }
-   * The purpose of this function is to flatten nested ifs into one sequence.
-   * Basically compute: ([if, else if, else if, else if], else) *)
+ * The purpose of this function is to flatten nested ifs into one sequence.
+ * Basically compute: ([if, else if, else if, else if], else) *)
 val collect_if_expressions :
   Parsetree.expression ->
   (Location.t * if_condition_kind * Parsetree.expression) list
@@ -51,11 +51,11 @@ val fun_expr :
   Parsetree.expression -> bool * fun_param_kind list * Parsetree.expression
 
 (* example:
-   *  `makeCoordinate({
-   *    x: 1,
-   *    y: 2,
-   *  })`
-   *  Notice howe `({` and `})` "hug" or stick to each other *)
+ *  `makeCoordinate({
+ *    x: 1,
+ *    y: 2,
+ *  })`
+ *  Notice howe `({` and `})` "hug" or stick to each other *)
 val is_huggable_expression : Parsetree.expression -> bool
 
 val is_huggable_pattern : Parsetree.pattern -> bool

--- a/compiler/syntax/src/res_scanner.ml
+++ b/compiler/syntax/src/res_scanner.ml
@@ -259,7 +259,7 @@ let scan_number scanner =
   in
   let _ : bool = scan_digits scanner ~base in
 
-  (*  *)
+  (* *)
   let is_float =
     if '.' == scanner.ch then (
       next scanner;
@@ -633,8 +633,14 @@ let scan_single_line_comment scanner =
 
 let scan_multi_line_comment scanner =
   (* assumption: we're only ever using this helper in `scan` after detecting a comment *)
-  let doc_comment = peek2 scanner = '*' && peek3 scanner <> '/' (* no /**/ *) in
-  let standalone = doc_comment && peek3 scanner = '*' (* /*** *) in
+  let doc_comment =
+    peek2 scanner = '*' && peek3 scanner <> '/'
+    (* no /**/ *)
+  in
+  let standalone =
+    doc_comment && peek3 scanner = '*'
+    (* /*** *)
+  in
   let content_start_off =
     scanner.offset + if doc_comment then if standalone then 4 else 3 else 2
   in

--- a/dune-project
+++ b/dune-project
@@ -19,11 +19,11 @@
  (synopsis "ReScript compiler")
  (depends
   (ocaml
-   (>= 4.10))
+   (>= 4.14))
   (ocamlformat
    (and
     :with-test
-    (= 0.26.2)))
+    (= 0.27.0)))
   (yojson
    (and
     :with-test
@@ -31,15 +31,13 @@
   (ocaml-lsp-server
    (and
     :with-dev-setup
-    (= 1.19.0)))
+    (= 1.22.0)))
   (cppo
-   (= 1.6.9))
+   (= 1.8.0))
   (js_of_ocaml
-   (= 5.9.1))
+   (= 6.0.1))
   (ounit2
    (= 2.2.7))
-  (reanalyze
-   (= 2.25.1))
   dune))
 
 (package
@@ -47,9 +45,9 @@
  (synopsis "ReScript Analysis")
  (depends
   (ocaml
-   (>= 4.10))
+   (>= 4.14))
   (cppo
-   (= 1.6.9))
+   (= 1.8.0))
   dune))
 
 (package
@@ -57,8 +55,8 @@
  (synopsis "ReScript Tools")
  (depends
   (ocaml
-   (>= 4.10))
+   (>= 4.14))
   (cppo
-   (= 1.6.9))
+   (= 1.8.0))
   analysis
   dune))

--- a/rescript.opam
+++ b/rescript.opam
@@ -7,14 +7,13 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
-  "ocaml" {>= "4.10"}
-  "ocamlformat" {with-test & = "0.26.2"}
+  "ocaml" {>= "4.14"}
+  "ocamlformat" {with-test & = "0.27.0"}
   "yojson" {with-test & = "2.2.2"}
-  "ocaml-lsp-server" {with-dev-setup & = "1.19.0"}
-  "cppo" {= "1.6.9"}
-  "js_of_ocaml" {= "5.9.1"}
+  "ocaml-lsp-server" {with-dev-setup & = "1.22.0"}
+  "cppo" {= "1.8.0"}
+  "js_of_ocaml" {= "6.0.1"}
   "ounit2" {= "2.2.7"}
-  "reanalyze" {= "2.25.1"}
   "dune"
 ]
 build: [

--- a/tests/ounit_tests/ounit_hash_set_tests.ml
+++ b/tests/ounit_tests/ounit_hash_set_tests.ml
@@ -145,9 +145,9 @@ let suites =
              Hash_set_poly.remove v {name = "x"; stamp = i}
            done;
            OUnit.assert_equal (Hash_set_poly.length v) 1990
-           (* OUnit.assert_equal (Hash_set.stats v) *)
-           (*   {Hashtbl.num_bindings = 1990; num_buckets = 1024; max_bucket_length = 7; *)
-           (*    bucket_histogram = [|139; 303; 264; 178; 93; 32; 12; 3|]} *) );
+         (* OUnit.assert_equal (Hash_set.stats v) *)
+         (*   {Hashtbl.num_bindings = 1990; num_buckets = 1024; max_bucket_length = 7; *)
+         (*    bucket_histogram = [|139; 303; 264; 178; 93; 32; 12; 3|]} *) );
          ( __LOC__ >:: fun _ ->
            let v = Id_hash_set.create 30 in
            for i = 0 to 2_000 do
@@ -176,9 +176,9 @@ let suites =
              OUnit.assert_bool "exist"
                (Id_hash_set.mem v {name = "x"; stamp = i})
            done
-           (* OUnit.assert_equal (Hash_set.stats v) *)
-           (*   {num_bindings = 1990; num_buckets = 1024; max_bucket_length = 8; *)
-           (*    bucket_histogram = [|148; 275; 285; 182; 95; 21; 14; 2; 2|]} *)
+         (* OUnit.assert_equal (Hash_set.stats v) *)
+         (*   {num_bindings = 1990; num_buckets = 1024; max_bucket_length = 8; *)
+         (*    bucket_histogram = [|148; 275; 285; 182; 95; 21; 14; 2; 2|]} *)
          );
          ( __LOC__ >:: fun _ ->
            let duplicate arr =

--- a/tests/ounit_tests/ounit_scc_tests.ml
+++ b/tests/ounit_tests/ounit_scc_tests.ml
@@ -296,7 +296,7 @@ let suites =
                   ("e", []);
                 ])
              (4, [1; 1; 2; 1])
-           (* {[
+         (* {[
               a -> b
               a -> c
               b -> c
@@ -308,7 +308,8 @@ let suites =
               {[
               [d ; e ; [b;c] [a] ]
               ]}
-           *) );
+           *)
+         );
          ( __LOC__ >:: fun _ ->
            OUnit.assert_equal
              (test

--- a/tests/ounit_tests/ounit_unicode_tests.ml
+++ b/tests/ounit_tests/ounit_unicode_tests.ml
@@ -9,7 +9,8 @@ let ( ==~ ) a b =
        (Ast_utf8_string_interp.transform_test a
        |> List.filter (fun x -> not @@ Ast_utf8_string_interp.empty_segment x))
        (fun ({start = {offset = a}; finish = {offset = b}; kind; content} :
-              Ast_utf8_string_interp.segment) -> (a, b, kind, content)))
+              Ast_utf8_string_interp.segment)
+          -> (a, b, kind, content)))
     b
 
 let ( ==* ) a b =
@@ -23,7 +24,8 @@ let ( ==* ) a b =
               kind;
               content;
             } :
-             Ast_utf8_string_interp.segment) -> (la, a, lb, b, kind, content))
+             Ast_utf8_string_interp.segment)
+         -> (la, a, lb, b, kind, content))
   in
   OUnit.assert_equal segments b
 

--- a/tools.opam
+++ b/tools.opam
@@ -7,8 +7,8 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
-  "ocaml" {>= "4.10"}
-  "cppo" {= "1.6.9"}
+  "ocaml" {>= "4.14"}
+  "cppo" {= "1.8.0"}
   "analysis"
   "dune"
 ]


### PR DESCRIPTION
- Some dependency upgrades required, including ocamlformat and ocaml-lsp-server
- Some reformatting required for ocamlformat 0.27.0
- `effect` is a reserved word now
- OCaml 4.14 is the minimum version supported now
- It is unclear when (or whether at all) @cristianoc will release a 5.3 compatible version of reanalyze. Therefore it is removed from the dependencies. However, we also build the compiler for older versions (just to check), and for 5.2.1 I then install and run reanalyze additionally.