### PR TITLE
Analysis tests fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :nail_care: Polish
 
 - Allow single newline in JSX. https://github.com/rescript-lang/rescript/pull/7269
+- Editor: Always complete from Core first. Use actual native regex syntax in code snippets for regexps. https://github.com/rescript-lang/rescript/pull/7295
 
 #### :bug: Bug fix
 
@@ -29,6 +30,7 @@
 #### :house: Internal
 
 - Remove ignore in res_scanner.ml . https://github.com/rescript-lang/rescript/pull/7280
+- Use the new stdlib modules in the analysis tests. https://github.com/rescript-lang/rescript/pull/7295
 
 # 12.0.0-alpha.8
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -2244,12 +2244,7 @@ let rec processCompletable ~debug ~full ~scope ~env ~pos ~forHover completable =
         | _ -> items)))
   | CexhaustiveSwitch {contextPath; exprLoc} ->
     let range = Utils.rangeOfLoc exprLoc in
-    let rescriptMajor, rescriptMinor = Packages.getReScriptVersion () in
-    let printFailwithStr num =
-      if (rescriptMajor = 11 && rescriptMinor >= 1) || rescriptMajor >= 12 then
-        "${" ^ string_of_int num ^ ":%todo}"
-      else "${" ^ string_of_int num ^ ":failwith(\"todo\")}"
-    in
+    let printFailwithStr num = "${" ^ string_of_int num ^ ":%todo}" in
     let withExhaustiveItem ~cases ?(startIndex = 0) (c : Completion.t) =
       (* We don't need to write out `switch` here since we know that's what the
          user has already written. Just complete for the rest. *)

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1801,7 +1801,7 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
     if Debug.verbose () then print_endline "[complete_typed_value]--> Texn";
     [
       create
-        (["Exn.t"; "Error(error)"] |> ident)
+        (["Exn"; "Error(error)"] |> ident)
         ~kind:(Label "Catches errors from JavaScript errors.")
         ~docstring:
           [

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1451,9 +1451,10 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
     (* Special casing for things where we want extra things in the completions *)
     let completionItems =
       match path with
-      | Pdot (Pdot (Pident m, "Re", _), "t", _) when Ident.name m = "Js" ->
+      | Pdot (Pdot (Pident {name = "Js"}, "Re", _), "t", _)
+      | Pdot (Pident {name = "RegExp"}, "t", _) ->
         (* regexps *)
-        create "%re()" ~insertText:"%re(\"/$0/g\")" ~includesSnippets:true
+        create "/<regexp>/g" ~insertText:"/$0/g" ~includesSnippets:true
           ~kind:(Label "Regular expression") ~env
         :: completionItems
       | _ -> completionItems

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1090,8 +1090,7 @@ and getCompletionsForContextPath ~debug ~full ~opens ~rawOpens ~pos ~env ~exact
           *)
           let completeAsBuiltin =
             match typePath with
-            | Some t ->
-              TypeUtils.completionPathFromMaybeBuiltin t ~package:full.package
+            | Some t -> TypeUtils.completionPathFromMaybeBuiltin t
             | None -> None
           in
           let completionPath =
@@ -1801,8 +1800,7 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
     if Debug.verbose () then print_endline "[complete_typed_value]--> Texn";
     [
       create
-        (full.package.builtInCompletionModules.exnModulePath @ ["Error(error)"]
-        |> ident)
+        (["Exn.t"; "Error(error)"] |> ident)
         ~kind:(Label "Catches errors from JavaScript errors.")
         ~docstring:
           [

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -148,61 +148,6 @@ let newBsPackage ~rootPath =
              pathsForModule;
              opens;
              namespace;
-             builtInCompletionModules =
-               (if
-                  opens_from_bsc_flags
-                  |> List.find_opt (fun opn ->
-                         match opn with
-                         | ["RescriptCore"] -> true
-                         | _ -> false)
-                  |> Option.is_some
-                  || fst rescriptVersion >= 12
-                then
-                  {
-                    arrayModulePath = ["Array"];
-                    optionModulePath = ["Option"];
-                    stringModulePath = ["String"];
-                    intModulePath = ["Int"];
-                    floatModulePath = ["Float"];
-                    promiseModulePath = ["Promise"];
-                    listModulePath = ["List"];
-                    resultModulePath = ["Result"];
-                    exnModulePath = ["Exn"];
-                    regexpModulePath = ["RegExp"];
-                  }
-                else if
-                  opens_from_bsc_flags
-                  |> List.find_opt (fun opn ->
-                         match opn with
-                         | ["Belt"] -> true
-                         | _ -> false)
-                  |> Option.is_some
-                then
-                  {
-                    arrayModulePath = ["Array"];
-                    optionModulePath = ["Option"];
-                    stringModulePath = ["Js"; "String2"];
-                    intModulePath = ["Int"];
-                    floatModulePath = ["Float"];
-                    promiseModulePath = ["Js"; "Promise"];
-                    listModulePath = ["List"];
-                    resultModulePath = ["Result"];
-                    exnModulePath = ["Js"; "Exn"];
-                    regexpModulePath = ["Js"; "Re"];
-                  }
-                else
-                  {
-                    arrayModulePath = ["Js"; "Array2"];
-                    optionModulePath = ["Belt"; "Option"];
-                    stringModulePath = ["Js"; "String2"];
-                    intModulePath = ["Belt"; "Int"];
-                    floatModulePath = ["Belt"; "Float"];
-                    promiseModulePath = ["Js"; "Promise"];
-                    listModulePath = ["Belt"; "List"];
-                    resultModulePath = ["Belt"; "Result"];
-                    exnModulePath = ["Js"; "Exn"];
-                    regexpModulePath = ["Js"; "Re"];
-                  });
              uncurried;
            }))
     | None -> None

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -483,19 +483,6 @@ type file = string
 
 module FileSet = Set.Make (String)
 
-type builtInCompletionModules = {
-  arrayModulePath: string list;
-  optionModulePath: string list;
-  stringModulePath: string list;
-  intModulePath: string list;
-  floatModulePath: string list;
-  promiseModulePath: string list;
-  listModulePath: string list;
-  resultModulePath: string list;
-  exnModulePath: string list;
-  regexpModulePath: string list;
-}
-
 type package = {
   genericJsxModule: string option;
   suffix: string;
@@ -504,7 +491,6 @@ type package = {
   dependenciesFiles: FileSet.t;
   pathsForModule: (file, paths) Hashtbl.t;
   namespace: string option;
-  builtInCompletionModules: builtInCompletionModules;
   opens: path list;
   uncurried: bool;
   rescriptVersion: int * int;

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -1253,17 +1253,16 @@ let pathToBuiltin path =
   Predef.builtin_idents
   |> List.find_opt (fun (_, i) -> Ident.same i (Path.head path))
 
-let completionPathFromMaybeBuiltin path ~package =
+let completionPathFromMaybeBuiltin path =
   match pathToBuiltin path with
-  | Some ("array", _) -> Some package.builtInCompletionModules.arrayModulePath
-  | Some ("option", _) -> Some package.builtInCompletionModules.optionModulePath
-  | Some ("string", _) -> Some package.builtInCompletionModules.stringModulePath
-  | Some ("int", _) -> Some package.builtInCompletionModules.intModulePath
-  | Some ("float", _) -> Some package.builtInCompletionModules.floatModulePath
-  | Some ("promise", _) ->
-    Some package.builtInCompletionModules.promiseModulePath
-  | Some ("list", _) -> Some package.builtInCompletionModules.listModulePath
-  | Some ("result", _) -> Some package.builtInCompletionModules.resultModulePath
+  | Some ("array", _) -> Some ["Array"]
+  | Some ("option", _) -> Some ["Option"]
+  | Some ("string", _) -> Some ["String"]
+  | Some ("int", _) -> Some ["Int"]
+  | Some ("float", _) -> Some ["Float"]
+  | Some ("promise", _) -> Some ["Promise"]
+  | Some ("list", _) -> Some ["List"]
+  | Some ("result", _) -> Some ["Result"]
   | Some ("dict", _) -> Some ["Dict"]
   | Some ("char", _) -> Some ["Char"]
   | _ -> None

--- a/tests/analysis_tests/tests-generic-jsx-transform/package-lock.json
+++ b/tests/analysis_tests/tests-generic-jsx-transform/package-lock.json
@@ -10,7 +10,7 @@
     },
     "../../..": {
       "name": "rescript",
-      "version": "12.0.0-alpha.8",
+      "version": "12.0.0-alpha.9",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {

--- a/tests/analysis_tests/tests-generic-jsx-transform/src/expected/GenericJsxCompletion.res.txt
+++ b/tests/analysis_tests/tests-generic-jsx-transform/src/expected/GenericJsxCompletion.res.txt
@@ -59,7 +59,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
-Path Js.String2.st
+Path String.st
 [{
     "label": "GenericJsx.string",
     "kind": 12,
@@ -69,17 +69,17 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/GenericJsxCompletion.res 20:24
@@ -106,7 +106,7 @@ Resolved opens 1 GenericJsx
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
-Path Js.String2.st
+Path String.st
 [{
     "label": "string",
     "kind": 12,
@@ -116,16 +116,16 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 

--- a/tests/analysis_tests/tests/src/Completion.res
+++ b/tests/analysis_tests/tests/src/Completion.res
@@ -170,8 +170,8 @@ module WithChildren = {
 // <WithChildren
 //              ^com
 
-// type t = n
-//           ^com
+// type t = Null.
+//               ^com
 // type t = ForAuto.
 //                  ^com
 

--- a/tests/analysis_tests/tests/src/Completion.res
+++ b/tests/analysis_tests/tests/src/Completion.res
@@ -389,7 +389,6 @@ let _ = x =>
 //                      ^com
 
 let _ = _ => {
-  open Js
   //  []->ma
   //        ^com
   ()

--- a/tests/analysis_tests/tests/src/Completion.res
+++ b/tests/analysis_tests/tests/src/Completion.res
@@ -1,4 +1,4 @@
-module MyList = Belt.List
+module MyList = List
 // MyList.m
 //         ^com
 // Array.
@@ -45,7 +45,7 @@ let fa: ForAuto.t = 34
 // fa->
 //     ^com
 
-// "hello"->Js.Dict.u
+// "hello"->String.in
 //                   ^com
 
 module O = {
@@ -142,7 +142,7 @@ let foo = {
     type z = int
     let v = 44
   }
-  exception MyException(int, string, float, array<Js.Json.t>)
+  exception MyException(int, string, float, array<JSON.t>)
   let _ = raise(MyException(2, "", 1.0, []))
   add((x: Inner.z), Inner.v + y)
 }
@@ -170,8 +170,8 @@ module WithChildren = {
 // <WithChildren
 //              ^com
 
-// type t = Js.n
-//              ^com
+// type t = n
+//           ^com
 // type t = ForAuto.
 //                  ^com
 
@@ -414,7 +414,7 @@ let onClick = evt => {
   evt->ReactEvent.Synthetic.preventDefault
   // SomeLocalModule.
   //                 ^com
-  Js.log("Hello")
+  Console.log("Hello")
 }
 
 // let _ = 123->t

--- a/tests/analysis_tests/tests/src/CompletionDicts.res
+++ b/tests/analysis_tests/tests/src/CompletionDicts.res
@@ -1,14 +1,14 @@
-// let dict = Js.Dict.fromArray([])
-//                               ^com
+// let dict = Dict.fromArray([])
+//                            ^com
 
-// let dict = Js.Dict.fromArray([()])
-//                                ^com
+// let dict = Dict.fromArray([()])
+//                             ^com
 
-// let dict = Js.Dict.fromArray([("key", )])
-//                                      ^com
+// let dict = Dict.fromArray([("key", )])
+//                                   ^com
 
 // ^in+
-let dict = Js.Dict.fromArray([
+let dict = Dict.fromArray([
   ("key", true),
   //  ("key2", )
   //          ^com

--- a/tests/analysis_tests/tests/src/CompletionExpressions.res
+++ b/tests/analysis_tests/tests/src/CompletionExpressions.res
@@ -183,8 +183,8 @@ let something = {
   let second2 = 1
   ignore(second)
   ignore(second2)
-  Js.log(s)
-  //      ^com
+  Console.log(s)
+  //           ^com
 }
 
 let fff: recordWithOptionalField = {
@@ -314,7 +314,7 @@ open CompletionSupport
 // CompletionSupport.makeTestHidden()
 //                                  ^com
 
-let mkStuff = (r: Js.Re.t) => {
+let mkStuff = (r: RegExp.t) => {
   ignore(r)
   "hello"
 }
@@ -343,7 +343,7 @@ module Money: {
 
   let make = (): t => zero
 
-  let fromInt = (int): t => int->Js.Int.toString
+  let fromInt = (int): t => int->Int.toString
 
   let plus = (m1, _) => m1
 }

--- a/tests/analysis_tests/tests/src/CompletionInferValues.res
+++ b/tests/analysis_tests/tests/src/CompletionInferValues.res
@@ -48,11 +48,11 @@ module Div = {
 // let _ = <div onMouseEnter={event => { let btn = event->JsxEvent.Mouse.button; btn->t }} />
 //                                                                                     ^com
 
-// let _ = <div onMouseEnter={event => { let btn = event->JsxEvent.Mouse.button->Belt.Int.toString; btn->spl }} />
-//                                                                                                          ^com
+// let _ = <div onMouseEnter={event => { let btn = event->JsxEvent.Mouse.button->Int.toString; btn->spl }} />
+//                                                                                                     ^com
 
-// let _ = <div onMouseEnter={event => { let btn = event->JsxEvent.Mouse.button->Belt.Int.toString->Js.String2.split("/"); btn->ma }} />
-//                                                                                                                                ^com
+// let _ = <div onMouseEnter={event => { let btn = event->JsxEvent.Mouse.button->Int.toString->String.split("/"); btn->ma }} />
+//                                                                                                                       ^com
 
 type someVariant = One | Two | Three(int, string)
 type somePolyVariant = [#one | #two | #three(int, string)]
@@ -145,8 +145,8 @@ let fn3 = (~cb: sameFileRecord => unit) => {
 //                                             ^com
 
 // Handles pipe chains as input for switch
-// let x = 123; switch x->Belt.Int.toString->Js.String2.split("/") { | }
-//                                                                    ^com
+// let x = 123; switch x->Belt.Int.toString->String.split("/") { | }
+//                                                                ^com
 
 // Regular completion works
 // let renderer = CompletionSupport2.makeRenderer(~prepare=() => "hello",~render=({support}) => {support.},())

--- a/tests/analysis_tests/tests/src/CompletionJsx.res
+++ b/tests/analysis_tests/tests/src/CompletionJsx.res
@@ -20,8 +20,8 @@ module SomeComponent = {
       //                ^com
       // {"Some string"->st}
       //                   ^com
-      // {"Some string"->Js.String2.trim->st}
-      //                                    ^com
+      // {"Some string"->String.trim->st}
+      //                                ^com
       // {someInt->}
       //           ^com
       // {12->}

--- a/tests/analysis_tests/tests/src/CompletionJsxProps.res
+++ b/tests/analysis_tests/tests/src/CompletionJsxProps.res
@@ -38,7 +38,7 @@ let tsomeVar = #two
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module CompletableComponentLazy = {
-  let loadComponent = () => Js.import(CompletableComponent.make)
+  let loadComponent = () => import(CompletableComponent.make)
   let make = React.lazy_(loadComponent)
 }
 

--- a/tests/analysis_tests/tests/src/CompletionPipeChain.res
+++ b/tests/analysis_tests/tests/src/CompletionPipeChain.res
@@ -55,7 +55,7 @@ let f = int->Integer.increment(2)
 // let _ = CompletionSupport.Test.make(1)->CompletionSupport.Test.addSelf(2)->
 //                                                                            ^com
 
-let _ = [123]->Js.Array2.forEach(v => Js.log(v))
+let _ = [123]->Array.forEach(v => Console.log(v))
 // ->
 //   ^com
 
@@ -99,7 +99,7 @@ let renderer = CompletionSupport2.makeRenderer(
 // Console.log(int->t)
 //                   ^com
 
-let r = %re("/t/g")
+let r = /t/g
 
 // r->la
 //      ^com

--- a/tests/analysis_tests/tests/src/CompletionTypeT.res
+++ b/tests/analysis_tests/tests/src/CompletionTypeT.res
@@ -1,6 +1,6 @@
-let date = Some(Js.Date.make())
+let date = Some(Date.make())
 
-type withDate = {date: Js.Date.t}
+type withDate = {date: Date.t}
 
 // let x = switch date { | }
 //                        ^com

--- a/tests/analysis_tests/tests/src/DotPipeCompletionSpec.res
+++ b/tests/analysis_tests/tests/src/DotPipeCompletionSpec.res
@@ -84,19 +84,19 @@ let nnn: typeOutsideModule = {nname: "hello"}
 // Continuous completion
 let xxxx = [1, 2]
 
-// xxxx->Js.Array2.filter(v => v > 10).filt
-//                                         ^com
+// xxxx->Array.filter(v => v > 10).filt
+//                                     ^com
 
-// xxxx->Js.Array2.filter(v => v > 10)->Js.Array2.joinWith(",").includ
-//                                                                    ^com
+// xxxx->Array.filter(v => v > 10)->Array.joinWith(",").includ
+//                                                            ^com
 
 let str = "hello"
 
-// str->Js.String2.toLowerCase.toUpperCa
-//                                      ^com
+// str->String.toLowerCase.toUpperCa
+//                                  ^com
 
-// str->Js.String2.toLowerCase->Js.String2.toUpperCase.toLowerC
-//                                                             ^com
+// str->String.toLowerCase->String.toUpperCase.toLowerC
+//                                                     ^com
 
 let cc = (t: typeOutsideModule) => {
   // t.

--- a/tests/analysis_tests/tests/src/Hover.res
+++ b/tests/analysis_tests/tests/src/Hover.res
@@ -54,7 +54,7 @@ module type Logger = {
 
 module JsLogger: Logger = {
   //   ^hov
-  let log = (msg: string) => Js.log(msg)
+  let log = (msg: string) => Console.log(msg)
   let _oneMore = 3
 }
 
@@ -123,19 +123,19 @@ let typeDuplicate = AA.fnnxx
 @live let dd = 34
 // ^hov
 
-let arity0a = (. ()) => {
+let arity0a = () => {
   //^hov
   let f = () => 3
   f
 }
 
-let arity0b = (. (), . ()) => 3
+let arity0b = ((), ()) => 3
 //  ^hov
 
-let arity0c = (. (), ()) => 3
+let arity0c = ((), ()) => 3
 //  ^hov
 
-let arity0d = (. ()) => {
+let arity0d = () => {
   // ^hov
   let f = () => 3
   f

--- a/tests/analysis_tests/tests/src/PolyRec.res
+++ b/tests/analysis_tests/tests/src/PolyRec.res
@@ -10,5 +10,5 @@ let myTree = #Node(
   #Node(3, #Node(5, #Leaf, #Leaf), #Node(7, #Leaf, #Leaf)),
 )
 
-let () = myTree->sum->Js.log
+let () = myTree->sum->Console.log
 //        ^hov

--- a/tests/analysis_tests/tests/src/SignatureHelp.res
+++ b/tests/analysis_tests/tests/src/SignatureHelp.res
@@ -101,7 +101,7 @@ let three = Three("", [])
 let three2 = Three("", [])
 //                      ^she
 
-let _deepestTakesPrecedence = [12]->Js.Array2.map(v =>
+let _deepestTakesPrecedence = [12]->Array.map(v =>
   if v > 0 {
     One({})
     //   ^she

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -10,67 +10,31 @@ Path MyList.m
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nEquivalent to `Belt.List.map(someList, f)->Belt.List.reverse`\n\n## Examples\n\n```rescript\nlist{3, 4, 5}\n->Belt.List.mapReverse(x => x * x)\n->assertEqual(list{25, 16, 9})\n```\n"}
-  }, {
-    "label": "makeBy",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int => 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "\nReturn a list of length `numItems` with element `i` initialized with `f(i)`.\nReturns an empty list if `numItems` is negative.\n\n## Examples\n\n```rescript\nBelt.List.makeBy(5, i => i) // list{0, 1, 2, 3, 4}\n\nBelt.List.makeBy(5, i => i * i) // list{0, 1, 4, 9, 16}\n```\n"}
-  }, {
-    "label": "make",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "\nReturns a list of length `numItems` with each element filled with value `v`. Returns an empty list if `numItems` is negative.\n\n## Examples\n\n```rescript\nBelt.List.make(3, 1) // list{1, 1, 1}\n```\n"}
-  }, {
-    "label": "mapReverse2U",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `mapReverse2` instead\n\n Uncurried version of [mapReverse2](#mapReverse2). "}
-  }, {
-    "label": "map",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nReturns a new list with `f` applied to each element of `someList`.\n\n## Examples\n\n```rescript\nlist{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}\n```\n"}
-  }, {
-    "label": "mapWithIndexU",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(t<'a>, (int, 'a) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `mapWithIndex` instead\n\n Uncurried version of [mapWithIndex](#mapWithIndex). "}
-  }, {
-    "label": "mapU",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `map` instead\n\n Uncurried version of [map](#map). "}
-  }, {
-    "label": "makeByU",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(int, int => 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `makeBy` instead\n\n Uncurried version of [makeBy](#makeBy) "}
+    "documentation": {"kind": "markdown", "value": "\n`mapReverse(list, f)` is equivalent to `map` function.\n\n## Examples\n\n```rescript\nlet f = x => x * x\nlet l = list{3, 4, 5}\n\nlet withMap = List.map(l, f)->List.reverse\nlet withMapReverse = l->List.mapReverse(f)\n\nConsole.log(withMap == withMapReverse) // true\n```\n"}
   }, {
     "label": "mapReverse2",
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>",
-    "documentation": {"kind": "markdown", "value": "\nEquivalent to: `zipBy(xs, ys, f)->reverse`\n\n## Examples\n\n```rescript\n\nBelt.List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`mapReverse2(list1, list2, f)` is equivalent to `List.zipBy(list1, list2, f)->List.reverse`.\n\n## Examples\n\n```rescript\nList.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}\n```\n"}
+  }, {
+    "label": "make",
+    "kind": 12,
+    "tags": [],
+    "detail": "(~length: int, 'a) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "\n`make(length, value)` returns a list of length `length` with each element filled\nwith `value`. Returns an empty list if `value` is negative.\n\n## Examples\n\n```rescript\nList.make(~length=3, 1) // list{1, 1, 1}\n```\n"}
   }, {
     "label": "mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, (int, 'a) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies `f` to each element of `someList`.\nFunction `f` takes two arguments: the index starting from 0 and the element from `someList`, in that order.\n\n## Examples\n\n```rescript\nlist{1, 2, 3}->Belt.List.mapWithIndex((index, x) => index + x) // list{1, 3, 5}\n```\n"}
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(list, f)` applies `f` to each element of `list`. Function `f`\ntakes two arguments: the index starting from 0 and the element from `list`, in\nthat order.\n\n## Examples\n\n```rescript\nlist{1, 2, 3}->List.mapWithIndex((x, index) => index + x) // list{1, 3, 5}\n```\n"}
   }, {
-    "label": "mapReverseU",
+    "label": "map",
     "kind": 12,
-    "tags": [1],
+    "tags": [],
     "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `mapReverse` instead\n\n Uncurried version of [mapReverse](#mapReverse). "}
+    "documentation": {"kind": "markdown", "value": "\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}
   }]
 
 Complete src/Completion.res 3:9
@@ -722,26 +686,8 @@ Path ForAuto.
   }]
 
 Complete src/Completion.res 47:21
-posCursor:[47:21] posNoWhite:[47:20] Found expr:[47:3->47:21]
-posCursor:[47:21] posNoWhite:[47:20] Found expr:[47:12->47:21]
-Pexp_ident Js.Dict.u:[47:12->47:21]
-Completable: Cpath Value[Js, Dict, u]
-Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, Dict, u]
-Path Js.Dict.u
-[{
-    "label": "unsafeGet",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t<'a>, key) => 'a",
-    "documentation": {"kind": "markdown", "value": "\n`Js.Dict.unsafeGet(key)` returns the value if the key exists, otherwise an `undefined` value is returned. Use this only when you are sure the key exists (i.e. when having used the `keys()` function to check that the key is valid).\n\n## Examples\n\n```rescript\nJs.Dict.unsafeGet(ages, \"Fred\") == 49\nJs.Dict.unsafeGet(ages, \"Paul\") // returns undefined\n```\n"}
-  }, {
-    "label": "unsafeDeleteKey",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t<string>, string) => unit",
-    "documentation": {"kind": "markdown", "value": " Experimental internal function "}
-  }]
+XXX Not found!
+[]
 
 Complete src/Completion.res 59:30
 posCursor:[59:30] posNoWhite:[59:29] Found expr:[59:15->59:30]
@@ -1152,31 +1098,19 @@ Path WithChildren
     "documentation": null
   }]
 
-Complete src/Completion.res 172:16
-posCursor:[172:16] posNoWhite:[172:15] Found type:[172:12->172:16]
-Ptyp_constr Js.n:[172:12->172:16]
-Completable: Cpath Type[Js, n]
+Complete src/Completion.res 172:13
+posCursor:[172:13] posNoWhite:[172:12] Found type:[172:12->172:13]
+Ptyp_constr n:[172:12->172:13]
+Completable: Cpath Type[n]
 Package opens Pervasives.JsxModules.place holder
-ContextPath Type[Js, n]
-Path Js.n
+ContextPath Type[n]
+Path n
 [{
-    "label": "null_undefined",
+    "label": "nestedObjT",
     "kind": 22,
     "tags": [],
-    "detail": "type null_undefined",
-    "documentation": {"kind": "markdown", "value": "```rescript\ntype null_undefined<'a> = nullable<'a>\n```"}
-  }, {
-    "label": "nullable",
-    "kind": 22,
-    "tags": [],
-    "detail": "type nullable",
-    "documentation": {"kind": "markdown", "value": "```rescript\n@unboxed\ntype nullable<'a> = Js_null_undefined.t<'a> =\n  | Value('a)\n  | @as(null) Null\n  | @as(undefined) Undefined\n```"}
-  }, {
-    "label": "null",
-    "kind": 22,
-    "tags": [],
-    "detail": "type null",
-    "documentation": {"kind": "markdown", "value": "```rescript\n@unboxed\ntype null<'a> = Js_null.t<'a> = Value('a) | @as(null) Null\n```"}
+    "detail": "type nestedObjT",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype nestedObjT = {\"x\": Objects.nestedObjT}\n```"}
   }]
 
 Complete src/Completion.res 174:20
@@ -2352,7 +2286,7 @@ Path r
 
 Complete src/Completion.res 411:21
 posCursor:[411:21] posNoWhite:[411:20] Found expr:[410:14->417:1]
-posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->416:17]
+posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->416:22]
 posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->413:42]
 posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->413:5]
 Pexp_ident SomeLocalModule.:[411:5->413:5]
@@ -2378,11 +2312,11 @@ Path SomeLocalModule.
 
 Complete src/Completion.res 414:21
 posCursor:[414:21] posNoWhite:[414:20] Found expr:[410:14->417:1]
-posCursor:[414:21] posNoWhite:[414:20] Found expr:[413:2->416:17]
-posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:17]
-Pexp_apply ...[414:5->416:8] (...[416:9->416:16])
-posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:8]
-Pexp_ident SomeLocalModule.:[414:5->416:8]
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[413:2->416:22]
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:22]
+Pexp_apply ...[414:5->416:13] (...[416:14->416:21])
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:13]
+Pexp_ident SomeLocalModule.:[414:5->416:13]
 Completable: Cpath Value[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -650,19 +650,19 @@ Completable: Cpath array<int>->m
 Package opens Pervasives.JsxModules.place holder
 ContextPath array<int>->m
 ContextPath array<int>
-Path Js.Array2.m
+Path Array.m
 [{
-    "label": "Js.Array2.mapi",
+    "label": "Array.map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The function acceps two arguments: an item from the array and its\nindex number. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\n// multiply each item in array by its position\nlet product = (item, index) => item * index\nJs.Array2.mapi([10, 11, 12], product) == [0, 11, 24]\n```\n"}
+    "detail": "(array<'a>, 'a => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`map(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray = array->Array.map(greeting => greeting ++ \" to you\")\n\nassertEqual(mappedArray, [\"Hello to you\", \"Hi to you\", \"Good bye to you\"])\n```\n"}
   }, {
-    "label": "Js.Array2.map",
+    "label": "Array.mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\nJs.Array2.map([12, 4, 8], x => x * x) == [144, 16, 64]\nJs.Array2.map([\"animal\", \"vegetable\", \"mineral\"], Js.String.length) == [6, 9, 7]\n```\n"}
+    "detail": "(array<'a>, ('a, int) => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray =\n  array->Array.mapWithIndex((greeting, index) =>\n    greeting ++ \" at position \" ++ Int.toString(index)\n  )\n\nassertEqual(mappedArray, [\"Hello at position 0\", \"Hi at position 1\", \"Good bye at position 2\"])\n```\n"}
   }]
 
 Complete src/Completion.res 29:13
@@ -671,13 +671,13 @@ Completable: Cpath string->toU
 Package opens Pervasives.JsxModules.place holder
 ContextPath string->toU
 ContextPath string
-Path Js.String2.toU
+Path String.toU
 [{
-    "label": "Js.String2.toUpperCase",
+    "label": "String.toUpperCase",
     "kind": 12,
     "tags": [],
-    "detail": "t => t",
-    "documentation": {"kind": "markdown", "value": "\n`toUpperCase(str)` converts `str` to upper case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\nexpand the number of letters in the result; for example the German ß\ncapitalizes to two Ses in a row.\n\nSee [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.toUpperCase(\"abc\") == \"ABC\"\nJs.String2.toUpperCase(`Straße`) == `STRASSE`\nJs.String2.toUpperCase(`πς`) == `ΠΣ`\n```\n"}
+    "detail": "string => string",
+    "documentation": {"kind": "markdown", "value": "\n`toUpperCase(str)` converts `str` to upper case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\nexpand the number of letters in the result, for example the German ß\ncapitalizes to two Ses in a row.\nSee [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) on MDN.\n\n## Examples\n\n```rescript\nString.toUpperCase(\"abc\") == \"ABC\"\nString.toUpperCase(`Straße`) == `STRASSE`\nString.toUpperCase(`πς`) == `ΠΣ`\n```\n"}
   }]
 
 Complete src/Completion.res 34:8
@@ -687,19 +687,13 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[op]->e
 ContextPath Value[op]
 Path op
-Path Belt.Option.e
+Path Option.e
 [{
-    "label": "Belt.Option.eqU",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(option<'a>, option<'b>, ('a, 'b) => bool) => bool",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use `eq` instead\n\n\nUncurried version of `eq`\n"}
-  }, {
-    "label": "Belt.Option.eq",
+    "label": "Option.equal",
     "kind": 12,
     "tags": [],
     "detail": "(option<'a>, option<'b>, ('a, 'b) => bool) => bool",
-    "documentation": {"kind": "markdown", "value": "\nEvaluates two optional values for equality with respect to a predicate\nfunction. If both `optValue1` and `optValue2` are `None`, returns `true`.\nIf one of the arguments is `Some(value)` and the other is `None`, returns\n`false`.\n\nIf arguments are `Some(value1)` and `Some(value2)`, returns the result of\n`predicate(value1, value2)`; the predicate function must return a bool.\n\n## Examples\n\n```rescript\nlet clockEqual = (a, b) => mod(a, 12) == mod(b, 12)\n\nopen Belt.Option\n\neq(Some(3), Some(15), clockEqual) /* true */\n\neq(Some(3), None, clockEqual) /* false */\n\neq(None, Some(3), clockEqual) /* false */\n\neq(None, None, clockEqual) /* true */\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`equal(opt1, opt2, f)` evaluates two optional values for equality with respect to a predicate function `f`. If both `opt1` and `opt2` are `None`, returns `true`.\nIf one of the arguments is `Some(value)` and the other is `None`, returns\n`false`.\nIf arguments are `Some(value1)` and `Some(value2)`, returns the result of\n`f(value1, value2)`, the predicate function `f` must return a bool.\n\n## Examples\n\n```rescript\nlet clockEqual = (a, b) => mod(a, 12) == mod(b, 12)\n\nopen Option\n\nequal(Some(3), Some(15), clockEqual) // true\nequal(Some(3), None, clockEqual) // false\nequal(None, Some(3), clockEqual) // false\nequal(None, None, clockEqual) // true\n```\n"}
   }]
 
 Complete src/Completion.res 44:7
@@ -2255,39 +2249,38 @@ Path Completion.
     "documentation": {"kind": "markdown", "value": "```rescript\nstuff: string\n```\n\n```rescript\ntype funRecord = {\n  someFun: (~name: string) => unit,\n  stuff: string,\n}\n```"}
   }]
 
-Complete src/Completion.res 392:12
-posCursor:[392:12] posNoWhite:[392:11] Found expr:[390:8->395:1]
-posCursor:[392:12] posNoWhite:[392:11] Found expr:[391:2->394:4]
-posCursor:[392:12] posNoWhite:[392:11] Found expr:[392:6->394:4]
-posCursor:[392:12] posNoWhite:[392:11] Found expr:[392:6->392:12]
+Complete src/Completion.res 391:12
+posCursor:[391:12] posNoWhite:[391:11] Found expr:[390:8->394:1]
+posCursor:[391:12] posNoWhite:[391:11] Found expr:[391:6->393:4]
+posCursor:[391:12] posNoWhite:[391:11] Found expr:[391:6->391:12]
 Completable: Cpath array->ma
-Raw opens: 3 Js.place holder ... Shadow.B.place holder ... Shadow.A.place holder
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
-Resolved opens 3 Completion Completion Js
+Resolved opens 2 Completion Completion
 ContextPath array->ma
 ContextPath array
-Path Js.Array2.ma
+Path Array.ma
 [{
-    "label": "Array2.mapi",
+    "label": "Array.map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The function acceps two arguments: an item from the array and its\nindex number. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\n// multiply each item in array by its position\nlet product = (item, index) => item * index\nJs.Array2.mapi([10, 11, 12], product) == [0, 11, 24]\n```\n"}
+    "detail": "(array<'a>, 'a => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`map(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray = array->Array.map(greeting => greeting ++ \" to you\")\n\nassertEqual(mappedArray, [\"Hello to you\", \"Hi to you\", \"Good bye to you\"])\n```\n"}
   }, {
-    "label": "Array2.map",
+    "label": "Array.mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\nJs.Array2.map([12, 4, 8], x => x * x) == [144, 16, 64]\nJs.Array2.map([\"animal\", \"vegetable\", \"mineral\"], Js.String.length) == [6, 9, 7]\n```\n"}
+    "detail": "(array<'a>, ('a, int) => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray =\n  array->Array.mapWithIndex((greeting, index) =>\n    greeting ++ \" at position \" ++ Int.toString(index)\n  )\n\nassertEqual(mappedArray, [\"Hello at position 0\", \"Hi at position 1\", \"Good bye at position 2\"])\n```\n"}
   }]
 
-Complete src/Completion.res 400:14
-posCursor:[400:14] posNoWhite:[400:13] Found expr:[399:14->400:20]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[399:14->400:16], ...[400:16->400:19])
-posCursor:[400:14] posNoWhite:[400:13] Found expr:[399:14->400:16]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[399:14->400:11], ...[400:13->400:16])
-posCursor:[400:14] posNoWhite:[400:13] Found expr:[400:13->400:16]
-Pexp_ident red:[400:13->400:16]
+Complete src/Completion.res 399:14
+posCursor:[399:14] posNoWhite:[399:13] Found expr:[398:14->399:20]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[398:14->399:16], ...[399:16->399:19])
+posCursor:[399:14] posNoWhite:[399:13] Found expr:[398:14->399:16]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[398:14->399:11], ...[399:13->399:16])
+posCursor:[399:14] posNoWhite:[399:13] Found expr:[399:13->399:16]
+Pexp_ident red:[399:13->399:16]
 Completable: Cpath Value[red]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2302,13 +2295,13 @@ Path red
     "documentation": null
   }]
 
-Complete src/Completion.res 405:25
-posCursor:[405:25] posNoWhite:[405:24] Found expr:[403:14->405:31]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[403:14->405:27], ...[405:27->405:30])
-posCursor:[405:25] posNoWhite:[405:24] Found expr:[403:14->405:27]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[403:14->405:22], ...[405:24->405:27])
-posCursor:[405:25] posNoWhite:[405:24] Found expr:[405:24->405:27]
-Pexp_ident red:[405:24->405:27]
+Complete src/Completion.res 404:25
+posCursor:[404:25] posNoWhite:[404:24] Found expr:[402:14->404:31]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[402:14->404:27], ...[404:27->404:30])
+posCursor:[404:25] posNoWhite:[404:24] Found expr:[402:14->404:27]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[402:14->404:22], ...[404:24->404:27])
+posCursor:[404:25] posNoWhite:[404:24] Found expr:[404:24->404:27]
+Pexp_ident red:[404:24->404:27]
 Completable: Cpath Value[red]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2323,14 +2316,14 @@ Path red
     "documentation": null
   }]
 
-Complete src/Completion.res 408:22
-posCursor:[408:22] posNoWhite:[408:21] Found expr:[408:11->469:0]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[408:11->426:17], ...[431:0->469:0])
-posCursor:[408:22] posNoWhite:[408:21] Found expr:[408:11->426:17]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[408:11->408:19], ...[408:21->426:17])
-posCursor:[408:22] posNoWhite:[408:21] Found expr:[408:21->426:17]
-posCursor:[408:22] posNoWhite:[408:21] Found expr:[408:21->408:22]
-Pexp_ident r:[408:21->408:22]
+Complete src/Completion.res 407:22
+posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:11->468:0]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[407:11->425:17], ...[430:0->468:0])
+posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:11->425:17]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[407:11->407:19], ...[407:21->425:17])
+posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:21->425:17]
+posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:21->407:22]
+Pexp_ident r:[407:21->407:22]
 Completable: Cpath Value[r]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2357,12 +2350,12 @@ Path r
     "documentation": {"kind": "markdown", "value": "```rescript\ntype r = {x: int, y: string}\n```"}
   }]
 
-Complete src/Completion.res 412:21
-posCursor:[412:21] posNoWhite:[412:20] Found expr:[411:14->418:1]
-posCursor:[412:21] posNoWhite:[412:20] Found expr:[412:5->417:17]
-posCursor:[412:21] posNoWhite:[412:20] Found expr:[412:5->414:42]
-posCursor:[412:21] posNoWhite:[412:20] Found expr:[412:5->414:5]
-Pexp_ident SomeLocalModule.:[412:5->414:5]
+Complete src/Completion.res 411:21
+posCursor:[411:21] posNoWhite:[411:20] Found expr:[410:14->417:1]
+posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->416:17]
+posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->413:42]
+posCursor:[411:21] posNoWhite:[411:20] Found expr:[411:5->413:5]
+Pexp_ident SomeLocalModule.:[411:5->413:5]
 Completable: Cpath Value[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2383,13 +2376,13 @@ Path SomeLocalModule.
     "documentation": null
   }]
 
-Complete src/Completion.res 415:21
-posCursor:[415:21] posNoWhite:[415:20] Found expr:[411:14->418:1]
-posCursor:[415:21] posNoWhite:[415:20] Found expr:[414:2->417:17]
-posCursor:[415:21] posNoWhite:[415:20] Found expr:[415:5->417:17]
-Pexp_apply ...[415:5->417:8] (...[417:9->417:16])
-posCursor:[415:21] posNoWhite:[415:20] Found expr:[415:5->417:8]
-Pexp_ident SomeLocalModule.:[415:5->417:8]
+Complete src/Completion.res 414:21
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[410:14->417:1]
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[413:2->416:17]
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:17]
+Pexp_apply ...[414:5->416:8] (...[416:9->416:16])
+posCursor:[414:21] posNoWhite:[414:20] Found expr:[414:5->416:8]
+Pexp_ident SomeLocalModule.:[414:5->416:8]
 Completable: Cpath Value[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2410,54 +2403,150 @@ Path SomeLocalModule.
     "documentation": null
   }]
 
-Complete src/Completion.res 420:17
-posCursor:[420:17] posNoWhite:[420:16] Found expr:[420:11->420:17]
+Complete src/Completion.res 419:17
+posCursor:[419:17] posNoWhite:[419:16] Found expr:[419:11->419:17]
 Completable: Cpath int->t
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion Completion
 ContextPath int->t
 ContextPath int
-Path Belt.Int.t
+Path Int.t
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.toPrecision",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
+  }, {
+    "label": "Int.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
-Complete src/Completion.res 423:19
-posCursor:[423:19] posNoWhite:[423:18] Found expr:[423:11->423:19]
+Complete src/Completion.res 422:19
+posCursor:[422:19] posNoWhite:[422:18] Found expr:[422:11->422:19]
 Completable: Cpath float->t
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion Completion
 ContextPath float->t
 ContextPath float
-Path Belt.Float.t
+Path Float.t
 [{
-    "label": "Belt.Float.toInt",
+    "label": "Float.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(float, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` with `~radix` instead\n\n\n`toStringWithRadix(v, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) on MDN.\n\n## Examples\n\n```rescript\nFloat.toStringWithRadix(6.0, ~radix=2) // \"110\"\nFloat.toStringWithRadix(3735928559.0, ~radix=16) // \"deadbeef\"\nFloat.toStringWithRadix(123456.0, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Float.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(float, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(v, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point.\nSee [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential) on MDN.\n\n## Examples\n\n```rescript\nFloat.toExponentialWithPrecision(77.0, ~digits=2) // \"7.70e+1\"\nFloat.toExponentialWithPrecision(5678.0, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Float.toInt",
     "kind": 12,
     "tags": [],
     "detail": "float => int",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `float` to an `int`.\n\n## Examples\n\n```rescript\nJs.log(Belt.Float.toInt(1.0) === 1) /* true */\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toInt(v)` returns an int to given float `v`.\n\n## Examples\n\n```rescript\nFloat.toInt(2.0) == 2\nFloat.toInt(1.0) == 1\nFloat.toInt(1.1) == 1\nFloat.toInt(1.6) == 1\n```\n"}
   }, {
-    "label": "Belt.Float.toString",
+    "label": "Float.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(float, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(v, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point.\nSee [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) on MDN.\n\n## Examples\n\n```rescript\nFloat.toFixedWithPrecision(300.0, ~digits=4) // \"300.0000\"\nFloat.toFixedWithPrecision(300.0, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Float.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(float, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(v, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits.\nSee [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nFloat.toPrecisionWithPrecision(100.0, ~digits=2) // \"1.0e+2\"\nFloat.toPrecisionWithPrecision(1.0, ~digits=1) // \"1\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Float.toPrecision",
+    "kind": 12,
+    "tags": [],
+    "detail": "(float, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(v, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits.\nSee [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nFloat.toPrecision(100.0) // \"100\"\nFloat.toPrecision(1.0) // \"1\"\nFloat.toPrecision(100.0, ~digits=2) // \"1.0e+2\"\nFloat.toPrecision(1.0, ~digits=1) // \"1\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
+  }, {
+    "label": "Float.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(float, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(v)` return a `string` representing the given value.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) on MDN.\n\n## Examples\n\n```rescript\nFloat.toString(1000.0) // \"1000\"\nFloat.toString(-1000.0) // \"-1000\"\n```\n"}
+  }, {
+    "label": "Float.toLocaleString",
     "kind": 12,
     "tags": [],
     "detail": "float => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `float` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nJs.log(Belt.Float.toString(1.0) === \"1.0\") /* true */\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(v)` return a `string` with language-sensitive representing the\ngiven value.\nSee [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nFloat.toLocaleString(1000.0) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nFloat.toLocaleString(1000.0) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Float.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(float, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(v, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point.\nSee [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential) on MDN.\n\n## Examples\n\n```rescript\nFloat.toExponential(1000.0) // \"1e+3\"\nFloat.toExponential(-1000.0) // \"-1e+3\"\nFloat.toExponential(77.0, ~digits=2) // \"7.70e+1\"\nFloat.toExponential(5678.0, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Float.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(float, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(v, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point.\nSee [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) on MDN.\n\n## Examples\n\n```rescript\nFloat.toFixed(123456.0) // \"123456.00\"\nFloat.toFixed(10.0) // \"10.00\"\nFloat.toFixed(300.0, ~digits=4) // \"300.0000\"\nFloat.toFixed(300.0, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
-Complete src/Completion.res 428:8
-posCursor:[428:8] posNoWhite:[428:7] Found expr:[428:3->428:8]
+Complete src/Completion.res 427:8
+posCursor:[427:8] posNoWhite:[427:7] Found expr:[427:3->427:8]
 Completable: Cpath Value[ok]->g
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2465,24 +2554,30 @@ Resolved opens 2 Completion Completion
 ContextPath Value[ok]->g
 ContextPath Value[ok]
 Path ok
-Path Belt.Result.g
+Path Result.g
 [{
-    "label": "Belt.Result.getExn",
+    "label": "Result.getExn",
     "kind": 12,
     "tags": [],
-    "detail": "t<'a, 'b> => 'a",
-    "documentation": {"kind": "markdown", "value": "\n`getExn(res)`: when `res` is `Ok(n)`, returns `n` when `res` is `Error(m)`, raise an exception\n\n## Examples\n\n```rescript\nBelt.Result.Ok(42)\n->Belt.Result.getExn\n->assertEqual(42)\n\n\nswitch Belt.Result.getExn(Belt.Result.Error(\"Invalid data\")) { // raise a exception\n| exception _ => assert(true)\n| _ => assert(false)\n}\n```\n"}
+    "detail": "result<'a, 'b> => 'a",
+    "documentation": {"kind": "markdown", "value": "\n  Result types are really useful to describe the result of a certain operation\n  without relying on exceptions or `option` types.\n\n  This module gives you useful utilities to create and combine `Result` data.\n"}
   }, {
-    "label": "Belt.Result.getWithDefault",
+    "label": "Result.getOr",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a, 'b>, 'a) => 'a",
-    "documentation": {"kind": "markdown", "value": "\n`getWithDefault(res, defaultValue)`: If `res` is `Ok(n)`, returns `n`,\notherwise `default`\n\n## Examples\n\n```rescript\nBelt.Result.getWithDefault(Ok(42), 0) == 42\n\nBelt.Result.getWithDefault(Error(\"Invalid Data\"), 0) == 0\n```\n"}
+    "detail": "(result<'a, 'b>, 'a) => 'a",
+    "documentation": {"kind": "markdown", "value": "\n`getOr(res, defaultValue)`: If `res` is `Ok(n)`, returns `n`, otherwise `default`\n\n## Examples\n\n```rescript\nResult.getOr(Ok(42), 0) == 42\n\nResult.getOr(Error(\"Invalid Data\"), 0) == 0\n```\n"}
+  }, {
+    "label": "Result.getWithDefault",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(result<'a, 'b>, 'a) => 'a",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use getOr instead\n\n"}
   }]
 
-Complete src/Completion.res 446:15
-posCursor:[446:15] posNoWhite:[446:14] Found expr:[446:3->446:15]
-Pexp_field [446:3->446:12] so:[446:13->446:15]
+Complete src/Completion.res 445:15
+posCursor:[445:15] posNoWhite:[445:14] Found expr:[445:3->445:15]
+Pexp_field [445:3->445:12] so:[445:13->445:15]
 Completable: Cpath Value[rWithDepr].so
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2509,7 +2604,7 @@ Path Completion.so
     "documentation": {"kind": "markdown", "value": "Deprecated: Use 'someInt'.\n\n```rescript\nsomeFloat: float\n```\n\n```rescript\ntype someRecordWithDeprecatedField = {\n  name: string,\n  someInt: int,\n  someFloat: float,\n}\n```"}
   }]
 
-Complete src/Completion.res 453:37
+Complete src/Completion.res 452:37
 XXX Not found!
 Completable: Cexpression Type[someVariantWithDeprecated]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
@@ -2543,8 +2638,8 @@ Path someVariantWithDeprecated
     "insertTextFormat": 2
   }]
 
-Complete src/Completion.res 458:30
-posCursor:[458:30] posNoWhite:[458:29] Found expr:[458:11->458:30]
+Complete src/Completion.res 457:30
+posCursor:[457:30] posNoWhite:[457:29] Found expr:[457:11->457:30]
 Completable: Cpath Value[uncurried](Nolabel)->toS
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -2553,16 +2648,22 @@ ContextPath Value[uncurried](Nolabel)->toS
 ContextPath Value[uncurried](Nolabel)
 ContextPath Value[uncurried]
 Path uncurried
-Path Belt.Int.toS
+Path Int.toS
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toString",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }]
 
-Complete src/Completion.res 463:30
+Complete src/Completion.res 462:30
 XXX Not found!
 Completable: Cexpression Type[withUncurried]->recordField(fn)
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
@@ -2581,9 +2682,9 @@ Path withUncurried
     "insertTextFormat": 2
   }]
 
-Complete src/Completion.res 466:26
-posCursor:[466:26] posNoWhite:[466:25] Found expr:[466:22->466:26]
-Pexp_ident FAR.:[466:22->466:26]
+Complete src/Completion.res 465:26
+posCursor:[465:26] posNoWhite:[465:25] Found expr:[465:22->465:26]
+Pexp_ident FAR.:[465:22->465:26]
 Completable: Cpath ValueOrField[FAR, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -1098,19 +1098,19 @@ Path WithChildren
     "documentation": null
   }]
 
-Complete src/Completion.res 172:13
-posCursor:[172:13] posNoWhite:[172:12] Found type:[172:12->172:13]
-Ptyp_constr n:[172:12->172:13]
-Completable: Cpath Type[n]
+Complete src/Completion.res 172:17
+posCursor:[172:17] posNoWhite:[172:16] Found type:[172:12->172:17]
+Ptyp_constr Null.:[172:12->172:17]
+Completable: Cpath Type[Null, ""]
 Package opens Pervasives.JsxModules.place holder
-ContextPath Type[n]
-Path n
+ContextPath Type[Null, ""]
+Path Null.
 [{
-    "label": "nestedObjT",
+    "label": "t",
     "kind": 22,
     "tags": [],
-    "detail": "type nestedObjT",
-    "documentation": {"kind": "markdown", "value": "```rescript\ntype nestedObjT = {\"x\": Objects.nestedObjT}\n```"}
+    "detail": "type t",
+    "documentation": {"kind": "markdown", "value": "\nA type representing a value that can be either `'a` or `null`.\n\n\n```rescript\n@unboxed\ntype t<'a> = Js.Null.t<'a> = Value('a) | @as(null) Null\n```"}
   }]
 
 Complete src/Completion.res 174:20

--- a/tests/analysis_tests/tests/src/expected/CompletionDicts.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionDicts.res.txt
@@ -1,58 +1,58 @@
-Complete src/CompletionDicts.res 0:33
-posCursor:[0:33] posNoWhite:[0:32] Found expr:[0:14->0:35]
-Pexp_apply ...[0:14->0:31] (...[0:32->0:34])
-Completable: Cexpression CArgument Value[Js, Dict, fromArray]($0)->array
+Complete src/CompletionDicts.res 0:30
+posCursor:[0:30] posNoWhite:[0:29] Found expr:[0:14->0:32]
+Pexp_apply ...[0:14->0:28] (...[0:29->0:31])
+Completable: Cexpression CArgument Value[Dict, fromArray]($0)->array
 Package opens Pervasives.JsxModules.place holder
-ContextPath CArgument Value[Js, Dict, fromArray]($0)
-ContextPath Value[Js, Dict, fromArray]
-Path Js.Dict.fromArray
+ContextPath CArgument Value[Dict, fromArray]($0)
+ContextPath Value[Dict, fromArray]
+Path Dict.fromArray
 [{
     "label": "(_, _)",
     "kind": 12,
     "tags": [],
-    "detail": "(key, 'a)",
+    "detail": "(string, 'a)",
     "documentation": null,
     "insertText": "(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionDicts.res 3:34
-posCursor:[3:34] posNoWhite:[3:33] Found expr:[3:14->3:37]
-Pexp_apply ...[3:14->3:31] (...[3:32->3:36])
-Completable: Cexpression CArgument Value[Js, Dict, fromArray]($0)->array
+Complete src/CompletionDicts.res 3:31
+posCursor:[3:31] posNoWhite:[3:30] Found expr:[3:14->3:34]
+Pexp_apply ...[3:14->3:28] (...[3:29->3:33])
+Completable: Cexpression CArgument Value[Dict, fromArray]($0)->array
 Package opens Pervasives.JsxModules.place holder
-ContextPath CArgument Value[Js, Dict, fromArray]($0)
-ContextPath Value[Js, Dict, fromArray]
-Path Js.Dict.fromArray
+ContextPath CArgument Value[Dict, fromArray]($0)
+ContextPath Value[Dict, fromArray]
+Path Dict.fromArray
 [{
     "label": "(_, _)",
     "kind": 12,
     "tags": [],
-    "detail": "(key, 'a)",
+    "detail": "(string, 'a)",
     "documentation": null,
     "insertText": "(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionDicts.res 6:40
-posCursor:[6:40] posNoWhite:[6:39] Found expr:[6:14->6:44]
-Pexp_apply ...[6:14->6:31] (...[6:32->6:43])
-Completable: Cexpression CArgument Value[Js, Dict, fromArray]($0)->array, tuple($1)
+Complete src/CompletionDicts.res 6:37
+posCursor:[6:37] posNoWhite:[6:36] Found expr:[6:14->6:41]
+Pexp_apply ...[6:14->6:28] (...[6:29->6:40])
+Completable: Cexpression CArgument Value[Dict, fromArray]($0)->array, tuple($1)
 Package opens Pervasives.JsxModules.place holder
-ContextPath CArgument Value[Js, Dict, fromArray]($0)
-ContextPath Value[Js, Dict, fromArray]
-Path Js.Dict.fromArray
+ContextPath CArgument Value[Dict, fromArray]($0)
+ContextPath Value[Dict, fromArray]
+Path Dict.fromArray
 []
 
 
 Complete src/CompletionDicts.res 12:14
 posCursor:[12:14] posNoWhite:[12:13] Found expr:[10:11->14:2]
-Pexp_apply ...[10:11->10:28] (...[10:29->14:1])
-Completable: Cexpression CArgument Value[Js, Dict, fromArray]($0)->array, tuple($1)
+Pexp_apply ...[10:11->10:25] (...[10:26->14:1])
+Completable: Cexpression CArgument Value[Dict, fromArray]($0)->array, tuple($1)
 Package opens Pervasives.JsxModules.place holder
-ContextPath CArgument Value[Js, Dict, fromArray]($0)
-ContextPath Value[Js, Dict, fromArray]
-Path Js.Dict.fromArray
+ContextPath CArgument Value[Dict, fromArray]($0)
+ContextPath Value[Dict, fromArray]
+Path Dict.fromArray
 [{
     "label": "true",
     "kind": 4,

--- a/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
@@ -862,18 +862,18 @@ Path fnTakingCallback
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 185:10
-posCursor:[185:10] posNoWhite:[185:9] Found expr:[181:2->185:11]
-posCursor:[185:10] posNoWhite:[185:9] Found expr:[182:2->185:11]
-posCursor:[185:10] posNoWhite:[185:9] Found expr:[183:2->185:11]
-posCursor:[185:10] posNoWhite:[185:9] Found expr:[184:2->185:11]
-posCursor:[185:10] posNoWhite:[185:9] Found expr:[185:2->185:11]
-Pexp_apply ...[185:2->185:8] (...[185:9->185:10])
-Completable: Cexpression CArgument Value[Js, log]($0)=s
+Complete src/CompletionExpressions.res 185:15
+posCursor:[185:15] posNoWhite:[185:14] Found expr:[181:2->185:16]
+posCursor:[185:15] posNoWhite:[185:14] Found expr:[182:2->185:16]
+posCursor:[185:15] posNoWhite:[185:14] Found expr:[183:2->185:16]
+posCursor:[185:15] posNoWhite:[185:14] Found expr:[184:2->185:16]
+posCursor:[185:15] posNoWhite:[185:14] Found expr:[185:2->185:16]
+Pexp_apply ...[185:2->185:13] (...[185:14->185:15])
+Completable: Cexpression CArgument Value[Console, log]($0)=s
 Package opens Pervasives.JsxModules.place holder
-ContextPath CArgument Value[Js, log]($0)
-ContextPath Value[Js, log]
-Path Js.log
+ContextPath CArgument Value[Console, log]($0)
+ContextPath Value[Console, log]
+Path Console.log
 [{
     "label": "second2",
     "kind": 12,

--- a/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
@@ -1259,12 +1259,12 @@ ContextPath CArgument Value[mkStuff]($0)
 ContextPath Value[mkStuff]
 Path mkStuff
 [{
-    "label": "%re()",
+    "label": "/<regexp>/g",
     "kind": 4,
     "tags": [],
     "detail": "Regular expression",
     "documentation": null,
-    "insertText": "%re(\"/$0/g\")",
+    "insertText": "/$0/g",
     "insertTextFormat": 2
   }, {
     "label": "Js.Re.fromString()",

--- a/tests/analysis_tests/tests/src/expected/CompletionInferValues.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionInferValues.res.txt
@@ -8,19 +8,67 @@ Path aliased
 ContextPath Value[x]
 Path x
 ContextPath int
-Path Belt.Int.t
+Path Int.t
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.toPrecision",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
+  }, {
+    "label": "Int.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
 Complete src/CompletionInferValues.res 18:30
@@ -262,19 +310,67 @@ Path btn
 ContextPath Value[JsxEvent, Mouse, button](Nolabel)
 ContextPath Value[JsxEvent, Mouse, button]
 Path JsxEvent.Mouse.button
-Path Belt.Int.t
+Path Int.t
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.toPrecision",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
+  }, {
+    "label": "Int.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
 Complete src/CompletionInferValues.res 50:108
@@ -291,31 +387,31 @@ Path btn
 ContextPath Value[Belt, Int, toString](Nolabel)
 ContextPath Value[Belt, Int, toString]
 Path Belt.Int.toString
-Path Js.String2.spl
+Path String.spl
 [{
-    "label": "Js.String2.splitAtMost",
+    "label": "String.splitAtMost",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, ~limit: int) => array<t>",
-    "documentation": {"kind": "markdown", "value": "\n`splitAtMost delimiter ~limit: n str` splits the given `str` at every occurrence of `delimiter` and returns an array of the first `n` resulting substrings. If `n` is negative or greater than the number of substrings, the array will contain all the substrings.\n\n```\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 3 = [|\"ant\"; \"bee\"; \"cat\"|];;\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 0 = [| |];;\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 9 = [|\"ant\"; \"bee\"; \"cat\"; \"dog\"; \"elk\"|];;\n```\n"}
+    "detail": "(string, string, ~limit: int) => array<string>",
+    "documentation": {"kind": "markdown", "value": "\n`splitAtMost(str, delimiter, ~limit)` splits the given `str` at every\noccurrence of `delimiter` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings,\nthe array will contain all the substrings.\n\n## Examples\n\n```rescript\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=3) == [\"ant\", \"bee\", \"cat\"]\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=0) == []\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=9) == [\"ant\", \"bee\", \"cat\", \"dog\", \"elk\"]\n```\n"}
   }, {
-    "label": "Js.String2.splitByRe",
+    "label": "String.splitByRegExpAtMost",
     "kind": 12,
     "tags": [],
-    "detail": "(t, Js_re.t) => array<option<t>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByRe(str, regex)` splits the given `str` at every occurrence of `regex`\nand returns an array of the resulting substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.splitByRe(\"art; bed , cog ;dad\", /\\s*[,;]\\s*TODO/) == [\n    Some(\"art\"),\n    Some(\"bed\"),\n    Some(\"cog\"),\n    Some(\"dad\"),\n  ]\n```\n"}
+    "detail": "(string, RegExp.t, ~limit: int) => array<option<string>>",
+    "documentation": {"kind": "markdown", "value": "\n`splitByRegExpAtMost(str, regexp, ~limit)` splits the given `str` at every\noccurrence of `regexp` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings, the\narray will contain all the substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExpAtMost(\"Hello World. How are you doing?\", %re(\"/ /\"), ~limit=3) == [\n  Some(\"Hello\"),\n  Some(\"World.\"),\n  Some(\"How\"),\n]\n```\n"}
   }, {
-    "label": "Js.String2.split",
+    "label": "String.splitByRegExp",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => array<t>",
-    "documentation": {"kind": "markdown", "value": "\n`split(str, delimiter)` splits the given `str` at every occurrence of\n`delimiter` and returns an array of the resulting substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.split(\"2018-01-02\", \"-\") == [\"2018\", \"01\", \"02\"]\nJs.String2.split(\"a,b,,c\", \",\") == [\"a\", \"b\", \"\", \"c\"]\nJs.String2.split(\"good::bad as great::awful\", \"::\") == [\"good\", \"bad as great\", \"awful\"]\nJs.String2.split(\"has-no-delimiter\", \";\") == [\"has-no-delimiter\"]\n```\n"}
+    "detail": "(string, RegExp.t) => array<option<string>>",
+    "documentation": {"kind": "markdown", "value": "\n`splitByRegExp(str, regexp)` splits the given `str` at every occurrence of\n`regexp` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExp(\"Jan,Feb,Mar\", %re(\"/,/\")) == [Some(\"Jan\"), Some(\"Feb\"), Some(\"Mar\")]\n```\n"}
   }, {
-    "label": "Js.String2.splitByReAtMost",
+    "label": "String.split",
     "kind": 12,
     "tags": [],
-    "detail": "(t, Js_re.t, ~limit: int) => array<option<t>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByReAtMost(str, regex, ~limit:n)` splits the given `str` at every\noccurrence of `regex` and returns an array of the first `n` resulting\nsubstrings. If `n` is negative or greater than the number of substrings, the\narray will contain all the substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=3) == [\n    Some(\"one\"),\n    Some(\"two\"),\n    Some(\"three\"),\n  ]\n\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=0) == []\n\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=8) == [\n    Some(\"one\"),\n    Some(\"two\"),\n    Some(\"three\"),\n    Some(\"four\"),\n  ]\n```\n"}
+    "detail": "(string, string) => array<string>",
+    "documentation": {"kind": "markdown", "value": "\n`split(str, delimiter)` splits the given `str` at every occurrence of\n`delimiter` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.split(\"2018-01-02\", \"-\") == [\"2018\", \"01\", \"02\"]\nString.split(\"a,b,,c\", \",\") == [\"a\", \"b\", \"\", \"c\"]\nString.split(\"good::bad as great::awful\", \"::\") == [\"good\", \"bad as great\", \"awful\"]\nString.split(\"has-no-delimiter\", \";\") == [\"has-no-delimiter\"]\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 53:130
@@ -332,19 +428,19 @@ Path btn
 ContextPath Value[Js, String2, split](Nolabel, Nolabel)
 ContextPath Value[Js, String2, split]
 Path Js.String2.split
-Path Js.Array2.ma
+Path Array.ma
 [{
-    "label": "Js.Array2.mapi",
+    "label": "Array.map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The function acceps two arguments: an item from the array and its\nindex number. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\n// multiply each item in array by its position\nlet product = (item, index) => item * index\nJs.Array2.mapi([10, 11, 12], product) == [0, 11, 24]\n```\n"}
+    "detail": "(array<'a>, 'a => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`map(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray = array->Array.map(greeting => greeting ++ \" to you\")\n\nassertEqual(mappedArray, [\"Hello to you\", \"Hi to you\", \"Good bye to you\"])\n```\n"}
   }, {
-    "label": "Js.Array2.map",
+    "label": "Array.mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\nJs.Array2.map([12, 4, 8], x => x * x) == [144, 16, 64]\nJs.Array2.map([\"animal\", \"vegetable\", \"mineral\"], Js.String.length) == [6, 9, 7]\n```\n"}
+    "detail": "(array<'a>, ('a, int) => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray =\n  array->Array.mapWithIndex((greeting, index) =>\n    greeting ++ \" at position \" ++ Int.toString(index)\n  )\n\nassertEqual(mappedArray, [\"Hello at position 0\", \"Hi at position 1\", \"Good bye at position 2\"])\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 75:78
@@ -464,19 +560,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[someRecordWithNestedStuff]
 Path someRecordWithNestedStuff
-Path Js.String2.slic
+Path String.slic
 [{
-    "label": "Js.String2.sliceToEnd",
+    "label": "String.slice",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, from:n)` returns the substring of `str` starting at character\n`n` to the end of the string.\n- If `n` is negative, then it is evaluated as `length(str - n)`.\n- If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.sliceToEnd(\"abcdefg\", ~from=4) == \"efg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=-2) == \"fg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=7) == \"\"\n```\n"}
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`slice(str, ~start, ~end)` returns the substring of `str` starting at\ncharacter `start` up to but not including `end`.\n- If either `start` or `end` is negative, then it is evaluated as\n`length(str - start)` or `length(str - end)`.\n- If `end` is greater than the length of `str`, then it is treated as\n`length(str)`.\n- If `start` is greater than `end`, slice returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.slice(\"abcdefg\", ~start=2, ~end=5) == \"cde\"\nString.slice(\"abcdefg\", ~start=2, ~end=9) == \"cdefg\"\nString.slice(\"abcdefg\", ~start=-4, ~end=-2) == \"de\"\nString.slice(\"abcdefg\", ~start=5, ~end=1) == \"\"\n```\n"}
   }, {
-    "label": "Js.String2.slice",
+    "label": "String.sliceToEnd",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`slice(str, from:n1, to_:n2)` returns the substring of `str` starting at\ncharacter `n1` up to but not including `n2`.\n- If either `n1` or `n2` is negative, then it is evaluated as `length(str - n1)` or `length(str - n2)`.\n- If `n2` is greater than the length of `str`, then it is treated as `length(str)`.\n- If `n1` is greater than `n2`, slice returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=5) == \"cde\"\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=9) == \"cdefg\"\nJs.String2.slice(\"abcdefg\", ~from=-4, ~to_=-2) == \"de\"\nJs.String2.slice(\"abcdefg\", ~from=5, ~to_=1) == \"\"\n```\n"}
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, ~start)` returns the substring of `str` starting at character\n`start` to the end of the string.\n- If `start` is negative, then it is evaluated as `length(str - start)`.\n- If `start` is greater than the length of `str`, then sliceToEnd returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.sliceToEnd(\"abcdefg\", ~start=4) == \"efg\"\nString.sliceToEnd(\"abcdefg\", ~start=-2) == \"fg\"\nString.sliceToEnd(\"abcdefg\", ~start=7) == \"\"\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 91:82
@@ -491,13 +587,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[someRecordWithNestedStuff]
 Path someRecordWithNestedStuff
-Path Belt.Int.toS
+Path Int.toS
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toString",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }]
 
 Complete src/CompletionInferValues.res 95:109
@@ -515,13 +617,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[otherNestedRecord]
 Path otherNestedRecord
-Path Belt.Int.toS
+Path Int.toS
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toString",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }]
 
 Complete src/CompletionInferValues.res 99:102
@@ -540,13 +648,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[otherNestedRecord]
 Path otherNestedRecord
-Path Belt.Int.toS
+Path Int.toS
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toString",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }]
 
 Complete src/CompletionInferValues.res 103:88
@@ -561,19 +675,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[otherNestedRecord]
 Path otherNestedRecord
-Path Js.String2.slic
+Path String.slic
 [{
-    "label": "Js.String2.sliceToEnd",
+    "label": "String.slice",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, from:n)` returns the substring of `str` starting at character\n`n` to the end of the string.\n- If `n` is negative, then it is evaluated as `length(str - n)`.\n- If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.sliceToEnd(\"abcdefg\", ~from=4) == \"efg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=-2) == \"fg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=7) == \"\"\n```\n"}
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`slice(str, ~start, ~end)` returns the substring of `str` starting at\ncharacter `start` up to but not including `end`.\n- If either `start` or `end` is negative, then it is evaluated as\n`length(str - start)` or `length(str - end)`.\n- If `end` is greater than the length of `str`, then it is treated as\n`length(str)`.\n- If `start` is greater than `end`, slice returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.slice(\"abcdefg\", ~start=2, ~end=5) == \"cde\"\nString.slice(\"abcdefg\", ~start=2, ~end=9) == \"cdefg\"\nString.slice(\"abcdefg\", ~start=-4, ~end=-2) == \"de\"\nString.slice(\"abcdefg\", ~start=5, ~end=1) == \"\"\n```\n"}
   }, {
-    "label": "Js.String2.slice",
+    "label": "String.sliceToEnd",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`slice(str, from:n1, to_:n2)` returns the substring of `str` starting at\ncharacter `n1` up to but not including `n2`.\n- If either `n1` or `n2` is negative, then it is evaluated as `length(str - n1)` or `length(str - n2)`.\n- If `n2` is greater than the length of `str`, then it is treated as `length(str)`.\n- If `n1` is greater than `n2`, slice returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=5) == \"cde\"\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=9) == \"cdefg\"\nJs.String2.slice(\"abcdefg\", ~from=-4, ~to_=-2) == \"de\"\nJs.String2.slice(\"abcdefg\", ~from=5, ~to_=1) == \"\"\n```\n"}
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, ~start)` returns the substring of `str` starting at character\n`start` to the end of the string.\n- If `start` is negative, then it is evaluated as `length(str - start)`.\n- If `start` is greater than the length of `str`, then sliceToEnd returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.sliceToEnd(\"abcdefg\", ~start=4) == \"efg\"\nString.sliceToEnd(\"abcdefg\", ~start=-2) == \"fg\"\nString.sliceToEnd(\"abcdefg\", ~start=7) == \"\"\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 107:89
@@ -588,19 +702,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[otherNestedRecord]
 Path otherNestedRecord
-Path Js.String2.slic
+Path String.slic
 [{
-    "label": "Js.String2.sliceToEnd",
+    "label": "String.slice",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, from:n)` returns the substring of `str` starting at character\n`n` to the end of the string.\n- If `n` is negative, then it is evaluated as `length(str - n)`.\n- If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.sliceToEnd(\"abcdefg\", ~from=4) == \"efg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=-2) == \"fg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=7) == \"\"\n```\n"}
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`slice(str, ~start, ~end)` returns the substring of `str` starting at\ncharacter `start` up to but not including `end`.\n- If either `start` or `end` is negative, then it is evaluated as\n`length(str - start)` or `length(str - end)`.\n- If `end` is greater than the length of `str`, then it is treated as\n`length(str)`.\n- If `start` is greater than `end`, slice returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.slice(\"abcdefg\", ~start=2, ~end=5) == \"cde\"\nString.slice(\"abcdefg\", ~start=2, ~end=9) == \"cdefg\"\nString.slice(\"abcdefg\", ~start=-4, ~end=-2) == \"de\"\nString.slice(\"abcdefg\", ~start=5, ~end=1) == \"\"\n```\n"}
   }, {
-    "label": "Js.String2.slice",
+    "label": "String.sliceToEnd",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`slice(str, from:n1, to_:n2)` returns the substring of `str` starting at\ncharacter `n1` up to but not including `n2`.\n- If either `n1` or `n2` is negative, then it is evaluated as `length(str - n1)` or `length(str - n2)`.\n- If `n2` is greater than the length of `str`, then it is treated as `length(str)`.\n- If `n1` is greater than `n2`, slice returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=5) == \"cde\"\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=9) == \"cdefg\"\nJs.String2.slice(\"abcdefg\", ~from=-4, ~to_=-2) == \"de\"\nJs.String2.slice(\"abcdefg\", ~from=5, ~to_=1) == \"\"\n```\n"}
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, ~start)` returns the substring of `str` starting at character\n`start` to the end of the string.\n- If `start` is negative, then it is evaluated as `length(str - start)`.\n- If `start` is greater than the length of `str`, then sliceToEnd returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.sliceToEnd(\"abcdefg\", ~start=4) == \"efg\"\nString.sliceToEnd(\"abcdefg\", ~start=-2) == \"fg\"\nString.sliceToEnd(\"abcdefg\", ~start=7) == \"\"\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 111:80
@@ -615,19 +729,19 @@ ContextPath Value[x]
 Path x
 ContextPath Type[otherNestedRecord]
 Path otherNestedRecord
-Path Js.String2.slic
+Path String.slic
 [{
-    "label": "Js.String2.sliceToEnd",
+    "label": "String.slice",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, from:n)` returns the substring of `str` starting at character\n`n` to the end of the string.\n- If `n` is negative, then it is evaluated as `length(str - n)`.\n- If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.sliceToEnd(\"abcdefg\", ~from=4) == \"efg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=-2) == \"fg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=7) == \"\"\n```\n"}
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`slice(str, ~start, ~end)` returns the substring of `str` starting at\ncharacter `start` up to but not including `end`.\n- If either `start` or `end` is negative, then it is evaluated as\n`length(str - start)` or `length(str - end)`.\n- If `end` is greater than the length of `str`, then it is treated as\n`length(str)`.\n- If `start` is greater than `end`, slice returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.slice(\"abcdefg\", ~start=2, ~end=5) == \"cde\"\nString.slice(\"abcdefg\", ~start=2, ~end=9) == \"cdefg\"\nString.slice(\"abcdefg\", ~start=-4, ~end=-2) == \"de\"\nString.slice(\"abcdefg\", ~start=5, ~end=1) == \"\"\n```\n"}
   }, {
-    "label": "Js.String2.slice",
+    "label": "String.sliceToEnd",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`slice(str, from:n1, to_:n2)` returns the substring of `str` starting at\ncharacter `n1` up to but not including `n2`.\n- If either `n1` or `n2` is negative, then it is evaluated as `length(str - n1)` or `length(str - n2)`.\n- If `n2` is greater than the length of `str`, then it is treated as `length(str)`.\n- If `n1` is greater than `n2`, slice returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=5) == \"cde\"\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=9) == \"cdefg\"\nJs.String2.slice(\"abcdefg\", ~from=-4, ~to_=-2) == \"de\"\nJs.String2.slice(\"abcdefg\", ~from=5, ~to_=1) == \"\"\n```\n"}
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, ~start)` returns the substring of `str` starting at character\n`start` to the end of the string.\n- If `start` is negative, then it is evaluated as `length(str - start)`.\n- If `start` is greater than the length of `str`, then sliceToEnd returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.sliceToEnd(\"abcdefg\", ~start=4) == \"efg\"\nString.sliceToEnd(\"abcdefg\", ~start=-2) == \"fg\"\nString.sliceToEnd(\"abcdefg\", ~start=7) == \"\"\n```\n"}
   }]
 
 Complete src/CompletionInferValues.res 115:53
@@ -640,13 +754,19 @@ Path v
 ContextPath Value[x]
 Path x
 ContextPath int
-Path Belt.Int.toSt
+Path Int.toSt
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toString",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }]
 
 Complete src/CompletionInferValues.res 123:26

--- a/tests/analysis_tests/tests/src/expected/CompletionInferValues.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionInferValues.res.txt
@@ -373,61 +373,36 @@ Path Int.t
     "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
-Complete src/CompletionInferValues.res 50:108
-posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:12->50:114]
-JSX <div:[50:12->50:15] onMouseEnter[50:16->50:28]=...[50:36->50:110]> _children:50:112
-posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:36->50:110]
-posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:41->50:108]
-posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:100->50:108]
+Complete src/CompletionInferValues.res 50:103
+posCursor:[50:103] posNoWhite:[50:102] Found expr:[50:12->50:109]
+JSX <div:[50:12->50:15] onMouseEnter[50:16->50:28]=...[50:36->50:105]> _children:50:107
+posCursor:[50:103] posNoWhite:[50:102] Found expr:[50:36->50:105]
+posCursor:[50:103] posNoWhite:[50:102] Found expr:[50:41->50:103]
+posCursor:[50:103] posNoWhite:[50:102] Found expr:[50:95->50:103]
 Completable: Cpath Value[btn]->spl <<jsx>>
 Package opens Pervasives.JsxModules.place holder
 ContextPath Value[btn]->spl <<jsx>>
 ContextPath Value[btn]
 Path btn
-ContextPath Value[Belt, Int, toString](Nolabel)
-ContextPath Value[Belt, Int, toString]
-Path Belt.Int.toString
-Path String.spl
-[{
-    "label": "String.splitAtMost",
-    "kind": 12,
-    "tags": [],
-    "detail": "(string, string, ~limit: int) => array<string>",
-    "documentation": {"kind": "markdown", "value": "\n`splitAtMost(str, delimiter, ~limit)` splits the given `str` at every\noccurrence of `delimiter` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings,\nthe array will contain all the substrings.\n\n## Examples\n\n```rescript\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=3) == [\"ant\", \"bee\", \"cat\"]\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=0) == []\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=9) == [\"ant\", \"bee\", \"cat\", \"dog\", \"elk\"]\n```\n"}
-  }, {
-    "label": "String.splitByRegExpAtMost",
-    "kind": 12,
-    "tags": [],
-    "detail": "(string, RegExp.t, ~limit: int) => array<option<string>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByRegExpAtMost(str, regexp, ~limit)` splits the given `str` at every\noccurrence of `regexp` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings, the\narray will contain all the substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExpAtMost(\"Hello World. How are you doing?\", %re(\"/ /\"), ~limit=3) == [\n  Some(\"Hello\"),\n  Some(\"World.\"),\n  Some(\"How\"),\n]\n```\n"}
-  }, {
-    "label": "String.splitByRegExp",
-    "kind": 12,
-    "tags": [],
-    "detail": "(string, RegExp.t) => array<option<string>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByRegExp(str, regexp)` splits the given `str` at every occurrence of\n`regexp` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExp(\"Jan,Feb,Mar\", %re(\"/,/\")) == [Some(\"Jan\"), Some(\"Feb\"), Some(\"Mar\")]\n```\n"}
-  }, {
-    "label": "String.split",
-    "kind": 12,
-    "tags": [],
-    "detail": "(string, string) => array<string>",
-    "documentation": {"kind": "markdown", "value": "\n`split(str, delimiter)` splits the given `str` at every occurrence of\n`delimiter` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.split(\"2018-01-02\", \"-\") == [\"2018\", \"01\", \"02\"]\nString.split(\"a,b,,c\", \",\") == [\"a\", \"b\", \"\", \"c\"]\nString.split(\"good::bad as great::awful\", \"::\") == [\"good\", \"bad as great\", \"awful\"]\nString.split(\"has-no-delimiter\", \";\") == [\"has-no-delimiter\"]\n```\n"}
-  }]
+ContextPath Value[Int, toString](Nolabel)
+ContextPath Value[Int, toString]
+Path Int.toString
+[]
 
-Complete src/CompletionInferValues.res 53:130
-posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:12->53:136]
-JSX <div:[53:12->53:15] onMouseEnter[53:16->53:28]=...[53:36->53:132]> _children:53:134
-posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:36->53:132]
-posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:41->53:130]
-posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:123->53:130]
+Complete src/CompletionInferValues.res 53:121
+posCursor:[53:121] posNoWhite:[53:120] Found expr:[53:12->53:127]
+JSX <div:[53:12->53:15] onMouseEnter[53:16->53:28]=...[53:36->53:123]> _children:53:125
+posCursor:[53:121] posNoWhite:[53:120] Found expr:[53:36->53:123]
+posCursor:[53:121] posNoWhite:[53:120] Found expr:[53:41->53:121]
+posCursor:[53:121] posNoWhite:[53:120] Found expr:[53:114->53:121]
 Completable: Cpath Value[btn]->ma <<jsx>>
 Package opens Pervasives.JsxModules.place holder
 ContextPath Value[btn]->ma <<jsx>>
 ContextPath Value[btn]
 Path btn
-ContextPath Value[Js, String2, split](Nolabel, Nolabel)
-ContextPath Value[Js, String2, split]
-Path Js.String2.split
+ContextPath Value[String, split](Nolabel, Nolabel)
+ContextPath Value[String, split]
+Path String.split
 Path Array.ma
 [{
     "label": "Array.map",
@@ -877,18 +852,18 @@ Path Belt.Int.toString
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionInferValues.res 147:70
+Complete src/CompletionInferValues.res 147:66
 XXX Not found!
-Completable: Cpattern Value[Js, String2, split](Nolabel, Nolabel)
+Completable: Cpattern Value[String, split](Nolabel, Nolabel)
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, String2, split](Nolabel, Nolabel)
-ContextPath Value[Js, String2, split]
-Path Js.String2.split
+ContextPath Value[String, split](Nolabel, Nolabel)
+ContextPath Value[String, split]
+Path String.split
 [{
     "label": "[]",
     "kind": 12,
     "tags": [],
-    "detail": "t",
+    "detail": "string",
     "documentation": null,
     "sortText": "A",
     "insertText": "[$0]",

--- a/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
@@ -5,19 +5,19 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st
 ContextPath Value[someString]
 Path someString
-Path Js.String2.st
+Path String.st
 [{
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 13:21
@@ -33,7 +33,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
-Path Js.String2.st
+Path String.st
 [{
     "label": "React.string",
     "kind": 12,
@@ -43,17 +43,17 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 18:24
@@ -76,7 +76,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
-Path Js.String2.st
+Path String.st
 [{
     "label": "React.string",
     "kind": 12,
@@ -86,17 +86,17 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 20:27
@@ -118,7 +118,7 @@ Completable: Cpath string->st <<jsx>>
 Package opens Pervasives.JsxModules.place holder
 ContextPath string->st <<jsx>>
 ContextPath string
-Path Js.String2.st
+Path String.st
 [{
     "label": "React.string",
     "kind": 12,
@@ -128,17 +128,17 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 22:44
@@ -162,7 +162,7 @@ ContextPath Value[Js, String2, trim](Nolabel)->st <<jsx>>
 ContextPath Value[Js, String2, trim](Nolabel)
 ContextPath Value[Js, String2, trim]
 Path Js.String2.trim
-Path Js.String2.st
+Path String.st
 [{
     "label": "React.string",
     "kind": 12,
@@ -172,17 +172,17 @@ Path Js.String2.st
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.String2.startsWith",
+    "label": "String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"}
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
   }, {
-    "label": "Js.String2.startsWithFrom",
+    "label": "String.startsWithFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"}
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 24:19
@@ -205,7 +205,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someInt]-> <<jsx>>
 ContextPath Value[someInt]
 Path someInt
-Path Belt.Int.
+Path Int.
 [{
     "label": "React.int",
     "kind": 12,
@@ -215,41 +215,101 @@ Path Belt.Int.
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Belt.Int.*",
+    "label": "Int.equal",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nMultiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 * 2, 4)\n```\n"}
+    "detail": "(int, int) => bool",
+    "documentation": null
   }, {
-    "label": "Belt.Int./",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.clamp",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nDivision of two `int` values. Same as the division from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(4 / 2, 2)\n```\n"}
+    "detail": "(~min: int=?, ~max: int=?, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
   }, {
-    "label": "Belt.Int.toString",
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.compare",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, int) => Ordering.t",
+    "documentation": null
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toPrecision",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
+  }, {
+    "label": "Int.range",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int, ~options: rangeOptions=?) => array<int>",
+    "documentation": {"kind": "markdown", "value": "\n`range(start, end, ~options=?)` returns an int array of the sequence of integers in the\nrange `[start, end)`. That is, including `start` but excluding `end`.\n\nIf `step` is not set and `start < end`, the sequence will be increasing in steps of 1.\n\nIf `step` is not set and `start > end`, the sequence will be decreasing in steps of -1.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.range(3, 6) == [3, 4, 5]\nInt.range(-3, -1) == [-3, -2]\nInt.range(3, 1) == [3, 2]\nInt.range(3, 7, ~options={step: 2}) == [3, 5]\nInt.range(3, 7, ~options={step: 2, inclusive: true}) == [3, 5, 7]\nInt.range(3, 6, ~options={step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
   }, {
-    "label": "Belt.Int.-",
+    "label": "Int.mod",
     "kind": 12,
     "tags": [],
     "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nSubtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 - 1, 1)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`mod(n1, n2)` calculates the modulo (remainder after division) of two integers.\n\n## Examples\n\n```rescript\nInt.mod(7, 4) == 3\n```\n"}
   }, {
-    "label": "Belt.Int.+",
+    "label": "Int.rangeWithOptions",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, int, rangeOptions) => array<int>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `range` instead\n\n\n`rangeWithOptions(start, end, options)` is like `range`, but with `step` and\n`inclusive` options configurable.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.rangeWithOptions(3, 7, {step: 2}) == [3, 5]\nInt.rangeWithOptions(3, 7, {step: 2, inclusive: true}) == [3, 5, 7]\nInt.rangeWithOptions(3, 6, {step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.toLocaleString",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nAddition of two `int` values. Same as the addition from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 + 2, 4)\n```\n"}
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
 Complete src/CompletionJsx.res 26:14
@@ -271,7 +331,7 @@ Completable: Cpath int-> <<jsx>>
 Package opens Pervasives.JsxModules.place holder
 ContextPath int-> <<jsx>>
 ContextPath int
-Path Belt.Int.
+Path Int.
 [{
     "label": "React.int",
     "kind": 12,
@@ -281,41 +341,101 @@ Path Belt.Int.
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Belt.Int.*",
+    "label": "Int.equal",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nMultiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 * 2, 4)\n```\n"}
+    "detail": "(int, int) => bool",
+    "documentation": null
   }, {
-    "label": "Belt.Int./",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.clamp",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nDivision of two `int` values. Same as the division from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(4 / 2, 2)\n```\n"}
+    "detail": "(~min: int=?, ~max: int=?, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
   }, {
-    "label": "Belt.Int.toString",
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.compare",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, int) => Ordering.t",
+    "documentation": null
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toPrecision",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
+  }, {
+    "label": "Int.range",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int, ~options: rangeOptions=?) => array<int>",
+    "documentation": {"kind": "markdown", "value": "\n`range(start, end, ~options=?)` returns an int array of the sequence of integers in the\nrange `[start, end)`. That is, including `start` but excluding `end`.\n\nIf `step` is not set and `start < end`, the sequence will be increasing in steps of 1.\n\nIf `step` is not set and `start > end`, the sequence will be decreasing in steps of -1.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.range(3, 6) == [3, 4, 5]\nInt.range(-3, -1) == [-3, -2]\nInt.range(3, 1) == [3, 2]\nInt.range(3, 7, ~options={step: 2}) == [3, 5]\nInt.range(3, 7, ~options={step: 2, inclusive: true}) == [3, 5, 7]\nInt.range(3, 6, ~options={step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
   }, {
-    "label": "Belt.Int.-",
+    "label": "Int.mod",
     "kind": 12,
     "tags": [],
     "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nSubtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 - 1, 1)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`mod(n1, n2)` calculates the modulo (remainder after division) of two integers.\n\n## Examples\n\n```rescript\nInt.mod(7, 4) == 3\n```\n"}
   }, {
-    "label": "Belt.Int.+",
+    "label": "Int.rangeWithOptions",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, int, rangeOptions) => array<int>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `range` instead\n\n\n`rangeWithOptions(start, end, options)` is like `range`, but with `step` and\n`inclusive` options configurable.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.rangeWithOptions(3, 7, {step: 2}) == [3, 5]\nInt.rangeWithOptions(3, 7, {step: 2, inclusive: true}) == [3, 5, 7]\nInt.rangeWithOptions(3, 6, {step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.toLocaleString",
     "kind": 12,
     "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\nAddition of two `int` values. Same as the addition from `Pervasives`.\n\n## Examples\n\n```rescript\nopen Belt.Int\nassertEqual(2 + 2, 4)\n```\n"}
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
 Complete src/CompletionJsx.res 28:20
@@ -338,7 +458,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someArr]->a <<jsx>>
 ContextPath Value[someArr]
 Path someArr
-Path Js.Array2.a
+Path Array.a
 [{
     "label": "React.array",
     "kind": 12,
@@ -348,11 +468,11 @@ Path Js.Array2.a
     "sortText": "A",
     "insertTextFormat": 2
   }, {
-    "label": "Js.Array2.append",
+    "label": "Array.at",
     "kind": 12,
-    "tags": [1],
-    "detail": "(t<'a>, 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: `append` is not type-safe. Use `concat` instead.\n\n"}
+    "tags": [],
+    "detail": "(array<'a>, int) => option<'a>",
+    "documentation": {"kind": "markdown", "value": "\n`at(array, index)`\n\nGet an element by its index. Negative indices count backwards from the last item.\n\n## Examples\n\n```rescript\n[\"a\", \"b\", \"c\"]->Array.at(0)->assertEqual(Some(\"a\"))\n[\"a\", \"b\", \"c\"]->Array.at(2)->assertEqual(Some(\"c\"))\n[\"a\", \"b\", \"c\"]->Array.at(3)->assertEqual(None)\n[\"a\", \"b\", \"c\"]->Array.at(-1)->assertEqual(Some(\"c\"))\n[\"a\", \"b\", \"c\"]->Array.at(-3)->assertEqual(Some(\"a\"))\n[\"a\", \"b\", \"c\"]->Array.at(-4)->assertEqual(None)\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 30:12
@@ -571,7 +691,7 @@ ContextPath string.s
 ContextPath string
 ContextPath string->s <<jsx>>
 ContextPath string
-Path Js.String2.s
+Path String.s
 [{
     "label": "->React.string",
     "kind": 12,
@@ -586,157 +706,157 @@ Path Js.String2.s
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.startsWith",
+    "label": "->String.startsWith",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWith(\"ReScript\", \"Re\") == true\nJs.String2.startsWith(\"ReScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Re\") == false\n```\n"},
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWith(str, substr)` returns `true` if the `str` starts with `substr`,\n`false` otherwise.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWith(\"BuckleScript\", \"Buckle\") == true\nString.startsWith(\"BuckleScript\", \"\") == true\nString.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"},
     "sortText": "startsWith",
-    "insertText": "->Js.String2.startsWith",
+    "insertText": "->String.startsWith",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.splitAtMost",
+    "label": "->String.splitAtMost",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, ~limit: int) => array<t>",
-    "documentation": {"kind": "markdown", "value": "\n`splitAtMost delimiter ~limit: n str` splits the given `str` at every occurrence of `delimiter` and returns an array of the first `n` resulting substrings. If `n` is negative or greater than the number of substrings, the array will contain all the substrings.\n\n```\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 3 = [|\"ant\"; \"bee\"; \"cat\"|];;\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 0 = [| |];;\nsplitAtMost \"ant/bee/cat/dog/elk\" \"/\" ~limit: 9 = [|\"ant\"; \"bee\"; \"cat\"; \"dog\"; \"elk\"|];;\n```\n"},
+    "detail": "(string, string, ~limit: int) => array<string>",
+    "documentation": {"kind": "markdown", "value": "\n`splitAtMost(str, delimiter, ~limit)` splits the given `str` at every\noccurrence of `delimiter` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings,\nthe array will contain all the substrings.\n\n## Examples\n\n```rescript\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=3) == [\"ant\", \"bee\", \"cat\"]\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=0) == []\nString.splitAtMost(\"ant/bee/cat/dog/elk\", \"/\", ~limit=9) == [\"ant\", \"bee\", \"cat\", \"dog\", \"elk\"]\n```\n"},
     "sortText": "splitAtMost",
-    "insertText": "->Js.String2.splitAtMost",
+    "insertText": "->String.splitAtMost",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.substrAtMost",
+    "label": "->String.searchOpt",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~length: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`substrAtMost(str, ~from: pos, ~length: n)` returns the substring of `str` of\nlength `n` starting at position `pos`.\n- If `pos` is less than zero, the starting position is the length of `str - pos`.\n- If `pos` is greater than or equal to the length of `str`, returns the empty string.\n- If `n` is less than or equal to zero, returns the empty string.\n\nJavaScript’s `String.substr()` is a legacy function. When possible, use\n`substring()` instead.\n\nSee [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.substrAtMost(\"abcdefghij\", ~from=3, ~length=4) == \"defg\"\nJs.String2.substrAtMost(\"abcdefghij\", ~from=-3, ~length=4) == \"hij\"\nJs.String2.substrAtMost(\"abcdefghij\", ~from=12, ~length=2) == \"\"\n```\n"},
-    "sortText": "substrAtMost",
-    "insertText": "->Js.String2.substrAtMost",
+    "detail": "(string, RegExp.t) => option<int>",
+    "documentation": {"kind": "markdown", "value": "\n`searchOpt(str, regexp)`. Like `search`, but return an `option<int>`.\n\n## Examples\n\n```rescript\nString.searchOpt(\"testing 1 2 3\", %re(\"/\\d+/\")) == Some(8)\nString.searchOpt(\"no numbers\", %re(\"/\\d+/\")) == None\n```\n"},
+    "sortText": "searchOpt",
+    "insertText": "->String.searchOpt",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.sliceToEnd",
+    "label": "->String.splitByRegExpAtMost",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, from:n)` returns the substring of `str` starting at character\n`n` to the end of the string.\n- If `n` is negative, then it is evaluated as `length(str - n)`.\n- If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.sliceToEnd(\"abcdefg\", ~from=4) == \"efg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=-2) == \"fg\"\nJs.String2.sliceToEnd(\"abcdefg\", ~from=7) == \"\"\n```\n"},
-    "sortText": "sliceToEnd",
-    "insertText": "->Js.String2.sliceToEnd",
+    "detail": "(string, RegExp.t, ~limit: int) => array<option<string>>",
+    "documentation": {"kind": "markdown", "value": "\n`splitByRegExpAtMost(str, regexp, ~limit)` splits the given `str` at every\noccurrence of `regexp` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings, the\narray will contain all the substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExpAtMost(\"Hello World. How are you doing?\", %re(\"/ /\"), ~limit=3) == [\n  Some(\"Hello\"),\n  Some(\"World.\"),\n  Some(\"How\"),\n]\n```\n"},
+    "sortText": "splitByRegExpAtMost",
+    "insertText": "->String.splitByRegExpAtMost",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.slice",
+    "label": "->String.slice",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`slice(str, from:n1, to_:n2)` returns the substring of `str` starting at\ncharacter `n1` up to but not including `n2`.\n- If either `n1` or `n2` is negative, then it is evaluated as `length(str - n1)` or `length(str - n2)`.\n- If `n2` is greater than the length of `str`, then it is treated as `length(str)`.\n- If `n1` is greater than `n2`, slice returns the empty string.\n\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=5) == \"cde\"\nJs.String2.slice(\"abcdefg\", ~from=2, ~to_=9) == \"cdefg\"\nJs.String2.slice(\"abcdefg\", ~from=-4, ~to_=-2) == \"de\"\nJs.String2.slice(\"abcdefg\", ~from=5, ~to_=1) == \"\"\n```\n"},
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`slice(str, ~start, ~end)` returns the substring of `str` starting at\ncharacter `start` up to but not including `end`.\n- If either `start` or `end` is negative, then it is evaluated as\n`length(str - start)` or `length(str - end)`.\n- If `end` is greater than the length of `str`, then it is treated as\n`length(str)`.\n- If `start` is greater than `end`, slice returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.slice(\"abcdefg\", ~start=2, ~end=5) == \"cde\"\nString.slice(\"abcdefg\", ~start=2, ~end=9) == \"cdefg\"\nString.slice(\"abcdefg\", ~start=-4, ~end=-2) == \"de\"\nString.slice(\"abcdefg\", ~start=5, ~end=1) == \"\"\n```\n"},
     "sortText": "slice",
-    "insertText": "->Js.String2.slice",
+    "insertText": "->String.slice",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.splitByRe",
+    "label": "->String.sliceToEnd",
     "kind": 12,
     "tags": [],
-    "detail": "(t, Js_re.t) => array<option<t>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByRe(str, regex)` splits the given `str` at every occurrence of `regex`\nand returns an array of the resulting substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.splitByRe(\"art; bed , cog ;dad\", /\\s*[,;]\\s*TODO/) == [\n    Some(\"art\"),\n    Some(\"bed\"),\n    Some(\"cog\"),\n    Some(\"dad\"),\n  ]\n```\n"},
-    "sortText": "splitByRe",
-    "insertText": "->Js.String2.splitByRe",
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`sliceToEnd(str, ~start)` returns the substring of `str` starting at character\n`start` to the end of the string.\n- If `start` is negative, then it is evaluated as `length(str - start)`.\n- If `start` is greater than the length of `str`, then sliceToEnd returns the empty string.\nSee [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.\n\n## Examples\n\n```rescript\nString.sliceToEnd(\"abcdefg\", ~start=4) == \"efg\"\nString.sliceToEnd(\"abcdefg\", ~start=-2) == \"fg\"\nString.sliceToEnd(\"abcdefg\", ~start=7) == \"\"\n```\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->String.sliceToEnd",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.startsWithFrom",
+    "label": "->String.setSymbol",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.startsWithFrom(\"ReScript\", \"Scri\", 2) == true\nJs.String2.startsWithFrom(\"ReScript\", \"\", 2) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Scri\", 2) == false\n```\n"},
+    "detail": "(string, Symbol.t, 'a) => unit",
+    "documentation": null,
+    "sortText": "setSymbol",
+    "insertText": "->String.setSymbol",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->String.splitByRegExp",
+    "kind": 12,
+    "tags": [],
+    "detail": "(string, RegExp.t) => array<option<string>>",
+    "documentation": {"kind": "markdown", "value": "\n`splitByRegExp(str, regexp)` splits the given `str` at every occurrence of\n`regexp` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExp(\"Jan,Feb,Mar\", %re(\"/,/\")) == [Some(\"Jan\"), Some(\"Feb\"), Some(\"Mar\")]\n```\n"},
+    "sortText": "splitByRegExp",
+    "insertText": "->String.splitByRegExp",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->String.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"},
     "sortText": "startsWithFrom",
-    "insertText": "->Js.String2.startsWithFrom",
+    "insertText": "->String.startsWithFrom",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.split",
+    "label": "->String.split",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => array<t>",
-    "documentation": {"kind": "markdown", "value": "\n`split(str, delimiter)` splits the given `str` at every occurrence of\n`delimiter` and returns an array of the resulting substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.split(\"2018-01-02\", \"-\") == [\"2018\", \"01\", \"02\"]\nJs.String2.split(\"a,b,,c\", \",\") == [\"a\", \"b\", \"\", \"c\"]\nJs.String2.split(\"good::bad as great::awful\", \"::\") == [\"good\", \"bad as great\", \"awful\"]\nJs.String2.split(\"has-no-delimiter\", \";\") == [\"has-no-delimiter\"]\n```\n"},
+    "detail": "(string, string) => array<string>",
+    "documentation": {"kind": "markdown", "value": "\n`split(str, delimiter)` splits the given `str` at every occurrence of\n`delimiter` and returns an array of the resulting substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.split(\"2018-01-02\", \"-\") == [\"2018\", \"01\", \"02\"]\nString.split(\"a,b,,c\", \",\") == [\"a\", \"b\", \"\", \"c\"]\nString.split(\"good::bad as great::awful\", \"::\") == [\"good\", \"bad as great\", \"awful\"]\nString.split(\"has-no-delimiter\", \";\") == [\"has-no-delimiter\"]\n```\n"},
     "sortText": "split",
-    "insertText": "->Js.String2.split",
+    "insertText": "->String.split",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.splitByReAtMost",
+    "label": "->String.substring",
     "kind": 12,
     "tags": [],
-    "detail": "(t, Js_re.t, ~limit: int) => array<option<t>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByReAtMost(str, regex, ~limit:n)` splits the given `str` at every\noccurrence of `regex` and returns an array of the first `n` resulting\nsubstrings. If `n` is negative or greater than the number of substrings, the\narray will contain all the substrings.\n\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=3) == [\n    Some(\"one\"),\n    Some(\"two\"),\n    Some(\"three\"),\n  ]\n\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=0) == []\n\nJs.String2.splitByReAtMost(\"one: two: three: four\", /\\s*:\\s*TODO/, ~limit=8) == [\n    Some(\"one\"),\n    Some(\"two\"),\n    Some(\"three\"),\n    Some(\"four\"),\n  ]\n```\n"},
-    "sortText": "splitByReAtMost",
-    "insertText": "->Js.String2.splitByReAtMost",
-    "additionalTextEdits": [{
-      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
-      "newText": ""
-      }]
-  }, {
-    "label": "->Js.String2.substring",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t, ~from: int, ~to_: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`substring(str, ~from: start, ~to_: finish)` returns characters `start` up to\nbut not including finish from `str`.\n- If `start` is less than zero, it is treated as zero.\n- If `finish` is zero or negative, the empty string is returned.\n- If `start` is greater than `finish`, the `start` and `finish` points are swapped.\n\nSee [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.substring(\"playground\", ~from=3, ~to_=6) == \"ygr\"\nJs.String2.substring(\"playground\", ~from=6, ~to_=3) == \"ygr\"\nJs.String2.substring(\"playground\", ~from=4, ~to_=12) == \"ground\"\n```\n"},
+    "detail": "(string, ~start: int, ~end: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`substring(str, ~start, ~end)` returns characters `start` up to but not\nincluding end from `str`.\n- If `start` is less than zero, it is treated as zero.\n- If `end` is zero or negative, the empty string is returned.\n- If `start` is greater than `end`, the `start` and `end` points are swapped.\nSee [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.\n\n## Examples\n\n```rescript\nString.substring(\"playground\", ~start=3, ~end=6) == \"ygr\"\nString.substring(\"playground\", ~start=6, ~end=3) == \"ygr\"\nString.substring(\"playground\", ~start=4, ~end=12) == \"ground\"\n```\n"},
     "sortText": "substring",
-    "insertText": "->Js.String2.substring",
+    "insertText": "->String.substring",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.substr",
+    "label": "->String.search",
     "kind": 12,
     "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`substr(str, ~from:n)` returns the substring of `str` from position `n` to the\nend of the string.\n- If `n` is less than zero, the starting position is the length of `str - n`.\n- If `n` is greater than or equal to the length of `str`, returns the empty string.\n\nJavaScript’s `String.substr()` is a legacy function. When possible, use\n`substring()` instead.\n\nSee [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.substr(\"abcdefghij\", ~from=3) == \"defghij\"\nJs.String2.substr(\"abcdefghij\", ~from=-3) == \"hij\"\nJs.String2.substr(\"abcdefghij\", ~from=12) == \"\"\n```\n"},
-    "sortText": "substr",
-    "insertText": "->Js.String2.substr",
-    "additionalTextEdits": [{
-      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
-      "newText": ""
-      }]
-  }, {
-    "label": "->Js.String2.substringToEnd",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t, ~from: int) => t",
-    "documentation": {"kind": "markdown", "value": "\n`substringToEnd(str, ~from: start)` returns the substring of `str` from\nposition `start` to the end.\n- If `start` is less than or equal to zero, the entire string is returned.\n- If `start` is greater than or equal to the length of `str`, the empty string is returned.\n\nSee [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.\n\n## Examples\n\n```rescript\nJs.String2.substringToEnd(\"playground\", ~from=4) == \"ground\"\nJs.String2.substringToEnd(\"playground\", ~from=-3) == \"playground\"\nJs.String2.substringToEnd(\"playground\", ~from=12) == \"\"\n```\n"},
-    "sortText": "substringToEnd",
-    "insertText": "->Js.String2.substringToEnd",
-    "additionalTextEdits": [{
-      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
-      "newText": ""
-      }]
-  }, {
-    "label": "->Js.String2.search",
-    "kind": 12,
-    "tags": [],
-    "detail": "(t, Js_re.t) => int",
-    "documentation": {"kind": "markdown", "value": "\n`search(str, regexp)` returns the starting position of the first match of\n`regexp` in the given `str`, or -1 if there is no match.\n\nSee [`String.search`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.search(\"testing 1 2 3\", /\\d+/) == 8\nJs.String2.search(\"no numbers\", /\\d+/) == -1\n```\n"},
+    "detail": "(string, RegExp.t) => int",
+    "documentation": {"kind": "markdown", "value": "\n`search(str, regexp)` returns the starting position of the first match of\n`regexp` in the given `str`, or -1 if there is no match.\nSee [`String.search`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search) on MDN.\n\n## Examples\n\n```rescript\nString.search(\"testing 1 2 3\", %re(\"/\\d+/\")) == 8\nString.search(\"no numbers\", %re(\"/\\d+/\")) == -1\n```\n"},
     "sortText": "search",
-    "insertText": "->Js.String2.search",
+    "insertText": "->String.search",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->String.substringToEnd",
+    "kind": 12,
+    "tags": [],
+    "detail": "(string, ~start: int) => string",
+    "documentation": {"kind": "markdown", "value": "\n`substringToEnd(str, ~start)` returns the substring of `str` from position\n`start` to the end.\n- If `start` is less than or equal to zero, the entire string is returned.\n- If `start` is greater than or equal to the length of `str`, the empty string\nis returned.\nSee [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.\n\n## Examples\n\n```rescript\nString.substringToEnd(\"playground\", ~start=4) == \"ground\"\nString.substringToEnd(\"playground\", ~start=-3) == \"playground\"\nString.substringToEnd(\"playground\", ~start=12) == \"\"\n```\n"},
+    "sortText": "substringToEnd",
+    "insertText": "->String.substringToEnd",
     "additionalTextEdits": [{
       "range": {"start": {"line": 93, "character": 17}, "end": {"line": 93, "character": 18}},
       "newText": ""

--- a/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
@@ -141,27 +141,27 @@ Path String.st
     "documentation": {"kind": "markdown", "value": "\n`startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, `false` otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.\n\n## Examples\n\n```rescript\nString.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nString.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nString.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 22:44
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[8:13->33:3]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[9:4->32:10]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[10:4->32:10]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[11:4->32:10]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[12:4->32:10]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[15:5->32:10]
+Complete src/CompletionJsx.res 22:40
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[8:13->33:3]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[9:4->32:10]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[10:4->32:10]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[11:4->32:10]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[12:4->32:10]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[15:5->32:10]
 JSX <div:[15:5->15:8] > _children:15:8
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[15:8->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[16:7->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[17:7->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[17:7->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->32:4]
-posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->22:44]
-Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[15:8->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[16:7->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[17:7->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[17:7->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[22:10->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[22:10->32:4]
+posCursor:[22:40] posNoWhite:[22:39] Found expr:[22:10->22:40]
+Completable: Cpath Value[String, trim](Nolabel)->st <<jsx>>
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, String2, trim](Nolabel)->st <<jsx>>
-ContextPath Value[Js, String2, trim](Nolabel)
-ContextPath Value[Js, String2, trim]
-Path Js.String2.trim
+ContextPath Value[String, trim](Nolabel)->st <<jsx>>
+ContextPath Value[String, trim](Nolabel)
+ContextPath Value[String, trim]
+Path String.trim
 Path String.st
 [{
     "label": "React.string",

--- a/tests/analysis_tests/tests/src/expected/CompletionPattern.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionPattern.res.txt
@@ -1016,7 +1016,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[xn]
 Path xn
 [{
-    "label": "Exn.t.Error(error)",
+    "label": "Exn.Error(error)",
     "kind": 4,
     "tags": [],
     "detail": "Catches errors from JavaScript errors.",

--- a/tests/analysis_tests/tests/src/expected/CompletionPattern.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionPattern.res.txt
@@ -1016,7 +1016,7 @@ Package opens Pervasives.JsxModules.place holder
 ContextPath Value[xn]
 Path xn
 [{
-    "label": "Js.Exn.Error(error)",
+    "label": "Exn.t.Error(error)",
     "kind": 4,
     "tags": [],
     "detail": "Catches errors from JavaScript errors.",

--- a/tests/analysis_tests/tests/src/expected/CompletionPipeChain.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionPipeChain.res.txt
@@ -269,19 +269,67 @@ ContextPath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->t
 ContextPath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)
 ContextPath Value[Belt, Array, reduce]
 Path Belt.Array.reduce
-Path Belt.Int.t
+Path Int.t
 [{
-    "label": "Belt.Int.toString",
+    "label": "Int.toStringWithRadix",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~radix: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toExponentialWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixedWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toFixed` instead\n\n\n`toFixedWithPrecision(n, ~digits)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixedWithPrecision(300, ~digits=4) // \"300.0000\"\nInt.toFixedWithPrecision(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.toPrecisionWithPrecision",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(int, ~digits: int) => string",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
+  }, {
+    "label": "Int.toPrecision",
     "kind": 12,
     "tags": [],
-    "detail": "int => string",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n## Examples\n\n```rescript\nBelt.Int.toString(1)->assertEqual(\"1\")\n```\n"}
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toPrecision(n, ~digits=?)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecision(100) // \"100\"\nInt.toPrecision(1) // \"1\"\nInt.toPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n"}
   }, {
-    "label": "Belt.Int.toFloat",
+    "label": "Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~radix: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
+  }, {
+    "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
     "detail": "int => float",
-    "documentation": {"kind": "markdown", "value": "\nConverts a given `int` to a `float`.\n\n## Examples\n\n```rescript\nBelt.Int.toFloat(1)->assertEqual(1.0)\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`toFloat(n)` return a `float` representing the given value.\n\n## Examples\n\n```rescript\nInt.toFloat(100) == 100.0\nInt.toFloat(2) == 2.0\n```\n"}
+  }, {
+    "label": "Int.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
+  }, {
+    "label": "Int.toExponential",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toExponential(n, ~digits=?)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\n\n## Examples\n\n```rescript\nInt.toExponential(1000) // \"1e+3\"\nInt.toExponential(-1000) // \"-1e+3\"\nInt.toExponential(77, ~digits=2) // \"7.70e+1\"\nInt.toExponential(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
+  }, {
+    "label": "Int.toFixed",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, ~digits: int=?) => string",
+    "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
   }]
 
 Complete src/CompletionPipeChain.res 70:12

--- a/tests/analysis_tests/tests/src/expected/CompletionPipeChain.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionPipeChain.res.txt
@@ -251,14 +251,14 @@ Path CompletionSupport.Test.
 
 Complete src/CompletionPipeChain.res 58:5
 posCursor:[58:5] posNoWhite:[58:4] Found expr:[57:8->0:-1]
-Completable: Cpath Value[Js, Array2, forEach](Nolabel, Nolabel)->
+Completable: Cpath Value[Array, forEach](Nolabel, Nolabel)->
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, Array2, forEach](Nolabel, Nolabel)->
-ContextPath Value[Js, Array2, forEach](Nolabel, Nolabel)
-ContextPath Value[Js, Array2, forEach]
-Path Js.Array2.forEach
+ContextPath Value[Array, forEach](Nolabel, Nolabel)->
+ContextPath Value[Array, forEach](Nolabel, Nolabel)
+ContextPath Value[Array, forEach]
+Path Array.forEach
 CPPipe pathFromEnv: found:true
-Path Js_array2.
+Path Array.
 []
 
 Complete src/CompletionPipeChain.res 62:6

--- a/tests/analysis_tests/tests/src/expected/CompletionTypeT.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionTypeT.res.txt
@@ -8,13 +8,13 @@ Path date
     "label": "None",
     "kind": 12,
     "tags": [],
-    "detail": "Js.Date.t",
+    "detail": "Date.t",
     "documentation": null
   }, {
     "label": "Some(_)",
     "kind": 12,
     "tags": [],
-    "detail": "Js.Date.t",
+    "detail": "Date.t",
     "documentation": null,
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2

--- a/tests/analysis_tests/tests/src/expected/DotPipeCompletionSpec.res.txt
+++ b/tests/analysis_tests/tests/src/expected/DotPipeCompletionSpec.res.txt
@@ -307,20 +307,20 @@ Path DotPipeCompletionSpec.SomeOtherModule.
       }]
   }]
 
-Complete src/DotPipeCompletionSpec.res 86:43
-posCursor:[86:43] posNoWhite:[86:42] Found expr:[86:3->86:43]
-posCursor:[86:43] posNoWhite:[86:42] Found expr:[86:9->86:43]
-Pexp_field [86:9->86:38] filt:[86:39->86:43]
-Completable: Cpath Value[Js, Array2, filter](Nolabel).filt
+Complete src/DotPipeCompletionSpec.res 86:39
+posCursor:[86:39] posNoWhite:[86:38] Found expr:[86:3->86:39]
+posCursor:[86:39] posNoWhite:[86:38] Found expr:[86:9->86:39]
+Pexp_field [86:9->86:34] filt:[86:35->86:39]
+Completable: Cpath Value[Array, filter](Nolabel).filt
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, Array2, filter](Nolabel).filt
-ContextPath Value[Js, Array2, filter](Nolabel)
-ContextPath Value[Js, Array2, filter]
-Path Js.Array2.filter
-ContextPath Value[Js, Array2, filter](Nolabel, Nolabel)->filt
-ContextPath Value[Js, Array2, filter](Nolabel, Nolabel)
-ContextPath Value[Js, Array2, filter]
-Path Js.Array2.filter
+ContextPath Value[Array, filter](Nolabel).filt
+ContextPath Value[Array, filter](Nolabel)
+ContextPath Value[Array, filter]
+Path Array.filter
+ContextPath Value[Array, filter](Nolabel, Nolabel)->filt
+ContextPath Value[Array, filter](Nolabel, Nolabel)
+ContextPath Value[Array, filter]
+Path Array.filter
 Path Array.filt
 [{
     "label": "->Array.filterMap",
@@ -331,7 +331,7 @@ Path Array.filt
     "sortText": "filterMap",
     "insertText": "->Array.filterMap",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
+      "range": {"start": {"line": 86, "character": 34}, "end": {"line": 86, "character": 35}},
       "newText": ""
       }]
   }, {
@@ -343,7 +343,7 @@ Path Array.filt
     "sortText": "filter",
     "insertText": "->Array.filter",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
+      "range": {"start": {"line": 86, "character": 34}, "end": {"line": 86, "character": 35}},
       "newText": ""
       }]
   }, {
@@ -355,25 +355,25 @@ Path Array.filt
     "sortText": "filterWithIndex",
     "insertText": "->Array.filterWithIndex",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
+      "range": {"start": {"line": 86, "character": 34}, "end": {"line": 86, "character": 35}},
       "newText": ""
       }]
   }]
 
-Complete src/DotPipeCompletionSpec.res 89:70
-posCursor:[89:70] posNoWhite:[89:69] Found expr:[89:3->89:70]
-posCursor:[89:70] posNoWhite:[89:69] Found expr:[89:40->89:70]
-Pexp_field [89:40->89:63] includ:[89:64->89:70]
-Completable: Cpath Value[Js, Array2, joinWith](Nolabel).includ
+Complete src/DotPipeCompletionSpec.res 89:62
+posCursor:[89:62] posNoWhite:[89:61] Found expr:[89:3->89:62]
+posCursor:[89:62] posNoWhite:[89:61] Found expr:[89:36->89:62]
+Pexp_field [89:36->89:55] includ:[89:56->89:62]
+Completable: Cpath Value[Array, joinWith](Nolabel).includ
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, Array2, joinWith](Nolabel).includ
-ContextPath Value[Js, Array2, joinWith](Nolabel)
-ContextPath Value[Js, Array2, joinWith]
-Path Js.Array2.joinWith
-ContextPath Value[Js, Array2, joinWith](Nolabel, Nolabel)->includ
-ContextPath Value[Js, Array2, joinWith](Nolabel, Nolabel)
-ContextPath Value[Js, Array2, joinWith]
-Path Js.Array2.joinWith
+ContextPath Value[Array, joinWith](Nolabel).includ
+ContextPath Value[Array, joinWith](Nolabel)
+ContextPath Value[Array, joinWith]
+Path Array.joinWith
+ContextPath Value[Array, joinWith](Nolabel, Nolabel)->includ
+ContextPath Value[Array, joinWith](Nolabel, Nolabel)
+ContextPath Value[Array, joinWith]
+Path Array.joinWith
 Path String.includ
 [{
     "label": "->String.includesFrom",
@@ -384,7 +384,7 @@ Path String.includ
     "sortText": "includesFrom",
     "insertText": "->String.includesFrom",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 89, "character": 63}, "end": {"line": 89, "character": 64}},
+      "range": {"start": {"line": 89, "character": 55}, "end": {"line": 89, "character": 56}},
       "newText": ""
       }]
   }, {
@@ -396,24 +396,24 @@ Path String.includ
     "sortText": "includes",
     "insertText": "->String.includes",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 89, "character": 63}, "end": {"line": 89, "character": 64}},
+      "range": {"start": {"line": 89, "character": 55}, "end": {"line": 89, "character": 56}},
       "newText": ""
       }]
   }]
 
-Complete src/DotPipeCompletionSpec.res 94:40
-posCursor:[94:40] posNoWhite:[94:39] Found expr:[94:3->94:40]
-posCursor:[94:40] posNoWhite:[94:39] Found expr:[94:8->94:40]
-Pexp_field [94:8->94:30] toUpperCa:[94:31->94:40]
-Completable: Cpath Value[Js, String2, toLowerCase].toUpperCa
+Complete src/DotPipeCompletionSpec.res 94:36
+posCursor:[94:36] posNoWhite:[94:35] Found expr:[94:3->94:36]
+posCursor:[94:36] posNoWhite:[94:35] Found expr:[94:8->94:36]
+Pexp_field [94:8->94:26] toUpperCa:[94:27->94:36]
+Completable: Cpath Value[String, toLowerCase].toUpperCa
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, String2, toLowerCase].toUpperCa
-ContextPath Value[Js, String2, toLowerCase]
-Path Js.String2.toLowerCase
-ContextPath Value[Js, String2, toLowerCase](Nolabel)->toUpperCa
-ContextPath Value[Js, String2, toLowerCase](Nolabel)
-ContextPath Value[Js, String2, toLowerCase]
-Path Js.String2.toLowerCase
+ContextPath Value[String, toLowerCase].toUpperCa
+ContextPath Value[String, toLowerCase]
+Path String.toLowerCase
+ContextPath Value[String, toLowerCase](Nolabel)->toUpperCa
+ContextPath Value[String, toLowerCase](Nolabel)
+ContextPath Value[String, toLowerCase]
+Path String.toLowerCase
 Path String.toUpperCa
 [{
     "label": "->String.toUpperCase",
@@ -424,24 +424,24 @@ Path String.toUpperCa
     "sortText": "toUpperCase",
     "insertText": "->String.toUpperCase",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 94, "character": 30}, "end": {"line": 94, "character": 31}},
+      "range": {"start": {"line": 94, "character": 26}, "end": {"line": 94, "character": 27}},
       "newText": ""
       }]
   }]
 
-Complete src/DotPipeCompletionSpec.res 97:63
-posCursor:[97:63] posNoWhite:[97:62] Found expr:[97:3->97:63]
-posCursor:[97:63] posNoWhite:[97:62] Found expr:[97:32->97:63]
-Pexp_field [97:32->97:54] toLowerC:[97:55->97:63]
-Completable: Cpath Value[Js, String2, toUpperCase].toLowerC
+Complete src/DotPipeCompletionSpec.res 97:55
+posCursor:[97:55] posNoWhite:[97:54] Found expr:[97:3->97:55]
+posCursor:[97:55] posNoWhite:[97:54] Found expr:[97:28->97:55]
+Pexp_field [97:28->97:46] toLowerC:[97:47->97:55]
+Completable: Cpath Value[String, toUpperCase].toLowerC
 Package opens Pervasives.JsxModules.place holder
-ContextPath Value[Js, String2, toUpperCase].toLowerC
-ContextPath Value[Js, String2, toUpperCase]
-Path Js.String2.toUpperCase
-ContextPath Value[Js, String2, toUpperCase](Nolabel)->toLowerC
-ContextPath Value[Js, String2, toUpperCase](Nolabel)
-ContextPath Value[Js, String2, toUpperCase]
-Path Js.String2.toUpperCase
+ContextPath Value[String, toUpperCase].toLowerC
+ContextPath Value[String, toUpperCase]
+Path String.toUpperCase
+ContextPath Value[String, toUpperCase](Nolabel)->toLowerC
+ContextPath Value[String, toUpperCase](Nolabel)
+ContextPath Value[String, toUpperCase]
+Path String.toUpperCase
 Path String.toLowerC
 [{
     "label": "->String.toLowerCase",
@@ -452,7 +452,7 @@ Path String.toLowerC
     "sortText": "toLowerCase",
     "insertText": "->String.toLowerCase",
     "additionalTextEdits": [{
-      "range": {"start": {"line": 97, "character": 54}, "end": {"line": 97, "character": 55}},
+      "range": {"start": {"line": 97, "character": 46}, "end": {"line": 97, "character": 47}},
       "newText": ""
       }]
   }]

--- a/tests/analysis_tests/tests/src/expected/DotPipeCompletionSpec.res.txt
+++ b/tests/analysis_tests/tests/src/expected/DotPipeCompletionSpec.res.txt
@@ -210,51 +210,39 @@ Path ffff
 ContextPath Value[ffff]->u
 ContextPath Value[ffff]
 Path ffff
-Path Js.Array2.u
+Path Array.u
 [{
-    "label": "->Js.Array2.unshiftMany",
+    "label": "->Array.unshiftMany",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, array<'a>) => int",
-    "documentation": {"kind": "markdown", "value": "\nAdds the elements in the second array argument at the beginning of the first\narray argument, returning the new number of elements in the array. *This\nfunction modifies the original array.* See\n[`Array.unshift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift)\non MDN.\n\n## Examples\n\n```rescript\nlet arr = [\"d\", \"e\"]\nJs.Array2.unshiftMany(arr, [\"a\", \"b\", \"c\"]) == 5\narr == [\"a\", \"b\", \"c\", \"d\", \"e\"]\n```\n"},
+    "detail": "(array<'a>, array<'a>) => unit",
+    "documentation": {"kind": "markdown", "value": "\n`unshiftMany(array, itemsArray)` inserts many new items to the start of the array.\n\nBeware this will *mutate* the array.\n\nSee [`Array.push`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift) on MDN.\n\n## Examples\n\n```rescript\nlet someArray = [\"hi\", \"hello\"]\nsomeArray->Array.unshiftMany([\"yay\", \"wehoo\"])\nsomeArray->assertEqual([\"yay\", \"wehoo\", \"hi\", \"hello\"])\n```\n"},
     "sortText": "unshiftMany",
-    "insertText": "->Js.Array2.unshiftMany",
+    "insertText": "->Array.unshiftMany",
     "additionalTextEdits": [{
       "range": {"start": {"line": 75, "character": 7}, "end": {"line": 75, "character": 8}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.Array2.unshift",
+    "label": "->Array.unshift",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a) => int",
-    "documentation": {"kind": "markdown", "value": "\nAdds the given element to the array, returning the new number of elements in\nthe array. *This function modifies the original array.* See\n[`Array.unshift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift)\non MDN.\n\n## Examples\n\n```rescript\nlet arr = [\"b\", \"c\", \"d\"]\nJs.Array2.unshift(arr, \"a\") == 4\narr == [\"a\", \"b\", \"c\", \"d\"]\n```\n"},
+    "detail": "(array<'a>, 'a) => unit",
+    "documentation": {"kind": "markdown", "value": "\n`unshift(array, item)` inserts a new item at the start of the array.\n\nBeware this will *mutate* the array.\n\nSee [`Array.unshift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift) on MDN.\n\n## Examples\n\n```rescript\nlet someArray = [\"hi\", \"hello\"]\nsomeArray->Array.unshift(\"yay\")\nsomeArray->assertEqual([\"yay\", \"hi\", \"hello\"])\n```\n"},
     "sortText": "unshift",
-    "insertText": "->Js.Array2.unshift",
+    "insertText": "->Array.unshift",
     "additionalTextEdits": [{
       "range": {"start": {"line": 75, "character": 7}, "end": {"line": 75, "character": 8}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.Array2.unsafe_get",
+    "label": "->Array.unsafe_get",
     "kind": 12,
-    "tags": [],
+    "tags": [1],
     "detail": "(array<'a>, int) => 'a",
-    "documentation": {"kind": "markdown", "value": "\nReturns the value at the given position in the array if the position is in\nbounds; returns the JavaScript value `undefined` otherwise.\n\n## Examples\n\n```rescript\nlet arr = [100, 101, 102, 103]\nJs.Array2.unsafe_get(arr, 3) == 103\nJs.Array2.unsafe_get(arr, 4) // returns undefined\n```\n"},
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use getUnsafe instead. This will be removed in v13\n\n\n`unsafe_get(array, index)` returns the element at `index` of `array`.\n\nThis is _unsafe_, meaning it will return `undefined` value if `index` does not exist in `array`.\n\nUse `Array.unsafe_get` only when you are sure the `index` exists (i.e. when using for-loop).\n\n## Examples\n\n```rescript\nlet array = [1, 2, 3]\nfor index in 0 to array->Array.length - 1 {\n  let value = array->Array.unsafe_get(index)\n  Console.log(value)\n}\n```\n"},
     "sortText": "unsafe_get",
-    "insertText": "->Js.Array2.unsafe_get",
-    "additionalTextEdits": [{
-      "range": {"start": {"line": 75, "character": 7}, "end": {"line": 75, "character": 8}},
-      "newText": ""
-      }]
-  }, {
-    "label": "->Js.Array2.unsafe_set",
-    "kind": 12,
-    "tags": [],
-    "detail": "(array<'a>, int, 'a) => unit",
-    "documentation": {"kind": "markdown", "value": "\nSets the value at the given position in the array if the position is in bounds.\nIf the index is out of bounds, well, “here there be dragons.“\n\n*This function modifies the original array.*\n\n## Examples\n\n```rescript\nlet arr = [100, 101, 102, 103]\nJs.Array2.unsafe_set(arr, 3, 99)\n// result is [100, 101, 102, 99];\n\nJs.Array2.unsafe_set(arr, 4, 88)\n// result is [100, 101, 102, 99, 88]\n\nJs.Array2.unsafe_set(arr, 6, 77)\n// result is [100, 101, 102, 99, 88, <1 empty item>, 77]\n\nJs.Array2.unsafe_set(arr, -1, 66)\n// you don't want to know.\n```\n"},
-    "sortText": "unsafe_set",
-    "insertText": "->Js.Array2.unsafe_set",
+    "insertText": "->Array.unsafe_get",
     "additionalTextEdits": [{
       "range": {"start": {"line": 75, "character": 7}, "end": {"line": 75, "character": 8}},
       "newText": ""
@@ -333,27 +321,39 @@ ContextPath Value[Js, Array2, filter](Nolabel, Nolabel)->filt
 ContextPath Value[Js, Array2, filter](Nolabel, Nolabel)
 ContextPath Value[Js, Array2, filter]
 Path Js.Array2.filter
-Path Js.Array2.filt
+Path Array.filt
 [{
-    "label": "->Js.Array2.filter",
+    "label": "->Array.filterMap",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => bool) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the given predicate function (the second argument) to each element in\nthe array; the result is an array of those elements for which the predicate\nfunction returned `true`. See\n[`Array.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\non MDN.\n\n## Examples\n\n```rescript\nlet nonEmpty = s => s != \"\"\nJs.Array2.filter([\"abc\", \"\", \"\", \"def\", \"ghi\"], nonEmpty) == [\"abc\", \"def\", \"ghi\"]\n```\n"},
-    "sortText": "filter",
-    "insertText": "->Js.Array2.filter",
+    "detail": "(array<'a>, 'a => option<'b>) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`filterMap(array, fn)`\n\nCalls `fn` for each element and returns a new array containing results of the `fn` calls which are not `None`.\n\n## Examples\n\n```rescript\n[\"Hello\", \"Hi\", \"Good bye\"]\n->Array.filterMap(item =>\n  switch item {\n  | \"Hello\" => Some(item->String.length)\n  | _ => None\n  }\n)\n->assertEqual([5])\n\n[1, 2, 3, 4, 5, 6]\n->Array.filterMap(n => mod(n, 2) == 0 ? Some(n * n) : None)\n->assertEqual([4, 16, 36])\n\nArray.filterMap([1, 2, 3, 4, 5, 6], _ => None)->assertEqual([])\n\nArray.filterMap([], n => mod(n, 2) == 0 ? Some(n * n) : None)->assertEqual([])\n```\n"},
+    "sortText": "filterMap",
+    "insertText": "->Array.filterMap",
     "additionalTextEdits": [{
       "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.Array2.filteri",
+    "label": "->Array.filter",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "\nEach element of the given array are passed to the predicate function. The\nreturn value is an array of all those elements for which the predicate function\nreturned `true`.\n\nSee\n[`Array.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\non MDN.\n\n## Examples\n\n```rescript\n// keep only positive elements at odd indices\nlet positiveOddElement = (item, index) => mod(index, 2) == 1 && item > 0\n\nJs.Array2.filteri([6, 3, 5, 8, 7, -4, 1], positiveOddElement) == [3, 8]\n```\n"},
-    "sortText": "filteri",
-    "insertText": "->Js.Array2.filteri",
+    "detail": "(array<'a>, 'a => bool) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "\n`filter(array, checker)` returns a new array containing all elements from `array` for which the provided `checker` function returns true.\n\nSee [`Array.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) on MDN.\n\n## Examples\n\n```rescript\n[1, 2, 3, 4]\n->Array.filter(num => num > 2)\n->assertEqual([3, 4])\n```\n"},
+    "sortText": "filter",
+    "insertText": "->Array.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->Array.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(array<'a>, ('a, int) => bool) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "\n`filterWithIndex(array, checker)` returns a new array containing all elements from `array` for which the provided `checker` function returns true.\n\nSee [`Array.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) on MDN.\n\n## Examples\n\n```rescript\n[1, 2, 3, 4]\n->Array.filterWithIndex((num, index) => index === 0 || num === 2)\n->assertEqual([1, 2])\n```\n"},
+    "sortText": "filterWithIndex",
+    "insertText": "->Array.filterWithIndex",
     "additionalTextEdits": [{
       "range": {"start": {"line": 86, "character": 38}, "end": {"line": 86, "character": 39}},
       "newText": ""
@@ -374,27 +374,27 @@ ContextPath Value[Js, Array2, joinWith](Nolabel, Nolabel)->includ
 ContextPath Value[Js, Array2, joinWith](Nolabel, Nolabel)
 ContextPath Value[Js, Array2, joinWith]
 Path Js.Array2.joinWith
-Path Js.String2.includ
+Path String.includ
 [{
-    "label": "->Js.String2.includesFrom",
+    "label": "->String.includesFrom",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t, int) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `includes(str, searchValue start)` returns `true` if `searchValue` is\nfound anywhere within `str` starting at character number `start` (where 0 is\nthe first character), `false` otherwise.\n\nSee [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.includesFrom(\"programmer\", \"gram\", 1) == true\nJs.String2.includesFrom(\"programmer\", \"gram\", 4) == false\nJs.String2.includesFrom(`대한민국`, `한`, 1) == true\n```\n"},
+    "detail": "(string, string, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`includesFrom(str, searchValue, start)` returns `true` if `searchValue` is found\nanywhere within `str` starting at character number `start` (where 0 is the\nfirst character), `false` otherwise.\nSee [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.\n\n## Examples\n\n```rescript\nString.includesFrom(\"programmer\", \"gram\", 1) == true\nString.includesFrom(\"programmer\", \"gram\", 4) == false\nString.includesFrom(`대한민국`, `한`, 1) == true\n```\n"},
     "sortText": "includesFrom",
-    "insertText": "->Js.String2.includesFrom",
+    "insertText": "->String.includesFrom",
     "additionalTextEdits": [{
       "range": {"start": {"line": 89, "character": 63}, "end": {"line": 89, "character": 64}},
       "newText": ""
       }]
   }, {
-    "label": "->Js.String2.includes",
+    "label": "->String.includes",
     "kind": 12,
     "tags": [],
-    "detail": "(t, t) => bool",
-    "documentation": {"kind": "markdown", "value": "\nES2015: `includes(str, searchValue)` returns `true` if `searchValue` is found\nanywhere within `str`, false otherwise.\n\nSee [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.includes(\"programmer\", \"gram\") == true\nJs.String2.includes(\"programmer\", \"er\") == true\nJs.String2.includes(\"programmer\", \"pro\") == true\nJs.String2.includes(\"programmer.dat\", \"xyz\") == false\n```\n"},
+    "detail": "(string, string) => bool",
+    "documentation": {"kind": "markdown", "value": "\n`includes(str, searchValue)` returns `true` if `searchValue` is found anywhere\nwithin `str`, `false` otherwise.\nSee [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.\n\n## Examples\n\n```rescript\nString.includes(\"programmer\", \"gram\") == true\nString.includes(\"programmer\", \"er\") == true\nString.includes(\"programmer\", \"pro\") == true\nString.includes(\"programmer.dat\", \"xyz\") == false\n```\n"},
     "sortText": "includes",
-    "insertText": "->Js.String2.includes",
+    "insertText": "->String.includes",
     "additionalTextEdits": [{
       "range": {"start": {"line": 89, "character": 63}, "end": {"line": 89, "character": 64}},
       "newText": ""
@@ -414,15 +414,15 @@ ContextPath Value[Js, String2, toLowerCase](Nolabel)->toUpperCa
 ContextPath Value[Js, String2, toLowerCase](Nolabel)
 ContextPath Value[Js, String2, toLowerCase]
 Path Js.String2.toLowerCase
-Path Js.String2.toUpperCa
+Path String.toUpperCa
 [{
-    "label": "->Js.String2.toUpperCase",
+    "label": "->String.toUpperCase",
     "kind": 12,
     "tags": [],
-    "detail": "t => t",
-    "documentation": {"kind": "markdown", "value": "\n`toUpperCase(str)` converts `str` to upper case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\nexpand the number of letters in the result; for example the German ß\ncapitalizes to two Ses in a row.\n\nSee [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.toUpperCase(\"abc\") == \"ABC\"\nJs.String2.toUpperCase(`Straße`) == `STRASSE`\nJs.String2.toUpperCase(`πς`) == `ΠΣ`\n```\n"},
+    "detail": "string => string",
+    "documentation": {"kind": "markdown", "value": "\n`toUpperCase(str)` converts `str` to upper case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\nexpand the number of letters in the result, for example the German ß\ncapitalizes to two Ses in a row.\nSee [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) on MDN.\n\n## Examples\n\n```rescript\nString.toUpperCase(\"abc\") == \"ABC\"\nString.toUpperCase(`Straße`) == `STRASSE`\nString.toUpperCase(`πς`) == `ΠΣ`\n```\n"},
     "sortText": "toUpperCase",
-    "insertText": "->Js.String2.toUpperCase",
+    "insertText": "->String.toUpperCase",
     "additionalTextEdits": [{
       "range": {"start": {"line": 94, "character": 30}, "end": {"line": 94, "character": 31}},
       "newText": ""
@@ -442,15 +442,15 @@ ContextPath Value[Js, String2, toUpperCase](Nolabel)->toLowerC
 ContextPath Value[Js, String2, toUpperCase](Nolabel)
 ContextPath Value[Js, String2, toUpperCase]
 Path Js.String2.toUpperCase
-Path Js.String2.toLowerC
+Path String.toLowerC
 [{
-    "label": "->Js.String2.toLowerCase",
+    "label": "->String.toLowerCase",
     "kind": 12,
     "tags": [],
-    "detail": "t => t",
-    "documentation": {"kind": "markdown", "value": "\n`toLowerCase(str)` converts `str` to lower case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\ngive different results depending upon context, for example with the Greek\nletter sigma, which has two different lower case forms; one when it is the last\ncharacter in a string and another when it is not.\n\nSee [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase)\non MDN.\n\n## Examples\n\n```rescript\nJs.String2.toLowerCase(\"ABC\") == \"abc\"\nJs.String2.toLowerCase(`ΣΠ`) == `σπ`\nJs.String2.toLowerCase(`ΠΣ`) == `πς`\n```\n"},
+    "detail": "string => string",
+    "documentation": {"kind": "markdown", "value": "\n`toLowerCase(str)` converts `str` to lower case using the locale-insensitive\ncase mappings in the Unicode Character Database. Notice that the conversion can\ngive different results depending upon context, for example with the Greek\nletter sigma, which has two different lower case forms, one when it is the last\ncharacter in a string and another when it is not.\nSee [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) on MDN.\n\n## Examples\n\n```rescript\nString.toLowerCase(\"ABC\") == \"abc\"\nString.toLowerCase(`ΣΠ`) == `σπ`\nString.toLowerCase(`ΠΣ`) == `πς`\n```\n"},
     "sortText": "toLowerCase",
-    "insertText": "->Js.String2.toLowerCase",
+    "insertText": "->String.toLowerCase",
     "additionalTextEdits": [{
       "range": {"start": {"line": 97, "character": 54}, "end": {"line": 97, "character": 55}},
       "newText": ""

--- a/tests/analysis_tests/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/tests/analysis_tests/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -17,7 +17,7 @@ Path withSomeVarian
     "detail": "insert exhaustive switch for value",
     "documentation": null,
     "filterText": "withSomeVariant",
-    "insertText": "withSomeVariant {\n   | One => ${1:failwith(\"todo\")}\n   | Two => ${2:failwith(\"todo\")}\n   | Three(_) => ${3:failwith(\"todo\")}\n   }",
+    "insertText": "withSomeVariant {\n   | One => ${1:%todo}\n   | Two => ${2:%todo}\n   | Three(_) => ${3:%todo}\n   }",
     "insertTextFormat": 2
   }]
 
@@ -40,7 +40,7 @@ Path withSomePol
     "detail": "insert exhaustive switch for value",
     "documentation": null,
     "filterText": "withSomePoly",
-    "insertText": "withSomePoly {\n   | #\"switch\" => ${1:failwith(\"todo\")}\n   | #one => ${2:failwith(\"todo\")}\n   | #three(_) => ${3:failwith(\"todo\")}\n   | #two => ${4:failwith(\"todo\")}\n   | #\"exotic ident\" => ${5:failwith(\"todo\")}\n   }",
+    "insertText": "withSomePoly {\n   | #\"switch\" => ${1:%todo}\n   | #one => ${2:%todo}\n   | #three(_) => ${3:%todo}\n   | #two => ${4:%todo}\n   | #\"exotic ident\" => ${5:%todo}\n   }",
     "insertTextFormat": 2
   }]
 
@@ -63,7 +63,7 @@ Path someBoo
     "detail": "insert exhaustive switch for value",
     "documentation": null,
     "filterText": "someBool",
-    "insertText": "someBool {\n   | true => ${1:failwith(\"todo\")}\n   | false => ${2:failwith(\"todo\")}\n   }",
+    "insertText": "someBool {\n   | true => ${1:%todo}\n   | false => ${2:%todo}\n   }",
     "insertTextFormat": 2
   }]
 
@@ -86,7 +86,7 @@ Path someOp
     "detail": "insert exhaustive switch for value",
     "documentation": null,
     "filterText": "someOpt",
-    "insertText": "someOpt {\n   | Some($1) => ${2:failwith(\"todo\")}\n   | None => ${3:failwith(\"todo\")}\n   }",
+    "insertText": "someOpt {\n   | Some($1) => ${2:%todo}\n   | None => ${3:%todo}\n   }",
     "insertTextFormat": 2
   }]
 

--- a/tests/analysis_tests/tests/src/expected/RecordCompletion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/RecordCompletion.res.txt
@@ -11,19 +11,19 @@ ContextPath Value[t]
 Path t
 CPPipe pathFromEnv: found:true
 Path RecordCompletion.n
-Path Js.Array2.m
+Path Array.m
 [{
-    "label": "Js.Array2.mapi",
+    "label": "Array.map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The function acceps two arguments: an item from the array and its\nindex number. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\n// multiply each item in array by its position\nlet product = (item, index) => item * index\nJs.Array2.mapi([10, 11, 12], product) == [0, 11, 24]\n```\n"}
+    "detail": "(array<'a>, 'a => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`map(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray = array->Array.map(greeting => greeting ++ \" to you\")\n\nassertEqual(mappedArray, [\"Hello to you\", \"Hi to you\", \"Good bye to you\"])\n```\n"}
   }, {
-    "label": "Js.Array2.map",
+    "label": "Array.mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\nJs.Array2.map([12, 4, 8], x => x * x) == [144, 16, 64]\nJs.Array2.map([\"animal\", \"vegetable\", \"mineral\"], Js.String.length) == [6, 9, 7]\n```\n"}
+    "detail": "(array<'a>, ('a, int) => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray =\n  array->Array.mapWithIndex((greeting, index) =>\n    greeting ++ \" at position \" ++ Int.toString(index)\n  )\n\nassertEqual(mappedArray, [\"Hello at position 0\", \"Hi at position 1\", \"Good bye at position 2\"])\n```\n"}
   }]
 
 Complete src/RecordCompletion.res 11:13
@@ -51,19 +51,19 @@ CPPipe pathFromEnv: found:true
 Path RecordCompletion.n2
 CPPipe pathFromEnv: found:true
 Path RecordCompletion.n
-Path Js.Array2.m
+Path Array.m
 [{
-    "label": "Js.Array2.mapi",
+    "label": "Array.map",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The function acceps two arguments: an item from the array and its\nindex number. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\n// multiply each item in array by its position\nlet product = (item, index) => item * index\nJs.Array2.mapi([10, 11, 12], product) == [0, 11, 24]\n```\n"}
+    "detail": "(array<'a>, 'a => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`map(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray = array->Array.map(greeting => greeting ++ \" to you\")\n\nassertEqual(mappedArray, [\"Hello to you\", \"Hi to you\", \"Good bye to you\"])\n```\n"}
   }, {
-    "label": "Js.Array2.map",
+    "label": "Array.mapWithIndex",
     "kind": 12,
     "tags": [],
-    "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\nApplies the function (the second argument) to each item in the array, returning\na new array. The result array does not have to have elements of the same type\nas the input array. See\n[`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\non MDN.\n\n## Examples\n\n```rescript\nJs.Array2.map([12, 4, 8], x => x * x) == [144, 16, 64]\nJs.Array2.map([\"animal\", \"vegetable\", \"mineral\"], Js.String.length) == [6, 9, 7]\n```\n"}
+    "detail": "(array<'a>, ('a, int) => 'b) => array<'b>",
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(array, fn)` returns a new array with all elements from `array`, each element transformed using the provided `fn`.\n\nSee [`Array.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) on MDN.\n\n## Examples\n\n```rescript\nlet array = [\"Hello\", \"Hi\", \"Good bye\"]\nlet mappedArray =\n  array->Array.mapWithIndex((greeting, index) =>\n    greeting ++ \" at position \" ++ Int.toString(index)\n  )\n\nassertEqual(mappedArray, [\"Hello at position 0\", \"Hi at position 1\", \"Good bye at position 2\"])\n```\n"}
   }]
 
 Complete src/RecordCompletion.res 19:7


### PR DESCRIPTION
* Removes the `builtInModules` config concept, since Core is now in the compiler repo and Js/Belt is never to be preferred
* Moves all tests in analysis to use Core
* Removes/cleans up a few things/checks related to handling multiple versions of the ReScript compiler - the current editor tooling only ever deals with exactly the version of the compiler it's included in