### PR TITLE
Backport use TLS 1.2 to upload files to CDN using FTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix "rescript format" with many files. https://github.com/rescript-lang/rescript-compiler/pull/7081
 - Fix exponential notation syntax. https://github.com/rescript-lang/rescript/pull/7174
 - Fix formatter handling of wildcard in pattern matching records with no fields specified. https://github.com/rescript-lang/rescript/pull/7224
+- Fix files that were being truncated when sent to the CDN over FTP. https://github.com/rescript-lang/rescript/pull/7307
 
 #### :house: Internal
 

--- a/playground/upload_bundle.sh
+++ b/playground/upload_bundle.sh
@@ -32,7 +32,7 @@ fi
 PACKAGES=("compiler-builtins" "@rescript/react" "@rescript/core")
 
 echo "Uploading compiler.js file..."
-curl --ftp-create-dirs -T "${SCRIPT_DIR}/compiler.js" --ssl --netrc-file $NETRC_FILE ftp://${KEYCDN_SRV}/v${VERSION}/compiler.js
+curl --ftp-create-dirs -T "${SCRIPT_DIR}/compiler.js" --ssl --tls-max 1.2 --netrc-file $NETRC_FILE ftp://${KEYCDN_SRV}/v${VERSION}/compiler.js
 
 echo "---"
 echo "Uploading packages cmij files..."
@@ -43,7 +43,7 @@ do
 
   echo "Uploading '$SOURCE/cmij.js' to '$TARGET/cmij.js'..."
 
-  curl --ftp-create-dirs -T "${SOURCE}/cmij.js" --ssl --netrc-file $NETRC_FILE "${TARGET}/cmij.js"
+  curl --ftp-create-dirs -T "${SOURCE}/cmij.js" --ssl --tls-max 1.2 --netrc-file $NETRC_FILE "${TARGET}/cmij.js"
 done
 
 # we now upload the bundled stdlib runtime files
@@ -54,4 +54,6 @@ TARGET="ftp://${KEYCDN_SRV}/v${VERSION}/${DIR}"
 
 echo "Uploading '$SOURCE/*.js' to '$TARGET/*.js'..."
 
-find "${SOURCE}" -type f -name "*.js" -exec sh -c 'curl --ftp-create-dirs --ssl --netrc-file "$0" -T "$1" "${2}/$(basename "$1")"' "$NETRC_FILE" {} "$TARGET" \;
+# we use TLS 1.2 because 1.3 sometimes causes data losses (files capped at 16384B)
+# https://github.com/curl/curl/issues/6149#issuecomment-1618591420
+find "${SOURCE}" -type f -name "*.js" -exec sh -c 'curl --ftp-create-dirs --ssl --tls-max 1.2 --netrc-file "$0" -T "$1" "${2}/$(basename "$1")"' "$NETRC_FILE" {} "$TARGET" \;


### PR DESCRIPTION
example of such truncated files:
https://cdn.rescript-lang.org/v12.0.0-alpha.8/compiler-builtins/stdlib/Belt_MapInt.js