### PR TITLE
Fix recursive untagged variant type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - Deprecate JSON.Classify.classify. https://github.com/rescript-lang/rescript/pull/7315
 
+#### :bug: Bug fix
+
+- Fix recursive untagged variant type checking by delaying well-formedness checks until environment construction completes. [#7320](https://github.com/rescript-lang/rescript/pull/7320)
+
 # 12.0.0-alpha.9
 
 #### :boom: Breaking Change

--- a/compiler/ml/ast_untagged_variants.ml
+++ b/compiler/ml/ast_untagged_variants.ml
@@ -377,8 +377,12 @@ let names_from_type_variant ?(is_untagged_def = false) ~env
   let blocks = Ext_array.reverse_of_list blocks in
   Some {consts; blocks}
 
-let check_well_formed ~env ~is_untagged_def
-    (cstrs : Types.constructor_declaration list) =
+type well_formedness_check = {
+  is_untagged_def: bool;
+  cstrs: Types.constructor_declaration list;
+}
+
+let check_well_formed ~env {is_untagged_def; cstrs} =
   ignore (names_from_type_variant ~env ~is_untagged_def cstrs)
 
 let has_undefined_literal attrs = process_tag_type attrs = Some Undefined

--- a/tests/tests/src/UntaggedVariants.mjs
+++ b/tests/tests/src/UntaggedVariants.mjs
@@ -600,6 +600,12 @@ let ObjectAndNull = {
   printLength: printLength
 };
 
+let RecursiveType = {
+  o: {
+    foo: "hello"
+  }
+};
+
 let $$Array;
 
 let i = 42;
@@ -653,5 +659,6 @@ export {
   OnlyOne,
   MergeCases,
   ObjectAndNull,
+  RecursiveType,
 }
 /* l2 Not a pure module */

--- a/tests/tests/src/UntaggedVariants.res
+++ b/tests/tests/src/UntaggedVariants.res
@@ -469,3 +469,10 @@ module ObjectAndNull = {
     | _ => ()
     }
 }
+
+module RecursiveType = {
+  type rec object2 = {foo: string}
+  @unboxed and tagged2 = Object(object2) | Fn(unit => object2)
+
+  let o = Object({foo: "hello"})
+}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7314

- Delay untagged variant well-formedness checks until after environment construction
- Collect all untagged variant checks during type declaration processing
- Perform checks once all recursive types are available in the environment
- Add test case for valid recursive untagged variant type definitions

This fixes issues where recursive references in untagged variants would fail validation due to premature checking before the full type environment was built.