### PR TITLE
deprecate unsafe host-specific bindings from stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - Deprecate JSON.Classify.classify. https://github.com/rescript-lang/rescript/pull/7315
 - Hide stdlib modules in output. https://github.com/rescript-lang/rescript/pull/7305
+- Deprecate unsafe host-specific bindings from stdlib. https://github.com/rescript-lang/rescript/pull/7334
 
 #### :bug: Bug fix
 

--- a/runtime/Stdlib.res
+++ b/runtime/Stdlib.res
@@ -53,8 +53,8 @@ type null<+'a> = Primitive_js_extern.null<'a>
 type undefined<+'a> = Primitive_js_extern.undefined<'a>
 type nullable<+'a> = Primitive_js_extern.nullable<'a>
 
-@val external window: Dom.window = "window"
-@val external document: Dom.document = "document"
+@deprecated("Use rescript-webapi instead") @val external window: Dom.window = "window"
+@deprecated("Use rescript-webapi instead") @val external document: Dom.document = "document"
 @val external globalThis: {..} = "globalThis"
 
 /**


### PR DESCRIPTION
Fixes rescript-lang/rescript-core#240