### PR TITLE
Add some docs to stblib Symbol

### DIFF
--- a/packages/artifacts.txt
+++ b/packages/artifacts.txt
@@ -115,7 +115,6 @@ lib/es6/Jsx.js
 lib/es6/JsxDOM.js
 lib/es6/JsxDOMStyle.js
 lib/es6/JsxEvent.js
-lib/es6/JsxPPXReactSupport.js
 lib/es6/Lazy.js
 lib/es6/Obj.js
 lib/es6/Pervasives.js
@@ -287,7 +286,6 @@ lib/js/Jsx.js
 lib/js/JsxDOM.js
 lib/js/JsxDOMStyle.js
 lib/js/JsxEvent.js
-lib/js/JsxPPXReactSupport.js
 lib/js/Lazy.js
 lib/js/Obj.js
 lib/js/Pervasives.js
@@ -808,10 +806,6 @@ lib/ocaml/JsxEvent.cmi
 lib/ocaml/JsxEvent.cmj
 lib/ocaml/JsxEvent.cmt
 lib/ocaml/JsxEvent.res
-lib/ocaml/JsxPPXReactSupport.cmi
-lib/ocaml/JsxPPXReactSupport.cmj
-lib/ocaml/JsxPPXReactSupport.cmt
-lib/ocaml/JsxPPXReactSupport.res
 lib/ocaml/Lazy.cmi
 lib/ocaml/Lazy.cmj
 lib/ocaml/Lazy.cmt
@@ -1184,6 +1178,7 @@ lib/ocaml/Stdlib_Symbol.cmi
 lib/ocaml/Stdlib_Symbol.cmj
 lib/ocaml/Stdlib_Symbol.cmt
 lib/ocaml/Stdlib_Symbol.res
+lib/ocaml/Stdlib_Symbol.resi
 lib/ocaml/Stdlib_Type.cmi
 lib/ocaml/Stdlib_Type.cmj
 lib/ocaml/Stdlib_Type.cmt

--- a/packages/artifacts.txt
+++ b/packages/artifacts.txt
@@ -115,6 +115,7 @@ lib/es6/Jsx.js
 lib/es6/JsxDOM.js
 lib/es6/JsxDOMStyle.js
 lib/es6/JsxEvent.js
+lib/es6/JsxPPXReactSupport.js
 lib/es6/Lazy.js
 lib/es6/Obj.js
 lib/es6/Pervasives.js
@@ -286,6 +287,7 @@ lib/js/Jsx.js
 lib/js/JsxDOM.js
 lib/js/JsxDOMStyle.js
 lib/js/JsxEvent.js
+lib/js/JsxPPXReactSupport.js
 lib/js/Lazy.js
 lib/js/Obj.js
 lib/js/Pervasives.js
@@ -806,6 +808,10 @@ lib/ocaml/JsxEvent.cmi
 lib/ocaml/JsxEvent.cmj
 lib/ocaml/JsxEvent.cmt
 lib/ocaml/JsxEvent.res
+lib/ocaml/JsxPPXReactSupport.cmi
+lib/ocaml/JsxPPXReactSupport.cmj
+lib/ocaml/JsxPPXReactSupport.cmt
+lib/ocaml/JsxPPXReactSupport.res
 lib/ocaml/Lazy.cmi
 lib/ocaml/Lazy.cmj
 lib/ocaml/Lazy.cmt
@@ -1177,6 +1183,7 @@ lib/ocaml/Stdlib_String.resi
 lib/ocaml/Stdlib_Symbol.cmi
 lib/ocaml/Stdlib_Symbol.cmj
 lib/ocaml/Stdlib_Symbol.cmt
+lib/ocaml/Stdlib_Symbol.cmti
 lib/ocaml/Stdlib_Symbol.res
 lib/ocaml/Stdlib_Symbol.resi
 lib/ocaml/Stdlib_Type.cmi

--- a/runtime/Stdlib_Symbol.res
+++ b/runtime/Stdlib_Symbol.res
@@ -3,6 +3,9 @@ type t
 @val external make: string => t = "Symbol"
 @val external getFor: string => t = "Symbol.for"
 @val external keyFor: t => option<string> = "Symbol.keyFor"
+@get
+external description: t => option<string> = "description"
+@send external toString: t => string = "toString"
 
 @val external asyncIterator: t = "Symbol.asyncIterator"
 @val external hasInstance: t = "Symbol.hasInstance"

--- a/runtime/Stdlib_Symbol.res
+++ b/runtime/Stdlib_Symbol.res
@@ -1,7 +1,7 @@
 type t
 
 @val external make: string => t = "Symbol"
-@val external getFor: string => t = "Symbol.for"
+@val external getFor: string => option<t> = "Symbol.for"
 @val external keyFor: t => option<string> = "Symbol.keyFor"
 @get
 external description: t => option<string> = "description"

--- a/runtime/Stdlib_Symbol.res
+++ b/runtime/Stdlib_Symbol.res
@@ -1,22 +1,25 @@
 type t
 
 @val external make: string => t = "Symbol"
-@val external getFor: string => option<t> = "Symbol.for"
-@val external keyFor: t => option<string> = "Symbol.keyFor"
+@val @scope("Symbol")
+external getFor: string => option<t> = "for"
+@val @scope("Symbol") external keyFor: t => option<string> = "keyFor"
 @get
 external description: t => option<string> = "description"
 @send external toString: t => string = "toString"
 
-@val external asyncIterator: t = "Symbol.asyncIterator"
-@val external hasInstance: t = "Symbol.hasInstance"
-@val external isConcatSpreadable: t = "Symbol.isConcatSpreadable"
-@val external iterator: t = "Symbol.iterator"
-@val external match: t = "Symbol.match"
-@val external matchAll: t = "Symbol.matchAll"
-@val external replace: t = "Symbol.replace"
-@val external search: t = "Symbol.search"
-@val external species: t = "Symbol.species"
-@val external split: t = "Symbol.split"
-@val external toPrimitive: t = "Symbol.toPrimitive"
-@val external toStringTag: t = "Symbol.toStringTag"
-@val external unscopables: t = "Symbol.unscopables"
+@val @scope("Symbol")
+external asyncIterator: t = "asyncIterator"
+@val @scope("Symbol")
+external hasInstance: t = "hasInstance"
+@val @scope("Symbol") external isConcatSpreadable: t = "isConcatSpreadable"
+@val @scope("Symbol") external iterator: t = "iterator"
+@val @scope("Symbol") external match: t = "match"
+@val @scope("Symbol") external matchAll: t = "matchAll"
+@val @scope("Symbol") external replace: t = "replace"
+@val @scope("Symbol") external search: t = "search"
+@val @scope("Symbol") external species: t = "species"
+@val @scope("Symbol") external split: t = "split"
+@val @scope("Symbol") external toPrimitive: t = "toPrimitive"
+@val @scope("Symbol") external toStringTag: t = "toStringTag"
+@val @scope("Symbol") external unscopables: t = "unscopables"

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -17,7 +17,7 @@ Makes a new unique Symbol value.
 ## Examples
 
 ```rescript
-let sym = Symbol.make("foo")
+Symbol.make("sym1")->assetEqual("sym1")
 ```
 */
 @val
@@ -32,7 +32,7 @@ Otherwise a new Symbol gets created and registered with key.
 ## Examples
 
 ```rescript
-let sym = Symbol.getFor("foo")
+Symbol.getFor("foo")->assetEqual("foo")
 ```
 */
 @val

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -17,7 +17,7 @@ Makes a new unique Symbol value.
 ## Examples
 
 ```rescript
-Symbol.make("sym1")
+let _ Symbol.make("sym1")
 ->Symbol.description
 ->assertEqual(Some("sym1"))
 ```
@@ -25,70 +25,15 @@ Symbol.make("sym1")
 @val
 external make: string => t = "Symbol"
 
-/**
-`getFor(key)`
-
-Searches for existing registered Symbols in the global Symbol registry with the given key and returns it if found. 
-Otherwise a new Symbol gets created and registered with key.
-
-## Examples
-
-```rescript
-Symbol.getFor("sym1")->assertEqual(Symbol.getFor("sym1"))
-```
-*/
-@val
-@scope("Symbol")
+@val @scope("Symbol")
 external getFor: string => option<t> = "for"
 
-/**
-`keyFor(key)`
-
-Retrieves a shared Symbol key from the global Symbol registry for the given Symbol.
-
-## Examples
-
-```rescript
-let globalSym = Symbol.getFor("sym1") // Global symbol
-
-globalSym->Option.flatMap(Symbol.description)->assertEqual(Some("sym1"))
-
-let localSym = Symbol.make("sym2") // Local symbol
-
-localSym->Option.flatMap(Symbol.description)->assertEqual(None)
-```
-*/
-@val
-@scope("Symbol")
+@val @scope("Symbol")
 external keyFor: t => option<string> = "keyFor"
 
-/**
-`description`
-
-Returns `Some(string)` containing the description of this symbol, or `None` if the symbol has no description.
-## Examples
-
-```rescript
-let sym = Symbol.make("sym1")
-Symbol.description(sym)->assertEqual(Some("sym1"))
-```
-*/
 @get
 external description: t => option<string> = "description"
 
-/**
-`toString`
-
-// Returns a string representing this symbol value.
-
-## Examples
-
-```rescript
-let sym = Symbol.make("sym1")
-
-Symbol.toString(sym)->assertEqual("Symbol(sym1)")
-```
-*/
 @send
 external toString: t => string = "toString"
 

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -17,7 +17,9 @@ Makes a new unique Symbol value.
 ## Examples
 
 ```rescript
-Symbol.make("sym1")->assertEqual("sym1")
+Symbol.make("sym1")
+->Symbol.description
+->assertEqual(Some("sym1"))
 ```
 */
 @val
@@ -49,11 +51,11 @@ Retrieves a shared Symbol key from the global Symbol registry for the given Symb
 ```rescript
 let globalSym = Symbol.getFor("sym1") // Global symbol
 
-Symbol.keyFor(globalSym)->assertEqual(Some("sym1"))
+globalSym->Option.flatMap(Symbol.description)->assertEqual(Some("sym1"))
 
 let localSym = Symbol.make("sym2") // Local symbol
 
-Symbol.keyFor(localSym)->assertEqual(None)
+localSym->Option.flatMap(Symbol.description)->assertEqual(None)
 ```
 */
 @val

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -1,0 +1,107 @@
+/***
+A built-in object that serves as a namespace for globally-unique identifiers.
+
+Compiles to a regular JavaScript Symbol.
+*/
+
+/**
+Type representing a Symbol.
+*/
+type t
+
+/**
+`make(key)`
+
+Makes a new unique Symbol value.
+
+## Examples
+
+```rescript
+let sym = Symbol.make("foo")
+```
+*/
+@val
+external make: string => t = "Symbol"
+
+/**
+`getFor(key)`
+
+Searches for existing registered Symbols in the global Symbol registry with the given key and returns it if found. 
+Otherwise a new Symbol gets created and registered with key.
+
+## Examples
+
+```rescript
+let sym = Symbol.getFor("foo")
+```
+*/
+@val
+external getFor: string => t = "Symbol.for"
+
+/**
+`keyFor(key)`
+
+Retrieves a shared Symbol key from the global Symbol registry for the given Symbol.
+
+## Examples
+
+```rescript
+let globalSym = Symbol.getFor("sym1") // Global symbol
+
+Console.log(Symbol.keyFor(globalSym))
+// Expected output: "sym1"
+
+let localSym = Symbol.make("sym2") // Local symbol
+
+Console.log(Symbol.keyFor(localSym))
+// Expected output: undefined
+```
+*/
+@val
+external keyFor: t => option<string> = "Symbol.keyFor"
+
+/**
+`description`
+
+Returns `Some(string)` containing the description of this symbol, or `None` if the symbol has no description.
+## Examples
+
+```rescript
+let sym = Symbol.make("foo")
+Console.log(sym->Symbol.description)
+```
+*/
+@get
+external description: t => option<string> = "description"
+
+/**
+`toString`
+
+// Returns a string representing this symbol value.
+
+## Examples
+
+```rescript
+let sym = Symbol.make("foo")
+Console.log(sym->Symbol.toString) 
+// Expected output: "Symbol(foo)"
+```
+*/
+@send
+external toString: t => string = "toString"
+
+@val
+external asyncIterator: t = "Symbol.asyncIterator"
+@val
+external hasInstance: t = "Symbol.hasInstance"
+@val external isConcatSpreadable: t = "Symbol.isConcatSpreadable"
+@val external iterator: t = "Symbol.iterator"
+@val external match: t = "Symbol.match"
+@val external matchAll: t = "Symbol.matchAll"
+@val external replace: t = "Symbol.replace"
+@val external search: t = "Symbol.search"
+@val external species: t = "Symbol.species"
+@val external split: t = "Symbol.split"
+@val external toPrimitive: t = "Symbol.toPrimitive"
+@val external toStringTag: t = "Symbol.toStringTag"
+@val external unscopables: t = "Symbol.unscopables"

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -17,7 +17,7 @@ Makes a new unique Symbol value.
 ## Examples
 
 ```rescript
-Symbol.make("sym1")->assetEqual("sym1")
+Symbol.make("sym1")->assertEqual("sym1")
 ```
 */
 @val
@@ -32,11 +32,12 @@ Otherwise a new Symbol gets created and registered with key.
 ## Examples
 
 ```rescript
-Symbol.getFor("sym1")->assetEqual(Symbol.getFor("sym1"))
+Symbol.getFor("sym1")->assertEqual(Symbol.getFor("sym1"))
 ```
 */
 @val
-external getFor: string => t = "Symbol.for"
+@scope("Symbol")
+external getFor: string => option<t> = "for"
 
 /**
 `keyFor(key)`
@@ -56,7 +57,8 @@ Symbol.keyFor(localSym)->assertEqual(None)
 ```
 */
 @val
-external keyFor: t => option<string> = "Symbol.keyFor"
+@scope("Symbol")
+external keyFor: t => option<string> = "keyFor"
 
 /**
 `description`
@@ -88,18 +90,18 @@ Symbol.toString(sym)->assertEqual("Symbol(sym1)")
 @send
 external toString: t => string = "toString"
 
-@val
-external asyncIterator: t = "Symbol.asyncIterator"
-@val
-external hasInstance: t = "Symbol.hasInstance"
-@val external isConcatSpreadable: t = "Symbol.isConcatSpreadable"
-@val external iterator: t = "Symbol.iterator"
-@val external match: t = "Symbol.match"
-@val external matchAll: t = "Symbol.matchAll"
-@val external replace: t = "Symbol.replace"
-@val external search: t = "Symbol.search"
-@val external species: t = "Symbol.species"
-@val external split: t = "Symbol.split"
-@val external toPrimitive: t = "Symbol.toPrimitive"
-@val external toStringTag: t = "Symbol.toStringTag"
-@val external unscopables: t = "Symbol.unscopables"
+@val @scope("Symbol")
+external asyncIterator: t = "asyncIterator"
+@val @scope("Symbol")
+external hasInstance: t = "hasInstance"
+@val @scope("Symbol") external isConcatSpreadable: t = "isConcatSpreadable"
+@val @scope("Symbol") external iterator: t = "iterator"
+@val @scope("Symbol") external match: t = "match"
+@val @scope("Symbol") external matchAll: t = "matchAll"
+@val @scope("Symbol") external replace: t = "replace"
+@val @scope("Symbol") external search: t = "search"
+@val @scope("Symbol") external species: t = "species"
+@val @scope("Symbol") external split: t = "split"
+@val @scope("Symbol") external toPrimitive: t = "toPrimitive"
+@val @scope("Symbol") external toStringTag: t = "toStringTag"
+@val @scope("Symbol") external unscopables: t = "unscopables"

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -65,8 +65,8 @@ Returns `Some(string)` containing the description of this symbol, or `None` if t
 ## Examples
 
 ```rescript
-let sym = Symbol.make("foo")
-Console.log(sym->Symbol.description)
+let sym = Symbol.make("sym1")
+Symbol.description(sym)->assertEqual(Some("sym1"))
 ```
 */
 @get
@@ -80,9 +80,9 @@ external description: t => option<string> = "description"
 ## Examples
 
 ```rescript
-let sym = Symbol.make("foo")
-Console.log(sym->Symbol.toString) 
-// Expected output: "Symbol(foo)"
+let sym = Symbol.make("sym1")
+
+Symbol.toString(sym)->assertEqual("Symbol(sym1)")
 ```
 */
 @send

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -32,7 +32,7 @@ Otherwise a new Symbol gets created and registered with key.
 ## Examples
 
 ```rescript
-Symbol.getFor("foo")->assetEqual("foo")
+Symbol.getFor("sym1")->assetEqual(Symbol.getFor("sym1"))
 ```
 */
 @val
@@ -48,13 +48,11 @@ Retrieves a shared Symbol key from the global Symbol registry for the given Symb
 ```rescript
 let globalSym = Symbol.getFor("sym1") // Global symbol
 
-Console.log(Symbol.keyFor(globalSym))
-// Expected output: "sym1"
+Symbol.keyFor(globalSym)->assertEqual(Some("sym1"))
 
 let localSym = Symbol.make("sym2") // Local symbol
 
-Console.log(Symbol.keyFor(localSym))
-// Expected output: undefined
+Symbol.keyFor(localSym)->assertEqual(None)
 ```
 */
 @val

--- a/runtime/Stdlib_Symbol.resi
+++ b/runtime/Stdlib_Symbol.resi
@@ -17,7 +17,7 @@ Makes a new unique Symbol value.
 ## Examples
 
 ```rescript
-let _ Symbol.make("sym1")
+Symbol.make("sym1")
 ->Symbol.description
 ->assertEqual(Some("sym1"))
 ```
@@ -25,15 +25,66 @@ let _ Symbol.make("sym1")
 @val
 external make: string => t = "Symbol"
 
-@val @scope("Symbol")
+/**
+`getFor(key)`
+
+Searches for existing registered Symbols in the global Symbol registry with the given key and returns it if found. 
+Otherwise a new Symbol gets created and registered with key.
+
+## Examples
+
+```rescript
+Symbol.getFor("sym1")->assertEqual(Symbol.getFor("sym1"))
+```
+*/
+@val
+@scope("Symbol")
 external getFor: string => option<t> = "for"
 
-@val @scope("Symbol")
+/**
+`keyFor(key)`
+
+Retrieves a shared Symbol key from the global Symbol registry for the given Symbol.
+
+## Examples
+
+```rescript
+let globalSym = Symbol.getFor("sym1") // Global symbol
+
+globalSym->Option.flatMap(Symbol.description)->assertEqual(Some("sym1"))
+```
+*/
+@val
+@scope("Symbol")
 external keyFor: t => option<string> = "keyFor"
 
+/**
+`description`
+
+Returns `Some(string)` containing the description of this symbol, or `None` if the symbol has no description.
+## Examples
+
+```rescript
+let sym = Symbol.make("sym1")
+Symbol.description(sym)->assertEqual(Some("sym1"))
+```
+*/
 @get
 external description: t => option<string> = "description"
 
+/**
+`toString`
+
+// Returns a string representing this symbol value.
+
+## Examples
+
+```rescript
+let sym = Symbol.make("sym1")
+
+Symbol.toString(sym)->assertEqual("Symbol(sym1)")
+```
+*/
 @send
 external toString: t => string = "toString"
 


### PR DESCRIPTION
This adds a `.resi` file for `Stdlib_Symbol` with documentation for most of the common uses for Symbols. I added a `description` and `toString` to the bindings.

A good chunk of what Symbols are used for aren't really applicable or possible with ReScript, such as the static [properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#static_properties). I'm not sure if there is value in including those bindings in the stdlib, but for now I just omitted documentation.