### PR TITLE
Update opam install command to correct flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ opam init
 opam switch create 5.3.0
 
 # Install dev dependencies from OPAM
-opam install . --deps-only --with-test --with-dev-setup -y
+opam install . --deps-only --with-test -y
 ```
 
 #### npm install


### PR DESCRIPTION
I noticed while following the setup steps that one of the flags was no longer correct.

```
$ opam install . --deps-only --with-test --with-dev-setup -y

opam: unknown option `--with-dev-setup', did you mean `-w' ?
Usage: opam install [OPTION]... [PACKAGES]...
Try `opam install --help' or `opam --help' for more information.
```

From what I can tell that flag is no longer needed: https://github.com/ocaml/dune/issues/10538