### PR TITLE
[PoC] Injectable source loc arg

### DIFF
--- a/compiler/ml/lambda.mli
+++ b/compiler/ml/lambda.mli
@@ -17,7 +17,14 @@
 
 open Asttypes
 
-type loc_kind = Loc_FILE | Loc_LINE | Loc_MODULE | Loc_LOC | Loc_POS
+type loc_kind =
+  | Loc_FILE
+  | Loc_LINE
+  | Loc_MODULE
+  | Loc_MODULE_PATH
+  | Loc_VALUE_PATH
+  | Loc_LOC
+  | Loc_POS
 
 type tag_info =
   | Blk_constructor of {
@@ -415,4 +422,9 @@ val is_guarded : lambda -> bool
 val patch_guarded : lambda -> lambda -> lambda
 
 val raise_kind : raise_kind -> string
-val lam_of_loc : loc_kind -> Location.t -> lambda
+val lam_of_loc :
+  ?root_path:Path.t ->
+  ?current_value_ident:Ident.t ->
+  loc_kind ->
+  Location.t ->
+  lambda

--- a/compiler/ml/predef.ml
+++ b/compiler/ml/predef.ml
@@ -51,6 +51,8 @@ and ident_result = ident_create "result"
 
 and ident_dict = ident_create "dict"
 
+and ident_source_loc = ident_create "sourceLoc"
+
 and ident_bigint = ident_create "bigint"
 
 and ident_lazy_t = ident_create "lazy_t"
@@ -97,6 +99,8 @@ and path_option = Pident ident_option
 and path_result = Pident ident_result
 
 and path_dict = Pident ident_dict
+
+and path_source_loc = Pident ident_source_loc
 
 and path_bigint = Pident ident_bigint
 
@@ -318,6 +322,32 @@ let common_initial_env add_type add_extension empty_env =
             ],
             Record_regular );
     }
+  and decl_source_loc =
+    {
+      decl_abstr with
+      type_kind =
+        (let mk_field name typ =
+           {
+             ld_id = ident_create name;
+             ld_attributes = [];
+             ld_loc = Location.none;
+             ld_mutable = Immutable;
+             ld_optional = false;
+             ld_type = typ;
+           }
+         in
+         Type_record
+           ( [
+               (* __FILE__ *)
+               mk_field "filename" type_string;
+               (* __MODULE__ *)
+               mk_field "module_" type_string;
+               (* __POS__ *)
+               mk_field "pos"
+                 (newgenty (Ttuple [type_string; type_int; type_int; type_int]));
+             ],
+             Record_regular ));
+    }
   and decl_uncurried =
     let tvar1 = newgenvar () in
     {
@@ -402,6 +432,7 @@ let common_initial_env add_type add_extension empty_env =
   |> add_type ident_array decl_array
   |> add_type ident_list decl_list
   |> add_type ident_dict decl_dict
+  |> add_type ident_source_loc decl_source_loc
   |> add_type ident_unknown decl_unknown
   |> add_exception ident_undefined_recursive_module
        [newgenty (Ttuple [type_string; type_int; type_int])]

--- a/compiler/ml/predef.ml
+++ b/compiler/ml/predef.ml
@@ -345,6 +345,10 @@ let common_initial_env add_type add_extension empty_env =
                (* __POS__ *)
                mk_field "pos"
                  (newgenty (Ttuple [type_string; type_int; type_int; type_int]));
+               (* __MODULE_PATH__ *)
+               mk_field "modulePath" type_string;
+               (* __VALUE_PATH__ *)
+               mk_field "valuePath" type_string;
              ],
              Record_regular ));
     }

--- a/compiler/ml/predef.mli
+++ b/compiler/ml/predef.mli
@@ -46,6 +46,7 @@ val path_list : Path.t
 val path_option : Path.t
 val path_result : Path.t
 val path_dict : Path.t
+val path_source_loc : Path.t
 
 val path_bigint : Path.t
 val path_lazy_t : Path.t

--- a/compiler/ml/printlambda.ml
+++ b/compiler/ml/printlambda.ml
@@ -55,6 +55,8 @@ let string_of_loc_kind = function
   | Loc_FILE -> "loc_FILE"
   | Loc_LINE -> "loc_LINE"
   | Loc_MODULE -> "loc_MODULE"
+  | Loc_MODULE_PATH -> "loc_MODULE_PATH"
+  | Loc_VALUE_PATH -> "loc_VALUE_PATH"
   | Loc_POS -> "loc_POS"
   | Loc_LOC -> "loc_LOC"
 

--- a/compiler/ml/translcore.mli
+++ b/compiler/ml/translcore.mli
@@ -41,3 +41,6 @@ val transl_module :
   Typedtree.module_expr ->
   Lambda.lambda)
   ref
+
+val current_root_path : Path.t option ref
+val current_value_ident : Ident.t option ref

--- a/compiler/ml/translmod.ml
+++ b/compiler/ml/translmod.ml
@@ -253,6 +253,13 @@ let rec compile_functor mexp coercion root_path loc =
 
 (* Compile a module expression *)
 and transl_module cc rootpath mexp =
+  let current_root_path = !Translcore.current_root_path in
+  Translcore.current_root_path := rootpath;
+  let res = transl_module_inner cc rootpath mexp in
+  Translcore.current_root_path := current_root_path;
+  res
+
+and transl_module_inner cc rootpath mexp =
   List.iter (Translattribute.check_attribute_on_module mexp) mexp.mod_attributes;
   let loc = mexp.mod_loc in
   match mexp.mod_type with

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -2254,6 +2254,8 @@ let expand_injectable_args ~(apply_expr : Parsetree.expression) ~exp_type
               mk_source_loc_field "filename" "__FILE__";
               mk_source_loc_field "module_" "__MODULE__";
               mk_source_loc_field "pos" "__POS__";
+              mk_source_loc_field "modulePath" "__MODULE_PATH__";
+              mk_source_loc_field "valuePath" "__VALUE_PATH__";
             ]
             None );
       ]

--- a/runtime/Pervasives.res
+++ b/runtime/Pervasives.res
@@ -34,6 +34,8 @@ external __LOC__: string = "%loc_LOC"
 external __FILE__: string = "%loc_FILE"
 external __LINE__: int = "%loc_LINE"
 external __MODULE__: string = "%loc_MODULE"
+external __MODULE_PATH__: string = "%loc_MODULE_PATH"
+external __VALUE_PATH__: string = "%loc_VALUE_PATH"
 external __POS__: (string, int, int, int) = "%loc_POS"
 
 external __LOC_OF__: 'a => (string, 'a) = "%loc_LOC"

--- a/runtime/Pervasives_mini.res
+++ b/runtime/Pervasives_mini.res
@@ -7,6 +7,8 @@ external __LOC__: string = "%loc_LOC"
 external __FILE__: string = "%loc_FILE"
 external __LINE__: int = "%loc_LINE"
 external __MODULE__: string = "%loc_MODULE"
+external __MODULE_PATH__: string = "%loc_MODULE_PATH"
+external __VALUE_PATH__: string = "%loc_VALUE_PATH"
 external __POS__: (string, int, int, int) = "%loc_POS"
 
 external __LOC_OF__: 'a => (string, 'a) = "%loc_LOC"

--- a/tests/tests/src/test_per.res
+++ b/tests/tests/src/test_per.res
@@ -19,6 +19,8 @@ external __LOC__: string = "%loc_LOC"
 external __MODULE__: string = "%loc_FILE"
 external __LINE__: int = "%loc_LINE"
 external __MODULE__: string = "%loc_MODULE"
+external __MODULE_PATH__: string = "%loc_MODULE_PATH"
+external __VALUE_PATH__: string = "%loc_VALUE_PATH"
 external __POS__: (string, int, int, int) = "%loc_POS"
 
 external __LOC_OF__: 'a => (string, 'a) = "%loc_LOC"


### PR DESCRIPTION
100% inspired by MoonBit's [autofill `SourceLoc` function argument](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#autofill-arguments), this makes it possible to inject a labelled argument to any function, and as long as it's required and has the type of `sourceLoc` (a builtin type), each call to that function will inject a bunch of information about _the call site_, without needing to pass that argument explicitly.

This is useful in many different scenarios, like for example logging (see [`rescript-logger`](https://github.com/shakacode/rescript-logger) which does the same, but with a PPX), tests, error reporting, and so on.

Example:
**`Tst.res`**
```rescript
let someFn = (name: string, ~loc: sourceLoc) => {
  "Hello " ++ name ++ " from " ++ loc.valuePath
}
```
```javascript
// Generated by ReScript, PLEASE EDIT WITH CARE


function someFn(name, loc) {
  return "Hello " + name + " from " + loc.valuePath;
}

export {
  someFn,
}
/* No side effect */

```

**`OtherFile.res`**
```rescript
module SomeModule = {
  let someName = Tst.someFn("from SomeModule")
}

```
```javascript
// Generated by ReScript, PLEASE EDIT WITH CARE

import * as Tst from "./Tst.bs.js";

let someName = Tst.someFn("from SomeModule", {
  filename: "OtherFile.res",
  module_: "OtherFile",
  pos: [
    "OtherFile.res",
    2,
    17,
    46
  ],
  modulePath: "OtherFile.SomeModule",
  valuePath: "OtherFile.SomeModule.someName"
});

let SomeModule = {
  someName: someName
};

export {
  SomeModule,
}
/* someName Not a pure module */

```

The `sourceLoc` type looks like this:
```rescript
type sourceLoc = {
  filename: string, // __FILE__
  module_: string, // __MODULE__
  pos: (string, int, int, int), // __POS__
  modulePath: string, // __MODULE_PATH__
  valuePath: string, // __VALUE_PATH__
}
```

### `__MODULE_PATH__` and `__VALUE_PATH__`
In order to make the information as useful as possible, I've also added 2 new "magic" constants:
- `__MODULE_PATH__` will return the path to the _current module_. So, if you're in `MyModule` inside of `SomeFile.res`, you'll get `SomeFile.MyModule`.
- `__VALUE_PATH__`, which does the same as `__MODULE_PATH__`, just that it also appends the _value_ you're currently in. So, if you're `MyModule` in `SomeFile.res`, and inside of a let binding called `myFunction`, you'll get `SomeFile.MyModule.myFunction`.

## Questions
Are what I've added so far enough? Do we want more/less information? Other things to think/worry about?

## Things left to figure out
- [ ] Figure out toplevel, which does not work right now
- [ ] Figure out the editor tooling - do we just hide injectable args? 
- [ ] Editor tooling - completions etc for `sourceLoc` which is a builtin
- [ ] Tests, docs, etc