### PR TITLE
Stdlib: rename binary operations to match JavaScript terms

### DIFF
--- a/lib/es6/Stdlib_BigInt.js
+++ b/lib/es6/Stdlib_BigInt.js
@@ -5,12 +5,12 @@ function toInt(t) {
   return Number(t) | 0;
 }
 
-function lnot(x) {
+function bitwiseNot(x) {
   return x ^ -1n;
 }
 
 export {
   toInt,
-  lnot,
+  bitwiseNot,
 }
 /* No side effect */

--- a/lib/es6/Stdlib_Int.js
+++ b/lib/es6/Stdlib_Int.js
@@ -62,13 +62,9 @@ function clamp(min, max, value) {
   }
 }
 
-function lnot(x) {
+function bitwiseNot(x) {
   return x ^ -1;
 }
-
-let Bitwise = {
-  lnot: lnot
-};
 
 let Constants = {
   minValue: -2147483648,
@@ -81,6 +77,6 @@ export {
   range,
   rangeWithOptions,
   clamp,
-  Bitwise,
+  bitwiseNot,
 }
 /* No side effect */

--- a/lib/js/Stdlib_BigInt.js
+++ b/lib/js/Stdlib_BigInt.js
@@ -5,10 +5,10 @@ function toInt(t) {
   return Number(t) | 0;
 }
 
-function lnot(x) {
+function bitwiseNot(x) {
   return x ^ -1n;
 }
 
 exports.toInt = toInt;
-exports.lnot = lnot;
+exports.bitwiseNot = bitwiseNot;
 /* No side effect */

--- a/lib/js/Stdlib_Int.js
+++ b/lib/js/Stdlib_Int.js
@@ -62,13 +62,9 @@ function clamp(min, max, value) {
   }
 }
 
-function lnot(x) {
+function bitwiseNot(x) {
   return x ^ -1;
 }
-
-let Bitwise = {
-  lnot: lnot
-};
 
 let Constants = {
   minValue: -2147483648,
@@ -80,5 +76,5 @@ exports.fromString = fromString;
 exports.range = range;
 exports.rangeWithOptions = rangeWithOptions;
 exports.clamp = clamp;
-exports.Bitwise = Bitwise;
+exports.bitwiseNot = bitwiseNot;
 /* No side effect */

--- a/runtime/Stdlib_BigInt.res
+++ b/runtime/Stdlib_BigInt.res
@@ -91,9 +91,6 @@ external bitwiseXor: (bigint, bigint) => bigint = "%xorbigint"
 // TODO: make it a primitive
 let bitwiseNot = x => bitwiseXor(x, -1n)
 
-external lsl: (bigint, bigint) => bigint = "%lslbigint"
-external asr: (bigint, bigint) => bigint = "%asrbigint"
-
 external shiftLeft: (bigint, bigint) => bigint = "%lslbigint"
 external shiftRight: (bigint, bigint) => bigint = "%asrbigint"
 

--- a/runtime/Stdlib_BigInt.res
+++ b/runtime/Stdlib_BigInt.res
@@ -84,14 +84,18 @@ external div: (bigint, bigint) => bigint = "%divbigint"
 
 external mod: (bigint, bigint) => bigint = "%modbigint"
 
-external land: (bigint, bigint) => bigint = "%andbigint"
-external lor: (bigint, bigint) => bigint = "%orbigint"
-external lxor: (bigint, bigint) => bigint = "%xorbigint"
+external bitwiseAnd: (bigint, bigint) => bigint = "%andbigint"
+external bitwiseOr: (bigint, bigint) => bigint = "%orbigint"
+external bitwiseXor: (bigint, bigint) => bigint = "%xorbigint"
+
+// TODO: make it a primitive
+let bitwiseNot = x => bitwiseXor(x, -1n)
 
 external lsl: (bigint, bigint) => bigint = "%lslbigint"
 external asr: (bigint, bigint) => bigint = "%asrbigint"
 
-let lnot = x => lxor(x, -1n)
+external leftShift: (bigint, bigint) => bigint = "%lslbigint"
+external rightShift: (bigint, bigint) => bigint = "%asrbigint"
 
 /**
   `ignore(bigint)` ignores the provided bigint and returns unit.

--- a/runtime/Stdlib_BigInt.res
+++ b/runtime/Stdlib_BigInt.res
@@ -94,8 +94,8 @@ let bitwiseNot = x => bitwiseXor(x, -1n)
 external lsl: (bigint, bigint) => bigint = "%lslbigint"
 external asr: (bigint, bigint) => bigint = "%asrbigint"
 
-external leftShift: (bigint, bigint) => bigint = "%lslbigint"
-external rightShift: (bigint, bigint) => bigint = "%asrbigint"
+external shiftLeft: (bigint, bigint) => bigint = "%lslbigint"
+external shiftRight: (bigint, bigint) => bigint = "%asrbigint"
 
 /**
   `ignore(bigint)` ignores the provided bigint and returns unit.

--- a/runtime/Stdlib_Int.res
+++ b/runtime/Stdlib_Int.res
@@ -102,8 +102,8 @@ external bitwiseXor: (int, int) => int = "%xorint"
 // TODO: make it a primitive
 let bitwiseNot = x => bitwiseXor(x, -1)
 
-external leftShift: (int, int) => int = "%lslint"
-external rightShift: (int, int) => int = "%asrint"
-external unsignedRightShift: (int, int) => int = "%lsrint"
+external shiftLeft: (int, int) => int = "%lslint"
+external shiftRight: (int, int) => int = "%asrint"
+external shiftRightUnsigned: (int, int) => int = "%lsrint"
 
 external ignore: int => unit = "%ignore"

--- a/runtime/Stdlib_Int.res
+++ b/runtime/Stdlib_Int.res
@@ -95,16 +95,15 @@ let clamp = (~min=?, ~max=?, value): int => {
   }
 }
 
-module Bitwise = {
-  external land: (int, int) => int = "%andint"
-  external lor: (int, int) => int = "%orint"
-  external lxor: (int, int) => int = "%xorint"
+external bitwiseAnd: (int, int) => int = "%andint"
+external bitwiseOr: (int, int) => int = "%orint"
+external bitwiseXor: (int, int) => int = "%xorint"
 
-  external lsl: (int, int) => int = "%lslint"
-  external lsr: (int, int) => int = "%lsrint"
-  external asr: (int, int) => int = "%asrint"
+// TODO: make it a primitive
+let bitwiseNot = x => bitwiseXor(x, -1)
 
-  let lnot = x => lxor(x, -1)
-}
+external leftShift: (int, int) => int = "%lslint"
+external rightShift: (int, int) => int = "%asrint"
+external unsignedRightShift: (int, int) => int = "%lsrint"
 
 external ignore: int => unit = "%ignore"

--- a/runtime/Stdlib_Int.resi
+++ b/runtime/Stdlib_Int.resi
@@ -438,31 +438,31 @@ Int.bitwiseNot(2) == -3
 let bitwiseNot: int => int
 
 /**
-`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.
+`shiftLeft(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.
 
 ## Examples
 
 ```rescript
-Int.leftShift(4, 1) == 8
+Int.shiftLeft(4, 1) == 8
 ```
 */
-external leftShift: (int, int) => int = "%lslint"
+external shiftLeft: (int, int) => int = "%lslint"
 
 /**
-`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
+`shiftRight(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
 
 Also known as "arithmetic right shift" operation.
 
 ## Examples
 
 ```rescript
-Int.rightShift(8, 1) == 4
+Int.shiftRight(8, 1) == 4
 ```
 */
-external rightShift: (int, int) => int = "%asrint"
+external shiftRight: (int, int) => int = "%asrint"
 
 /**
-`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
+`shiftRightUnsigned(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
 Excess bits shifted off to the right are discarded, and zero bits are shifted in from the left.
 
 Also known as "zero-filling right shift" operation.
@@ -470,10 +470,10 @@ Also known as "zero-filling right shift" operation.
 ## Examples
 
 ```rescript
-Int.unsignedRightShift(4, 1) == 2
+Int.shiftRightUnsigned(4, 1) == 2
 ```
 */
-external unsignedRightShift: (int, int) => int = "%lsrint"
+external shiftRightUnsigned: (int, int) => int = "%lsrint"
 
 /**
   `ignore(int)` ignores the provided int and returns unit.

--- a/runtime/Stdlib_Int.resi
+++ b/runtime/Stdlib_Int.resi
@@ -393,84 +393,87 @@ Int.clamp(42, ~min=50, ~max=40) == 50
 */
 let clamp: (~min: int=?, ~max: int=?, int) => int
 
-module Bitwise: {
-  /**
-  `land(n1, n2)` calculates the bitwise logical AND of two integers.
+/**
+`bitwiseAnd(n1, n2)` calculates the bitwise AND of two integers.
 
-  ## Examples
+## Examples
 
-  ```rescript
-  Int.Bitwise.land(7, 4) == 4
-  ```
-  */
-  external land: (int, int) => int = "%andint"
+```rescript
+Int.bitwiseAnd(7, 4) == 4
+```
+*/
+external bitwiseAnd: (int, int) => int = "%andint"
 
-  /**
-  `lor(n1, n2)` calculates the bitwise logical OR of two integers.
+/**
+`bitwiseOr(n1, n2)` calculates the bitwise OR of two integers.
 
-  ## Examples
+## Examples
 
-  ```rescript
-  Int.Bitwise.lor(7, 4) == 7
-  ```
-  */
-  external lor: (int, int) => int = "%orint"
+```rescript
+Int.bitwiseOr(7, 4) == 7
+```
+*/
+external bitwiseOr: (int, int) => int = "%orint"
 
-  /**
-  `lxor(n1, n2)` calculates the bitwise logical XOR of two integers.
+/**
+`bigwiseXor(n1, n2)` calculates the bitwise XOR of two integers.
 
-  ## Examples
+## Examples
 
-  ```rescript
-  Int.Bitwise.lxor(7, 4) == 3
-  ```
-  */
-  external lxor: (int, int) => int = "%xorint"
+```rescript
+Int.bitwiseXor(7, 4) == 3
+```
+*/
+external bitwiseXor: (int, int) => int = "%xorint"
 
-  /**
-  `lnot(n)` calculates the bitwise logical NOT of an integer.
+/**
+`bitwiseNot(n)` calculates the bitwise NOT of an integer.
 
-  ## Examples
+## Examples
 
-  ```rescript
-  Int.Bitwise.lnot(2) == -3
-  ```
-  */
-  let lnot: int => int
+```rescript
+Int.bitwiseNot(2) == -3
+```
+*/
+let bitwiseNot: int => int
 
-  /**
-  `lsl(n, length)` calculates the bitwise logical left shift of an integer `n` by `length`.
+/**
+`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.
 
-  ## Examples
+## Examples
 
-  ```rescript
-  Int.Bitwise.lsl(4, 1) == 8
-  ```
-  */
-  external lsl: (int, int) => int = "%lslint"
+```rescript
+Int.leftShift(4, 1) == 8
+```
+*/
+external leftShift: (int, int) => int = "%lslint"
 
-  /**
-  `lsr(n, length)` calculates the bitwise logical right shift of an integer `n` by `length`.
+/**
+`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
 
-  ## Examples
+Also known as "arithmetic right shift" operation.
 
-  ```rescript
-  Int.Bitwise.lsr(8, 1) == 4
-  ```
-  */
-  external lsr: (int, int) => int = "%lsrint"
+## Examples
 
-  /**
-  `asr(n, length)` calculates the bitwise arithmetic right shift of an integer `n` by `length`.
+```rescript
+Int.rightShift(8, 1) == 4
+```
+*/
+external rightShift: (int, int) => int = "%asrint"
 
-  ## Examples
+/**
+`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.
+Excess bits shifted off to the right are discarded, and zero bits are shifted in from the left.
 
-  ```rescript
-  Int.Bitwise.asr(4, 1) == 2
-  ```
-  */
-  external asr: (int, int) => int = "%asrint"
-}
+Also known as "zero-filling right shift" operation.
+
+## Examples
+
+```rescript
+Int.unsignedRightShift(4, 1) == 2
+```
+*/
+external unsignedRightShift: (int, int) => int = "%lsrint"
 
 /**
   `ignore(int)` ignores the provided int and returns unit.

--- a/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
@@ -233,12 +233,6 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
-    "label": "Int.leftShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.leftShift(4, 1) == 8\n```\n"}
-  }, {
     "label": "Int.toExponentialWithPrecision",
     "kind": 12,
     "tags": [1],
@@ -257,12 +251,6 @@ Path Stdlib.Int.
     "detail": "(~min: int=?, ~max: int=?, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
   }, {
-    "label": "Int.unsignedRightShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.unsignedRightShift(4, 1) == 2\n```\n"}
-  }, {
     "label": "Int.toFixedWithPrecision",
     "kind": 12,
     "tags": [1],
@@ -280,6 +268,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`bitwiseAnd(n1, n2)` calculates the bitwise AND of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseAnd(7, 4) == 4\n```\n"}
+  }, {
+    "label": "Int.shiftRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftRight(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.shiftRight(8, 1) == 4\n```\n"}
   }, {
     "label": "Int.compare",
     "kind": 12,
@@ -317,6 +311,12 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
+    "label": "Int.shiftLeft",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftLeft(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.shiftLeft(4, 1) == 8\n```\n"}
+  }, {
     "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
@@ -334,6 +334,12 @@ Path Stdlib.Int.
     "tags": [1],
     "detail": "(int, int, rangeOptions) => array<int>",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `range` instead\n\n\n`rangeWithOptions(start, end, options)` is like `range`, but with `step` and\n`inclusive` options configurable.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.rangeWithOptions(3, 7, {step: 2}) == [3, 5]\nInt.rangeWithOptions(3, 7, {step: 2, inclusive: true}) == [3, 5, 7]\nInt.rangeWithOptions(3, 6, {step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.shiftRightUnsigned",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftRightUnsigned(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.shiftRightUnsigned(4, 1) == 2\n```\n"}
   }, {
     "label": "Int.toLocaleString",
     "kind": 12,
@@ -358,12 +364,6 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, ~digits: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
-  }, {
-    "label": "Int.rightShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.rightShift(8, 1) == 4\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 26:14
@@ -408,12 +408,6 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
-    "label": "Int.leftShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.leftShift(4, 1) == 8\n```\n"}
-  }, {
     "label": "Int.toExponentialWithPrecision",
     "kind": 12,
     "tags": [1],
@@ -432,12 +426,6 @@ Path Stdlib.Int.
     "detail": "(~min: int=?, ~max: int=?, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
   }, {
-    "label": "Int.unsignedRightShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.unsignedRightShift(4, 1) == 2\n```\n"}
-  }, {
     "label": "Int.toFixedWithPrecision",
     "kind": 12,
     "tags": [1],
@@ -455,6 +443,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`bitwiseAnd(n1, n2)` calculates the bitwise AND of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseAnd(7, 4) == 4\n```\n"}
+  }, {
+    "label": "Int.shiftRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftRight(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.shiftRight(8, 1) == 4\n```\n"}
   }, {
     "label": "Int.compare",
     "kind": 12,
@@ -492,6 +486,12 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toString(n, ~radix=?)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toString(1000) // \"1000\"\nInt.toString(-1000) // \"-1000\"\nInt.toString(6, ~radix=2) // \"110\"\nInt.toString(373592855, ~radix=16) // \"16449317\"\nInt.toString(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
+    "label": "Int.shiftLeft",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftLeft(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.shiftLeft(4, 1) == 8\n```\n"}
+  }, {
     "label": "Int.toFloat",
     "kind": 12,
     "tags": [],
@@ -509,6 +509,12 @@ Path Stdlib.Int.
     "tags": [1],
     "detail": "(int, int, rangeOptions) => array<int>",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `range` instead\n\n\n`rangeWithOptions(start, end, options)` is like `range`, but with `step` and\n`inclusive` options configurable.\n\nIf `step` is set, the sequence will increase or decrease by that amount for each\nstep. If `start < end` and `step` is negative, or vice versa, an empty array is\nreturned since the sequence would otherwise never reach or exceed the end value\nand hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is\nraised as the sequence would never reach or exceed the end value and hence be\ninfinite.\n\nIf `inclusive` is set to `true`, the sequence will include `end` if `step` is\nset such that the sequence includes it.\n\n## Examples\n\n```rescript\nInt.rangeWithOptions(3, 7, {step: 2}) == [3, 5]\nInt.rangeWithOptions(3, 7, {step: 2, inclusive: true}) == [3, 5, 7]\nInt.rangeWithOptions(3, 6, {step: -2}) // RangeError\n```\n\n## Exceptions\n\n- Raises `RangeError` if `step == 0 && start != end`.\n"}
+  }, {
+    "label": "Int.shiftRightUnsigned",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`shiftRightUnsigned(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.shiftRightUnsigned(4, 1) == 2\n```\n"}
   }, {
     "label": "Int.toLocaleString",
     "kind": 12,
@@ -533,12 +539,6 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, ~digits: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
-  }, {
-    "label": "Int.rightShift",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.rightShift(8, 1) == 4\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 28:20

--- a/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
@@ -233,17 +233,35 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
+    "label": "Int.leftShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.leftShift(4, 1) == 8\n```\n"}
+  }, {
     "label": "Int.toExponentialWithPrecision",
     "kind": 12,
     "tags": [1],
     "detail": "(int, ~digits: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
   }, {
+    "label": "Int.bitwiseXor",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bigwiseXor(n1, n2)` calculates the bitwise XOR of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseXor(7, 4) == 3\n```\n"}
+  }, {
     "label": "Int.clamp",
     "kind": 12,
     "tags": [],
     "detail": "(~min: int=?, ~max: int=?, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
+  }, {
+    "label": "Int.unsignedRightShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.unsignedRightShift(4, 1) == 2\n```\n"}
   }, {
     "label": "Int.toFixedWithPrecision",
     "kind": 12,
@@ -257,6 +275,12 @@ Path Stdlib.Int.
     "detail": "(int, ~digits: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
   }, {
+    "label": "Int.bitwiseAnd",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseAnd(n1, n2)` calculates the bitwise AND of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseAnd(7, 4) == 4\n```\n"}
+  }, {
     "label": "Int.compare",
     "kind": 12,
     "tags": [],
@@ -268,6 +292,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "int => unit",
     "documentation": {"kind": "markdown", "value": "\n  `ignore(int)` ignores the provided int and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"}
+  }, {
+    "label": "Int.bitwiseOr",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseOr(n1, n2)` calculates the bitwise OR of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseOr(7, 4) == 7\n```\n"}
   }, {
     "label": "Int.toPrecision",
     "kind": 12,
@@ -311,6 +341,12 @@ Path Stdlib.Int.
     "detail": "int => string",
     "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
   }, {
+    "label": "Int.bitwiseNot",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseNot(n)` calculates the bitwise NOT of an integer.\n\n## Examples\n\n```rescript\nInt.bitwiseNot(2) == -3\n```\n"}
+  }, {
     "label": "Int.toExponential",
     "kind": 12,
     "tags": [],
@@ -322,6 +358,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, ~digits: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.rightShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.rightShift(8, 1) == 4\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 26:14
@@ -366,17 +408,35 @@ Path Stdlib.Int.
     "detail": "(int, ~radix: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toString` instead\n\n\n`toStringWithRadix(n, ~radix)` return a `string` representing the given value.\n`~radix` specifies the radix base to use for the formatted number.\nSee [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)\non MDN.\n\n## Examples\n\n```rescript\nInt.toStringWithRadix(6, ~radix=2) // \"110\"\nInt.toStringWithRadix(373592855, ~radix=16) // \"16449317\"\nInt.toStringWithRadix(123456, ~radix=36) // \"2n9c\"\n```\n\n## Exceptions\n\n`RangeError`: if `radix` is less than 2 or greater than 36.\n"}
   }, {
+    "label": "Int.leftShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`leftShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the left.\n\n## Examples\n\n```rescript\nInt.leftShift(4, 1) == 8\n```\n"}
+  }, {
     "label": "Int.toExponentialWithPrecision",
     "kind": 12,
     "tags": [1],
     "detail": "(int, ~digits: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toExponential` instead\n\n\n`toExponential(n, ~digits)` return a `string` representing the given value in\nexponential notation. `digits` specifies how many digits should appear after\nthe decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)\non MDN.\n\n## Examples\n\n```rescript\nInt.toExponentialWithPrecision(77, ~digits=2) // \"7.70e+1\"\nInt.toExponentialWithPrecision(5678, ~digits=2) // \"5.68e+3\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` less than 0 or greater than 10.\n"}
   }, {
+    "label": "Int.bitwiseXor",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bigwiseXor(n1, n2)` calculates the bitwise XOR of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseXor(7, 4) == 3\n```\n"}
+  }, {
     "label": "Int.clamp",
     "kind": 12,
     "tags": [],
     "detail": "(~min: int=?, ~max: int=?, int) => int",
     "documentation": {"kind": "markdown", "value": "\n`clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.\n\nif `max` < `min` returns `min`.\n\n## Examples\n\n```rescript\nInt.clamp(42) == 42\nInt.clamp(42, ~min=50) == 50\nInt.clamp(42, ~max=40) == 40\nInt.clamp(42, ~min=50, ~max=40) == 50\n```\n"}
+  }, {
+    "label": "Int.unsignedRightShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`unsignedRightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\nExcess bits shifted off to the right are discarded, and zero bits are shifted in from the left.\n\nAlso known as \"zero-filling right shift\" operation.\n\n## Examples\n\n```rescript\nInt.unsignedRightShift(4, 1) == 2\n```\n"}
   }, {
     "label": "Int.toFixedWithPrecision",
     "kind": 12,
@@ -390,6 +450,12 @@ Path Stdlib.Int.
     "detail": "(int, ~digits: int) => string",
     "documentation": {"kind": "markdown", "value": "Deprecated: Use `toPrecision` instead\n\n\n`toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with\nprecision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.\n\n## Examples\n\n```rescript\nInt.toPrecisionWithPrecision(100, ~digits=2) // \"1.0e+2\"\nInt.toPrecisionWithPrecision(1, ~digits=2) // \"1.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is not between 1 and 100 (inclusive).\nImplementations are allowed to support larger and smaller values as well.\nECMA-262 only requires a precision of up to 21 significant digits.\n\n"}
   }, {
+    "label": "Int.bitwiseAnd",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseAnd(n1, n2)` calculates the bitwise AND of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseAnd(7, 4) == 4\n```\n"}
+  }, {
     "label": "Int.compare",
     "kind": 12,
     "tags": [],
@@ -401,6 +467,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "int => unit",
     "documentation": {"kind": "markdown", "value": "\n  `ignore(int)` ignores the provided int and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"}
+  }, {
+    "label": "Int.bitwiseOr",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseOr(n1, n2)` calculates the bitwise OR of two integers.\n\n## Examples\n\n```rescript\nInt.bitwiseOr(7, 4) == 7\n```\n"}
   }, {
     "label": "Int.toPrecision",
     "kind": 12,
@@ -444,6 +516,12 @@ Path Stdlib.Int.
     "detail": "int => string",
     "documentation": {"kind": "markdown", "value": "\n`toLocaleString(n)` return a `string` with language-sensitive representing the\ngiven value. See [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) on MDN.\n\n## Examples\n\n```rescript\n// If the application uses English as the default language\nInt.toLocaleString(1000) // \"1,000\"\n\n// If the application uses Portuguese Brazil as the default language\nInt.toLocaleString(1000) // \"1.000\"\n```\n"}
   }, {
+    "label": "Int.bitwiseNot",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => int",
+    "documentation": {"kind": "markdown", "value": "\n`bitwiseNot(n)` calculates the bitwise NOT of an integer.\n\n## Examples\n\n```rescript\nInt.bitwiseNot(2) == -3\n```\n"}
+  }, {
     "label": "Int.toExponential",
     "kind": 12,
     "tags": [],
@@ -455,6 +533,12 @@ Path Stdlib.Int.
     "tags": [],
     "detail": "(int, ~digits: int=?) => string",
     "documentation": {"kind": "markdown", "value": "\n`toFixed(n, ~digits=?)` return a `string` representing the given\nvalue using fixed-point notation. `digits` specifies how many digits should\nappear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)\non MDN.\n\n## Examples\n\n```rescript\nInt.toFixed(123456) // \"123456.00\"\nInt.toFixed(10) // \"10.00\"\nInt.toFixed(300, ~digits=4) // \"300.0000\"\nInt.toFixed(300, ~digits=1) // \"300.0\"\n```\n\n## Exceptions\n\n- `RangeError`: If `digits` is less than 0 or larger than 100.\n"}
+  }, {
+    "label": "Int.rightShift",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n`rightShift(n, length)` calculates the shifted value of an integer `n` by `length` bits to the right.\n\nAlso known as \"arithmetic right shift\" operation.\n\n## Examples\n\n```rescript\nInt.rightShift(8, 1) == 4\n```\n"}
   }]
 
 Complete src/CompletionJsx.res 28:20


### PR DESCRIPTION
- [Left Shift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift)
- [Right Shift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift)
- [Unsigned Right Shift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift)
- [Bitwise AND](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND)

So on