### PR TITLE
Error message: Suggest module in place of value where it makes sense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 - Better representation of JSX in AST. https://github.com/rescript-lang/rescript/pull/7286
 
+#### :nail_care: Polish
+
+- Improve error message for missing value when the identifier is also the name of a module in scope. https://github.com/rescript-lang/rescript/pull/7384
+
 # 12.0.0-alpha.11
 
 #### :bug: Bug fix

--- a/tests/build_tests/super_errors/expected/suggest_module_for_missing_identifier.res.expected
+++ b/tests/build_tests/super_errors/expected/suggest_module_for_missing_identifier.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/suggest_module_for_missing_identifier.res[0m:[2m1:1-7[0m
+
+  [1;31m1[0m [2m│[0m [1;31mconsole[0m.log("Hello")
+  2 [2m│[0m 
+
+  The value console can't be found
+
+  Maybe you meant to use the module [1;33mConsole[0m?

--- a/tests/build_tests/super_errors/expected/suggest_module_for_missing_identifier_with_spellcheck.res.expected
+++ b/tests/build_tests/super_errors/expected/suggest_module_for_missing_identifier_with_spellcheck.res.expected
@@ -1,0 +1,13 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/suggest_module_for_missing_identifier_with_spellcheck.res[0m:[2m2:1-7[0m
+
+  1 [2m│[0m let consol = 1
+  [1;31m2[0m [2m│[0m [1;31mconsole[0m.log("Hello")
+  3 [2m│[0m 
+
+  The value console can't be found
+  
+  [1;33mHint: Did you mean consol?[0m
+
+  Or did you mean to use the module [1;33mConsole[0m?

--- a/tests/build_tests/super_errors/fixtures/suggest_module_for_missing_identifier.res
+++ b/tests/build_tests/super_errors/fixtures/suggest_module_for_missing_identifier.res
@@ -1,0 +1,1 @@
+console.log("Hello")

--- a/tests/build_tests/super_errors/fixtures/suggest_module_for_missing_identifier_with_spellcheck.res
+++ b/tests/build_tests/super_errors/fixtures/suggest_module_for_missing_identifier_with_spellcheck.res
@@ -1,0 +1,2 @@
+let consol = 1
+console.log("Hello")

--- a/tests/build_tests/super_errors/input.js
+++ b/tests/build_tests/super_errors/input.js
@@ -10,8 +10,8 @@ const { bsc } = setup(import.meta.dirname);
 
 const expectedDir = path.join(import.meta.dirname, "expected");
 
-const fixtures = readdirSync("fixtures").filter(
-  fileName => path.extname(fileName) === ".res",
+const fixtures = readdirSync(path.join(import.meta.dirname, "fixtures")).filter(
+  (fileName) => path.extname(fileName) === ".res"
 );
 
 const prefix = ["-w", "+A", "-bs-jsx", "4"];


### PR DESCRIPTION
There are some subtle differences between how certain common things are called in ReScript vs in JS. One example is logging to the console:
```
// JS
console.log("Hello")

// ReScript
Console.log("Hello")
```

This difference (value vs module) can be subtle and not easily discoverable. So, this PR does a small addition to the "missing value" error message, and suggests the module version of the identifier _if it exists in scope_. This is intended to give a small hint for what you _might_ be looking for, instead of just telling you to "go fish".