### PR TITLE
Fix type of RegExp.Result.matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix node.js ExperimentalWarning. https://github.com/rescript-lang/rescript/pull/7379
 - Fix issue with gentype and stdlib json. https://github.com/rescript-lang/rescript/pull/7378
 - Fix type of `RegExp.Result.matches`. https://github.com/rescript-lang/rescript/pull/7393
+- Add optional `flags` argument to `RegExp.fromString` and deprecate `RegExp.fromStringWithFlags`. https://github.com/rescript-lang/rescript/pull/7393
 
 #### :house: Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix node.js ExperimentalWarning. https://github.com/rescript-lang/rescript/pull/7379
 - Fix issue with gentype and stdlib json. https://github.com/rescript-lang/rescript/pull/7378
+- Fix type of `RegExp.Result.matches`. https://github.com/rescript-lang/rescript/pull/7393
 
 #### :house: Internal
 

--- a/runtime/Stdlib_RegExp.res
+++ b/runtime/Stdlib_RegExp.res
@@ -3,7 +3,7 @@ type t
 module Result = {
   type t = array<option<string>>
   @get_index external fullMatch: (t, @as(0) _) => string = ""
-  @send external matches: (t, @as(1) _) => array<string> = "slice"
+  @send external matches: (t, @as(1) _) => array<option<string>> = "slice"
   @get external index: t => int = "index"
   @get external input: t => string = "input"
 }

--- a/runtime/Stdlib_RegExp.res
+++ b/runtime/Stdlib_RegExp.res
@@ -8,7 +8,7 @@ module Result = {
   @get external input: t => string = "input"
 }
 
-@new external fromString: string => t = "RegExp"
+@new external fromString: (string, ~flags: string=?) => t = "RegExp"
 @new external fromStringWithFlags: (string, ~flags: string) => t = "RegExp"
 
 @send external test: (t, string) => bool = "test"

--- a/runtime/Stdlib_RegExp.resi
+++ b/runtime/Stdlib_RegExp.resi
@@ -43,7 +43,7 @@ module Result: {
   // This below will log "ReScript" and "is" to the console.
   switch regexp->RegExp.exec("ReScript is pretty cool, right?") {
   | None => Console.log("Nope, no match...")
-  | Some(result) => switch result->RegExp.Result.matches {
+  | Some(result) => switch result->RegExp.Result.matches->Array.keepSome {
     | [firstWord, secondWord] => Console.log2(firstWord, secondWord)
     | _ => Console.log("Didn't find exactly two words...")
     }
@@ -51,7 +51,7 @@ module Result: {
   ```
   */
   @send
-  external matches: (t, @as(1) _) => array<string> = "slice"
+  external matches: (t, @as(1) _) => array<option<string>> = "slice"
   @get external index: t => int = "index"
 
   /**

--- a/runtime/Stdlib_RegExp.resi
+++ b/runtime/Stdlib_RegExp.resi
@@ -87,10 +87,18 @@ switch regexp->RegExp.exec("ReScript is pretty cool, right?") {
 | None => Console.log("Nope, no match...")
 | Some(result) => Console.log(result->RegExp.Result.fullMatch) // Prints "ReScript"
 }
+
+// Match 'foo' with case insensitive flag
+let regexp = RegExp.fromString("foo", ~flags="i")
+
+switch regexp->RegExp.exec("FOO") {
+| None => Console.log("Nope, no match...")
+| Some(result) => Console.log(result->RegExp.Result.fullMatch) // Prints "FOO"
+}
 ```
 */
 @new
-external fromString: string => t = "RegExp"
+external fromString: (string, ~flags: string=?) => t = "RegExp"
 
 /**
 `fromStringWithFlags(string)` creates a `RegExp.t` from the provided string, using the provided `flags`. This can then be used to match on strings using `RegExp.exec`.
@@ -108,6 +116,7 @@ switch regexp->RegExp.exec("ReScript is pretty cool, right?") {
 }
 ```
 */
+@deprecated("Use `fromString` instead")
 @new
 external fromStringWithFlags: (string, ~flags: string) => t = "RegExp"
 

--- a/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
@@ -1384,7 +1384,7 @@ Path mkStuff
     "label": "RegExp.fromString()",
     "kind": 12,
     "tags": [],
-    "detail": "string => t",
+    "detail": "(string, ~flags: string=?) => t",
     "documentation": null,
     "insertText": "RegExp.fromString($0)",
     "insertTextFormat": 2


### PR DESCRIPTION
While the type `RegExp.Result.t` (`array<option<string>>`) is correct, `matches` was typed as `array<string>` even though it can contain `undefined`.

I've also used this PR to make `RegExp.fromString` more ergonomic by adding an optional `flags` argument and deprecating `RegExp.fromStringWithFlags`.