### PR TITLE
Add slot attribute to JsxDom props

### DIFF
--- a/runtime/JsxDOM.res
+++ b/runtime/JsxDOM.res
@@ -533,6 +533,7 @@ type domProps = {
   seed?: string,
   shapeRendering?: string,
   slope?: string,
+  slot?: string,
   spacing?: string,
   specularConstant?: string,
   specularExponent?: string,


### PR DESCRIPTION
This adds the `slot` attribute to the JsxDom props which is commonly used in web component libraries that use the shadow dom.

MDN Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/slot