### PR TITLE
add assertEqual to docstrings

### DIFF
--- a/runtime/Belt_Array.resi
+++ b/runtime/Belt_Array.resi
@@ -33,8 +33,7 @@ Return the size of the array
 ## Examples
 
 ```rescript
-// Returns 1
-Belt.Array.length(["test"])
+assertEqual(Belt.Array.length(["test"]), 1)
 ```
 */
 external length: t<'a> => int = "%array_length"
@@ -49,9 +48,9 @@ If `i` is out of range returns `None`.
 ## Examples
 
 ```rescript
-Belt.Array.get(["a", "b", "c"], 0) == Some("a")
-Belt.Array.get(["a", "b", "c"], 3) == None
-Belt.Array.get(["a", "b", "c"], -1) == None
+assertEqual(Belt.Array.get(["a", "b", "c"], 0), Some("a"))
+assertEqual(Belt.Array.get(["a", "b", "c"], 3), None)
+assertEqual(Belt.Array.get(["a", "b", "c"], -1), None)
 ```
 */
 let get: (t<'a>, int) => option<'a>
@@ -111,7 +110,7 @@ let arr = [10, 11, 12, 13, 14]
 
 let () = Belt.Array.reverseInPlace(arr)
 
-arr == [14, 13, 12, 11, 10]
+assertEqual(arr, [14, 13, 12, 11, 10])
 ```
 */
 let reverseInPlace: t<'a> => unit
@@ -122,7 +121,7 @@ let reverseInPlace: t<'a> => unit
 ## Examples
 
 ```rescript
-Belt.Array.reverse([10, 11, 12, 13, 14]) == [14, 13, 12, 11, 10]
+assertEqual(Belt.Array.reverse([10, 11, 12, 13, 14]), [14, 13, 12, 11, 10])
 ```
 */
 let reverse: t<'a> => t<'a>
@@ -137,7 +136,7 @@ value. You must specify the type of data that will eventually fill the array.
 ```rescript
 let arr: array<Js.undefined<string>> = Belt.Array.makeUninitialized(5)
 
-Belt.Array.getExn(arr, 0) == Js.undefined
+assertEqual(Belt.Array.getExn(arr, 0), Js.undefined)
 ```
 */
 external makeUninitialized: int => array<Js.undefined<'a>> = "Array"
@@ -155,7 +154,7 @@ Js.log(Belt.Array.getExn(arr, 0)) // undefined
 
 Belt.Array.setExn(arr, 0, "example")
 
-Js.log(Belt.Array.getExn(arr, 0) == "example")
+assertEqual(Belt.Array.getExn(arr, 0), "example")
 ```
 */
 external makeUninitializedUnsafe: int => t<'a> = "Array"
@@ -172,11 +171,11 @@ let make: (int, 'a) => t<'a>
 ## Examples
 
 ```rescript
-Belt.Array.range(0, 3) == [0, 1, 2, 3]
+assertEqual(Belt.Array.range(0, 3), [0, 1, 2, 3])
 
-Belt.Array.range(3, 0) == []
+assertEqual(Belt.Array.range(3, 0), [])
 
-Belt.Array.range(3, 3) == [3]
+assertEqual(Belt.Array.range(3, 3), [3])
 ```
 */
 let range: (int, int) => array<int>
@@ -188,19 +187,19 @@ It also return an empty array when `start > finish`.
 ## Examples
 
 ```rescript
-Belt.Array.rangeBy(0, 10, ~step=3) == [0, 3, 6, 9]
+assertEqual(Belt.Array.rangeBy(0, 10, ~step=3), [0, 3, 6, 9])
 
-Belt.Array.rangeBy(0, 12, ~step=3) == [0, 3, 6, 9, 12]
+assertEqual(Belt.Array.rangeBy(0, 12, ~step=3), [0, 3, 6, 9, 12])
 
-Belt.Array.rangeBy(33, 0, ~step=1) == []
+assertEqual(Belt.Array.rangeBy(33, 0, ~step=1), [])
 
-Belt.Array.rangeBy(33, 0, ~step=-1) == []
+assertEqual(Belt.Array.rangeBy(33, 0, ~step=-1), [])
 
-Belt.Array.rangeBy(3, 12, ~step=-1) == []
+assertEqual(Belt.Array.rangeBy(3, 12, ~step=-1), [])
 
-Belt.Array.rangeBy(3, 3, ~step=0) == []
+assertEqual(Belt.Array.rangeBy(3, 3, ~step=0), [])
 
-Belt.Array.rangeBy(3, 3, ~step=1) == [3]
+assertEqual(Belt.Array.rangeBy(3, 3, ~step=1), [3])
 ```
 */
 let rangeBy: (int, int, ~step: int) => array<int>
@@ -214,9 +213,9 @@ n populated by `f(i)` start from `0` to `n - 1`.
 ## Examples
 
 ```rescript
-Belt.Array.makeBy(5, (i) => i) == [0, 1, 2, 3, 4]
+assertEqual(Belt.Array.makeBy(5, (i) => i), [0, 1, 2, 3, 4])
 
-Belt.Array.makeBy(5, (i) => i * i) == [0, 1, 4, 9, 16]
+assertEqual(Belt.Array.makeBy(5, (i) => i * i), [0, 1, 4, 9, 16])
 ```
 */
 let makeBy: (int, int => 'a) => t<'a>
@@ -235,7 +234,7 @@ Stop with the shorter array.
 ## Examples
 
 ```rescript
-Belt.Array.zip([1, 2], [3, 4, 5]) == [(1, 3), (2, 4)]
+assertEqual(Belt.Array.zip([1, 2], [3, 4, 5]), [(1, 3), (2, 4)])
 ```
 */
 let zip: (t<'a>, array<'b>) => array<('a, 'b)>
@@ -251,7 +250,7 @@ Equivalent to `map(zip(xs, ys), ((a, b)) => f(a, b))`
 ## Examples
 
 ```rescript
-Belt.Array.zipBy([1, 2, 3], [4, 5], (a, b) => 2 * a + b) == [6, 9]
+assertEqual(Belt.Array.zipBy([1, 2, 3], [4, 5], (a, b) => 2 * a + b), [6, 9])
 ```
 */
 let zipBy: (t<'a>, array<'b>, ('a, 'b) => 'c) => array<'c>
@@ -264,9 +263,9 @@ second items.
 ## Examples
 
 ```rescript
-Belt.Array.unzip([(1, 2), (3, 4)]) == ([1, 3], [2, 4])
+assertEqual(Belt.Array.unzip([(1, 2), (3, 4)]), ([1, 3], [2, 4]))
 
-Belt.Array.unzip([(1, 2), (3, 4), (5, 6), (7, 8)]) == ([1, 3, 5, 7], [2, 4, 6, 8])
+assertEqual(Belt.Array.unzip([(1, 2), (3, 4), (5, 6), (7, 8)]), ([1, 3, 5, 7], [2, 4, 6, 8]))
 ```
 */
 let unzip: array<('a, 'b)> => (t<'a>, array<'b>)
@@ -278,9 +277,9 @@ let unzip: array<('a, 'b)> => (t<'a>, array<'b>)
 ## Examples
 
 ```rescript
-Belt.Array.concat([1, 2, 3], [4, 5]) == [1, 2, 3, 4, 5]
+assertEqual(Belt.Array.concat([1, 2, 3], [4, 5]), [1, 2, 3, 4, 5])
 
-Belt.Array.concat([], ["a", "b", "c"]) == ["a", "b", "c"]
+assertEqual(Belt.Array.concat([], ["a", "b", "c"]), ["a", "b", "c"])
 ```
 */
 let concat: (t<'a>, t<'a>) => t<'a>
@@ -291,7 +290,7 @@ let concat: (t<'a>, t<'a>) => t<'a>
 ## Examples
 
 ```rescript
-Belt.Array.concatMany([[1, 2, 3], [4, 5, 6], [7, 8]]) == [1, 2, 3, 4, 5, 6, 7, 8]
+assertEqual(Belt.Array.concatMany([[1, 2, 3], [4, 5, 6], [7, 8]]), [1, 2, 3, 4, 5, 6, 7, 8])
 ```
 */
 let concatMany: array<t<'a>> => t<'a>
@@ -308,11 +307,11 @@ if `len` is negative; returns the empty array.
 ## Examples
 
 ```rescript
-Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=2, ~len=3) == [12, 13, 14]
+assertEqual(Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=2, ~len=3), [12, 13, 14])
 
-Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=-4, ~len=3) == [13, 14, 15]
+assertEqual(Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=-4, ~len=3), [13, 14, 15])
 
-Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=4, ~len=9) == [14, 15, 16]
+assertEqual(Belt.Array.slice([10, 11, 12, 13, 14, 15, 16], ~offset=4, ~len=9), [14, 15, 16])
 ```
 */
 let slice: (t<'a>, ~offset: int, ~len: int) => t<'a>
@@ -329,9 +328,9 @@ means get the last element as a singleton array
 ## Examples
 
 ```rescript
-Belt.Array.sliceToEnd([10, 11, 12, 13, 14, 15, 16], 2) == [12, 13, 14, 15, 16]
+assertEqual(Belt.Array.sliceToEnd([10, 11, 12, 13, 14, 15, 16], 2), [12, 13, 14, 15, 16])
 
-Belt.Array.sliceToEnd([10, 11, 12, 13, 14, 15, 16], -4) == [13, 14, 15, 16]
+assertEqual(Belt.Array.sliceToEnd([10, 11, 12, 13, 14, 15, 16], -4), [13, 14, 15, 16])
 ```
 */
 let sliceToEnd: (t<'a>, int) => t<'a>
@@ -357,11 +356,11 @@ let arr = Belt.Array.makeBy(5, (i) => i)
 
 Belt.Array.fill(arr, ~offset=2, ~len=2, 9)
 
-arr == [0, 1, 9, 9, 4]
+assertEqual(arr, [0, 1, 9, 9, 4])
 
 Belt.Array.fill(arr, ~offset=7, ~len=2, 8)
 
-arr == [0, 1, 9, 9, 4]
+assertEqual(arr, [0, 1, 9, 9, 4])
 ```
 */
 let fill: (t<'a>, ~offset: int, ~len: int, 'a) => unit
@@ -383,10 +382,10 @@ let v1 = [10, 11, 12, 13, 14, 15, 16, 17]
 let v2 = [20, 21, 22, 23, 24, 25, 26, 27]
 
 Belt.Array.blit(~src=v1, ~srcOffset=4, ~dst=v2, ~dstOffset=2, ~len=3)
-v2 == [20, 21, 14, 15, 16, 25, 26, 27]
+assertEqual(v2, [20, 21, 14, 15, 16, 25, 26, 27])
 
 Belt.Array.blit(~src=v1, ~srcOffset=4, ~dst=v1, ~dstOffset=2, ~len=3)
-v1 == [10, 11, 14, 15, 16, 15, 16, 17]
+assertEqual(v1, [10, 11, 14, 15, 16, 15, 16, 17])
 ```
 */
 let blit: (~src: t<'a>, ~srcOffset: int, ~dst: t<'a>, ~dstOffset: int, ~len: int) => unit
@@ -420,7 +419,7 @@ let total = ref(0)
 
 Belt.Array.forEach([1, 2, 3, 4], x => total := total.contents + x)
 
-total.contents == 1 + 2 + 3 + 4
+assertEqual(total.contents, 1 + 2 + 3 + 4)
 ```
 */
 let forEach: (t<'a>, 'a => unit) => unit
@@ -434,7 +433,7 @@ the beginning to end.
 ## Examples
 
 ```rescript
-Belt.Array.map([1, 2], (x) => x + 1) == [3, 4]
+assertEqual(Belt.Array.map([1, 2], (x) => x + 1), [2, 3])
 ```
 */
 let map: (t<'a>, 'a => 'b) => array<'b>
@@ -448,7 +447,7 @@ the beginning to end, concatenating the results.
 ## Examples
 
 ```rescript
-Belt.Array.flatMap([1, 2], x => [x + 10, x + 20]) == [11, 21, 12, 22]
+assertEqual(Belt.Array.flatMap([1, 2], x => [x + 10, x + 20]), [11, 21, 12, 22])
 ```
 */
 let flatMap: (t<'a>, 'a => array<'b>) => array<'b>
@@ -462,8 +461,8 @@ the predicate function `p`; returns `None` if no element satisifies the function
 ## Examples
 
 ```rescript
-Belt.Array.getBy([1, 4, 3, 2], (x) => mod(x, 2) == 0) == Some(4)
-Belt.Array.getBy([15, 13, 11], (x) => mod(x, 2) == 0) == None
+assertEqual(Belt.Array.getBy([1, 4, 3, 2], (x) => mod(x, 2) == 0), Some(4))
+assertEqual(Belt.Array.getBy([15, 13, 11], (x) => mod(x, 2) == 0), None)
 ```
 */
 let getBy: (t<'a>, 'a => bool) => option<'a>
@@ -478,8 +477,8 @@ the function.
 ## Examples
 
 ```rescript
-Belt.Array.getIndexBy([1, 4, 3, 2], (x) => mod(x, 2) == 0) == Some(1)
-Belt.Array.getIndexBy([15, 13, 11], (x) => mod(x, 2) == 0) == None
+assertEqual(Belt.Array.getIndexBy([1, 4, 3, 2], (x) => mod(x, 2) == 0), Some(1))
+assertEqual(Belt.Array.getIndexBy([15, 13, 11], (x) => mod(x, 2) == 0), None)
 ```
 */
 let getIndexBy: (t<'a>, 'a => bool) => option<int>
@@ -499,7 +498,7 @@ let keepWithIndexU: (t<'a>, ('a, int) => bool) => t<'a>
 ## Examples
 
 ```rescript
-Belt.Array.keepWithIndex([1, 2, 3], (_x, i) => i == 1) == [2]
+assertEqual(Belt.Array.keepWithIndex([1, 2, 3], (_x, i) => i == 1), [2])
 ```
 */
 let keepWithIndex: (t<'a>, ('a, int) => bool) => t<'a>
@@ -513,14 +512,16 @@ None applied `p`.
 ## Examples
 
 ```rescript
-Belt.Array.keepMap([1, 2, 3], x =>
-  if mod(x, 2) == 0 {
-    Some(x)
-  } else {
-    None
-  }
+assertEqual(
+  Belt.Array.keepMap([1, 2, 3], x =>
+    if mod(x, 2) == 0 {
+      Some(x)
+    } else {
+      None
+    }
+  ),
+  [2]
 )
-== [2]
 ```
 */
 let keepMap: (t<'a>, 'a => option<'b>) => array<'b>
@@ -546,7 +547,7 @@ let total = ref(0)
 
 Belt.Array.forEachWithIndex([10, 11, 12, 13], (i, x) => total := total.contents + x + i)
 
-total.contents == 0 + 10 + 1 + 11 + 2 + 12 + 3 + 13
+assertEqual(total.contents, 0 + 10 + 1 + 11 + 2 + 12 + 3 + 13)
 ```
 */
 let forEachWithIndex: (t<'a>, (int, 'a) => unit) => unit
@@ -560,7 +561,7 @@ two arguments: the index starting from 0 and the element from `xs`.
 ## Examples
 
 ```rescript
-Belt.Array.mapWithIndex([1, 2, 3], (i, x) => i + x) == [0 + 1, 1 + 2, 2 + 3]
+assertEqual(Belt.Array.mapWithIndex([1, 2, 3], (i, x) => i + x), [0 + 1, 1 + 2, 2 + 3])
 ```
 */
 let mapWithIndex: (t<'a>, (int, 'a) => 'b) => array<'b>
@@ -574,9 +575,9 @@ first of tuple where predicate cause true, second where predicate cause false
 ## Examples
 
 ```rescript
-Belt.Array.partition([1, 2, 3, 4, 5], (x) => mod(x, 2) == 0) == ([2, 4], [1, 3, 5])
+assertEqual(Belt.Array.partition([1, 2, 3, 4, 5], (x) => mod(x, 2) == 0), ([2, 4], [1, 3, 5]))
 
-Belt.Array.partition([1, 2, 3, 4, 5], (x) => mod(x, 2) != 0) == ([1, 3, 5], [2, 4])
+assertEqual(Belt.Array.partition([1, 2, 3, 4, 5], (x) => mod(x, 2) != 0), ([1, 3, 5], [2, 4]))
 ```
 */
 let partition: (t<'a>, 'a => bool) => (t<'a>, t<'a>)
@@ -592,9 +593,9 @@ accumulator.
 ## Examples
 
 ```rescript
-Belt.Array.reduce([2, 3, 4], 1, (a, b) => a + b) == 10
+assertEqual(Belt.Array.reduce([2, 3, 4], 1, (a, b) => a + b), 10)
 
-Belt.Array.reduce(["a", "b", "c", "d"], "", (a, b) => a ++ b) == "abcd"
+assertEqual(Belt.Array.reduce(["a", "b", "c", "d"], "", (a, b) => a ++ b), "abcd")
 ```
 */
 let reduce: (array<'b>, 'a, ('a, 'b) => 'a) => 'a
@@ -608,7 +609,7 @@ function `f` is applied to each item of `xs` from the last back to the first.
 ## Examples
 
 ```rescript
-Belt.Array.reduceReverse(["a", "b", "c", "d"], "", (a, b) => a ++ b) == "dcba"
+assertEqual(Belt.Array.reduceReverse(["a", "b", "c", "d"], "", (a, b) => a ++ b), "dcba")
 ```
 */
 let reduceReverse: (array<'b>, 'a, ('a, 'b) => 'a) => 'a
@@ -622,7 +623,7 @@ starting at `min(length(xs), length(ys))` down to and including zero.
 ## Examples
 
 ```rescript
-Belt.Array.reduceReverse2([1, 2, 3], [1, 2], 0, (acc, x, y) => acc + x + y) == 6
+assertEqual(Belt.Array.reduceReverse2([1, 2, 3], [1, 2], 0, (acc, x, y) => acc + x + y), 6)
 ```
 */
 let reduceReverse2: (t<'a>, array<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
@@ -638,7 +639,7 @@ the final value of the accumulator.
 ## Examples
 
 ```rescript
-Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, x, i) => acc + x + i) == 16
+assertEqual(Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, x, i) => acc + x + i), 16)
 ```
 */
 let reduceWithIndex: (t<'a>, 'b, ('b, 'a, int) => 'b) => 'b
@@ -656,9 +657,9 @@ using the separator. If the array is empty, the empty string will be returned.
 ## Examples
 
 ```rescript
-Belt.Array.joinWith([0, 1], ", ", Js.Int.toString) == "0, 1"
-Belt.Array.joinWith([], " ", Js.Int.toString) == ""
-Belt.Array.joinWith([1], " ", Js.Int.toString) == "1"
+assertEqual(Belt.Array.joinWith([0, 1], ", ", Js.Int.toString), "0, 1")
+assertEqual(Belt.Array.joinWith([], " ", Js.Int.toString), "")
+assertEqual(Belt.Array.joinWith([1], " ", Js.Int.toString), "1")
 ```
 */
 let joinWith: (t<'a>, string, 'a => string) => string
@@ -672,9 +673,9 @@ where `p` is a predicate: a function taking an element and returning a `bool`.
 ## Examples
 
 ```rescript
-Belt.Array.some([2, 3, 4], (x) => mod(x, 2) == 1) == true
+assertEqual(Belt.Array.some([2, 3, 4], (x) => mod(x, 2) == 1), true)
 
-Belt.Array.some([(-1), (-3), (-5)], (x) => x > 0) == false
+assertEqual(Belt.Array.some([(-1), (-3), (-5)], (x) => x > 0), false)
 ```
 */
 let some: (t<'a>, 'a => bool) => bool
@@ -688,9 +689,9 @@ predicate: a function taking an element and returning a `bool`.
 ## Examples
 
 ```rescript
-Belt.Array.every([1, 3, 5], (x) => mod(x, 2) == 1) == true
+assertEqual(Belt.Array.every([1, 3, 5], (x) => mod(x, 2) == 1), true)
 
-Belt.Array.every([1, (-3), 5], (x) => x > 0) == false
+assertEqual(Belt.Array.every([1, (-3), 5], (x) => x > 0), false)
 ```
 */
 let every: (t<'a>, 'a => bool) => bool
@@ -704,13 +705,13 @@ elements up to the shorter length (i.e. `min(length(xs), length(ys))`)
 ## Examples
 
 ```rescript
-Belt.Array.every2([1, 2, 3], [0, 1], (a, b) => a > b) == true
+assertEqual(Belt.Array.every2([1, 2, 3], [0, 1], (a, b) => a > b), true)
 
-Belt.Array.every2([], [1], (x, y) => x > y) == true
+assertEqual(Belt.Array.every2([], [1], (x, y) => x > y), true)
 
-Belt.Array.every2([2, 3], [1], (x, y) => x > y) == true
+assertEqual(Belt.Array.every2([2, 3], [1], (x, y) => x > y), true)
 
-Belt.Array.every2([0, 1], [5, 0], (x, y) => x > y) == false
+assertEqual(Belt.Array.every2([0, 1], [5, 0], (x, y) => x > y), false)
 ```
 */
 let every2: (t<'a>, array<'b>, ('a, 'b) => bool) => bool
@@ -724,11 +725,11 @@ up to the shorter length (i.e. `min(length(xs), length(ys))`)
 ## Examples
 
 ```rescript
-Belt.Array.some2([0, 2], [1, 0, 3], (a, b) => a > b) == true
+assertEqual(Belt.Array.some2([0, 2], [1, 0, 3], (a, b) => a > b), true)
 
-Belt.Array.some2([], [1], (x, y) => x > y) == false
+assertEqual(Belt.Array.some2([], [1], (x, y) => x > y), false)
 
-Belt.Array.some2([2, 3], [1, 4], (x, y) => x > y) == true
+assertEqual(Belt.Array.some2([2, 3], [1, 4], (x, y) => x > y), true)
 ```
 */
 let some2: (t<'a>, array<'b>, ('a, 'b) => bool) => bool
@@ -746,11 +747,11 @@ returns zero for all `x` and `y`.
 ## Examples
 
 ```rescript
-Belt.Array.cmp([1, 3, 5], [1, 4, 2], (a, b) => compare(a, b)) == -1
+assertEqual(Belt.Array.cmp([1, 3, 5], [1, 4, 2], (a, b) => compare(a, b)), -1)
 
-Belt.Array.cmp([1, 3, 5], [1, 2, 3], (a, b) => compare(a, b)) == 1
+assertEqual(Belt.Array.cmp([1, 3, 5], [1, 2, 3], (a, b) => compare(a, b)), 1)
 
-Belt.Array.cmp([1, 3, 5], [1, 3, 5], (a, b) => compare(a, b)) == 0
+assertEqual(Belt.Array.cmp([1, 3, 5], [1, 3, 5], (a, b) => compare(a, b)), 0)
 ```
 */
 let cmp: (t<'a>, t<'a>, ('a, 'a) => int) => int
@@ -764,7 +765,7 @@ one by one using `f(xi, yi)`; and return true if all results are true false othe
 ## Examples
 
 ```rescript
-Belt.Array.eq([1, 2, 3], [(-1), (-2), (-3)], (a, b) => abs(a) == abs(b)) == true
+assertEqual(Belt.Array.eq([1, 2, 3], [(-1), (-2), (-3)], (a, b) => abs(a) == abs(b)), true)
 ```
 */
 let eq: (t<'a>, t<'a>, ('a, 'a) => bool) => bool
@@ -782,7 +783,7 @@ let arr = ["ant", "bee", "cat", "dog", "elk"]
 
 Belt.Array.truncateToLengthUnsafe(arr, 3)
 
-arr == ["ant", "bee", "cat"]
+assertEqual(arr, ["ant", "bee", "cat"])
 ```
 */
 external truncateToLengthUnsafe: (t<'a>, int) => unit = "length"

--- a/runtime/Belt_Float.resi
+++ b/runtime/Belt_Float.resi
@@ -30,7 +30,7 @@ Converts a given `float` to an `int`.
 ## Examples
 
 ```rescript
-Js.log(Belt.Float.toInt(1.0) === 1) /* true */
+assertEqual(Belt.Float.toInt(1.0), 1)
 ```
 */
 external toInt: float => int = "%intoffloat"
@@ -41,7 +41,7 @@ Converts a given `int` to a `float`.
 ## Examples
 
 ```rescript
-Js.log(Belt.Float.fromInt(1) === 1.0) /* true */
+assertEqual(Belt.Float.fromInt(1), 1.0)
 ```
 */
 external fromInt: int => float = "%identity"
@@ -52,7 +52,7 @@ Converts a given `string` to a `float`. Returns `Some(float)` when the input is 
 ## Examples
 
 ```rescript
-Js.log(Belt.Float.fromString("1.0") === Some(1.0)) /* true */
+assertEqual(Belt.Float.fromString("1.0"), Some(1.0))
 ```
 */
 let fromString: string => option<float>
@@ -64,7 +64,7 @@ Converts a given `float` to a `string`. Uses the JavaScript `String` constructor
 ## Examples
 
 ```rescript
-Js.log(Belt.Float.toString(1.0) === "1.0") /* true */
+assertEqual(Belt.Float.toString(1.0), "1")
 ```
 */
 external toString: float => string = "String"

--- a/runtime/Belt_HashMap.resi
+++ b/runtime/Belt_HashMap.resi
@@ -114,7 +114,7 @@ module IntHash = Belt.Id.MakeHashable({
 
 let hMap = Belt.HashMap.fromArray([(1, "1")], ~id=module(IntHash))
 Belt.HashMap.clear(hMap)
-Belt.HashMap.isEmpty(hMap) == true
+assertEqual(Belt.HashMap.isEmpty(hMap), true)
 ```
 */
 let clear: t<'key, 'value, 'id> => unit
@@ -131,7 +131,7 @@ module IntHash = Belt.Id.MakeHashable({
   let eq = (a, b) => a == b
 })
 
-Belt.HashMap.isEmpty(Belt.HashMap.fromArray([(1, "1")], ~id=module(IntHash))) == false
+assertEqual(Belt.HashMap.isEmpty(Belt.HashMap.fromArray([(1, "1")], ~id=module(IntHash))), false)
 ```
 */
 let isEmpty: t<_> => bool
@@ -152,7 +152,7 @@ let s0 = Belt.HashMap.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntHa
 
 Belt.HashMap.set(s0, 2, "3")
 
-Belt.HashMap.valuesToArray(s0) == ["1", "3", "3"]
+assertEqual(Belt.HashMap.valuesToArray(s0), ["1", "3", "3"])
 ```
 */
 let set: (t<'key, 'value, 'id>, 'key, 'value) => unit
@@ -174,7 +174,7 @@ let s1 = Belt.HashMap.copy(s0)
 
 Belt.HashMap.set(s0, 2, "3")
 
-Belt.HashMap.get(s0, 2) != Belt.HashMap.get(s1, 2)
+assertEqual(Belt.HashMap.get(s0, 2) == Belt.HashMap.get(s1, 2), false)
 ```
 */
 let copy: t<'key, 'value, 'id> => t<'key, 'value, 'id>
@@ -194,8 +194,8 @@ module IntHash = Belt.Id.MakeHashable({
 let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 
-Belt.HashMap.get(s0, 1) == Some("value1")
-Belt.HashMap.get(s0, 2) == None
+assertEqual(Belt.HashMap.get(s0, 1), Some("value1"))
+assertEqual(Belt.HashMap.get(s0, 2), None)
 ```
 */
 let get: (t<'key, 'value, 'id>, 'key) => option<'value>
@@ -215,8 +215,8 @@ module IntHash = Belt.Id.MakeHashable({
 let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 
-Belt.HashMap.has(s0, 1) == true
-Belt.HashMap.has(s0, 2) == false
+assertEqual(Belt.HashMap.has(s0, 1), true)
+assertEqual(Belt.HashMap.has(s0, 2), false)
 ```
 */
 let has: (t<'key, 'value, 'id>, 'key) => bool
@@ -236,7 +236,7 @@ module IntHash = Belt.Id.MakeHashable({
 let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 Belt.HashMap.remove(s0, 1)
-Belt.HashMap.has(s0, 1) == false
+assertEqual(Belt.HashMap.has(s0, 1), false)
 ```
 */
 let remove: (t<'key, 'value, 'id>, 'key) => unit
@@ -340,7 +340,7 @@ let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 Belt.HashMap.set(s0, 2, "value2")
 
-Belt.HashMap.size(s0) == 2
+assertEqual(Belt.HashMap.size(s0), 2)
 ```
 */
 let size: t<_> => int
@@ -361,7 +361,7 @@ let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 Belt.HashMap.set(s0, 2, "value2")
 
-Belt.HashMap.toArray(s0) == [(1, "value1"), (2, "value2")]
+assertEqual(Belt.HashMap.toArray(s0), [(1, "value1"), (2, "value2")])
 ```
 */
 let toArray: t<'key, 'value, 'id> => array<('key, 'value)>
@@ -382,7 +382,7 @@ let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 Belt.HashMap.set(s0, 2, "value2")
 
-Belt.HashMap.keysToArray(s0) == [1, 2]
+assertEqual(Belt.HashMap.keysToArray(s0), [1, 2])
 ```
  */
 let keysToArray: t<'key, _, _> => array<'key>
@@ -403,7 +403,7 @@ let s0 = Belt.HashMap.make(~hintSize=10, ~id=module(IntHash))
 Belt.HashMap.set(s0, 1, "value1")
 Belt.HashMap.set(s0, 2, "value2")
 
-Belt.HashMap.valuesToArray(s0) == ["value1", "value2"]
+assertEqual(Belt.HashMap.valuesToArray(s0), ["value1", "value2"])
 ```
 */
 let valuesToArray: t<_, 'value, _> => array<'value>
@@ -423,7 +423,7 @@ module IntHash = Belt.Id.MakeHashable({
 })
 
 let s0 = Belt.HashMap.fromArray([(1, "value1"), (2, "value2")], ~id=module(IntHash))
-Belt.HashMap.toArray(s0) == [(1, "value1"), (2, "value2")]
+assertEqual(Belt.HashMap.toArray(s0), [(1, "value1"), (2, "value2")])
 ```
 */
 let fromArray: (array<('key, 'value)>, ~id: id<'key, 'id>) => t<'key, 'value, 'id>

--- a/runtime/Belt_List.resi
+++ b/runtime/Belt_List.resi
@@ -41,7 +41,7 @@ Returns the length of a list.
 ## Examples
 
 ```rescript
-Belt.List.length(list{1, 2, 3}) // 3
+assertEqual(Belt.List.length(list{1, 2, 3}), 3)
 ```
 */
 let length: t<'a> => int
@@ -56,8 +56,8 @@ Returns `Some(value)` where `value` is the first element in the list, or
 ## Examples
 
 ```rescript
-Belt.List.head(list{}) // None
-Belt.List.head(list{1, 2, 3}) // Some(1)
+assertEqual(Belt.List.head(list{}), None)
+assertEqual(Belt.List.head(list{1, 2, 3}), Some(1))
 ```
 */
 let head: t<'a> => option<'a>
@@ -86,9 +86,9 @@ where `tail` is everything except the first element of `someList`.
 ## Examples
 
 ```rescript
-Belt.List.tail(list{1, 2, 3}) // Some(list{2, 3})
+assertEqual(Belt.List.tail(list{1, 2, 3}), Some(list{2, 3}))
 
-Belt.List.tail(list{}) // None
+assertEqual(Belt.List.tail(list{}), None)
 ```
 */
 let tail: t<'a> => option<t<'a>>
@@ -118,7 +118,7 @@ Adds `value` to the beginning of `someList`.
 ```rescript
 Belt.List.add(list{2, 3}, 1) // list{1, 2, 3}
 
-Belt.List.add(list{"World", "!"}, "Hello") // list{"Hello", "World", "!"}
+assertEqual(Belt.List.add(list{"World", "!"}, "Hello"), list{"Hello", "World", "!"})
 ```
 */
 let add: (t<'a>, 'a) => t<'a>
@@ -132,9 +132,9 @@ length.
 ```rescript
 let abc = list{"A", "B", "C"}
 
-abc->Belt.List.get(1) // Some("B")
+assertEqual(abc->Belt.List.get(1), Some("B"))
 
-abc->Belt.List.get(4) // None
+assertEqual(abc->Belt.List.get(4), None)
 ```
 */
 let get: (t<'a>, int) => option<'a>
@@ -164,7 +164,7 @@ Returns a list of length `numItems` with each element filled with value `v`. Ret
 ## Examples
 
 ```rescript
-Belt.List.make(3, 1) // list{1, 1, 1}
+assertEqual(Belt.List.make(3, 1), list{1, 1, 1})
 ```
 */
 let make: (int, 'a) => t<'a>
@@ -180,9 +180,9 @@ Returns an empty list if `numItems` is negative.
 ## Examples
 
 ```rescript
-Belt.List.makeBy(5, i => i) // list{0, 1, 2, 3, 4}
+assertEqual(Belt.List.makeBy(5, i => i), list{0, 1, 2, 3, 4})
 
-Belt.List.makeBy(5, i => i * i) // list{0, 1, 4, 9, 16}
+assertEqual(Belt.List.makeBy(5, i => i * i), list{0, 1, 4, 9, 16})
 ```
 */
 let makeBy: (int, int => 'a) => t<'a>
@@ -204,11 +204,11 @@ Return a new list, dropping the first `n` elements. Returns `None` if `someList`
 ## Examples
 
 ```rescript
-list{1, 2, 3}->Belt.List.drop(2) // Some(list{3})
+assertEqual(list{1, 2, 3}->Belt.List.drop(2), Some(list{3}))
 
-list{1, 2, 3}->Belt.List.drop(3) // Some(list{})
+assertEqual(list{1, 2, 3}->Belt.List.drop(3), Some(list{}))
 
-list{1, 2, 3}->Belt.List.drop(4) // None
+assertEqual(list{1, 2, 3}->Belt.List.drop(4), None)
 ```
 */
 let drop: (t<'a>, int) => option<t<'a>>
@@ -219,11 +219,11 @@ Returns a list with the first `n` elements from `someList`, or `None` if `someLi
 ## Examples
 
 ```rescript
-list{1, 2, 3}->Belt.List.take(1) // Some(list{1})
+assertEqual(list{1, 2, 3}->Belt.List.take(1), Some(list{1}))
 
-list{1, 2, 3}->Belt.List.take(2) // Some(list{1, 2})
+assertEqual(list{1, 2, 3}->Belt.List.take(2), Some(list{1, 2}))
 
-list{1, 2, 3}->Belt.List.take(4) // None
+assertEqual(list{1, 2, 3}->Belt.List.take(4), None)
 ```
 */
 let take: (t<'a>, int) => option<t<'a>>
@@ -234,9 +234,9 @@ Split the list `someList` at `index`. Returns `None` when the length of `someLis
 ## Examples
 
 ```rescript
-list{"Hello", "World"}->Belt.List.splitAt(1) // Some((list{"Hello"}, list{"World"}))
+assertEqual(list{"Hello", "World"}->Belt.List.splitAt(1), Some((list{"Hello"}, list{"World"})))
 
-list{0, 1, 2, 3, 4}->Belt.List.splitAt(2) // Some((list{0, 1}, list{2, 3, 4}))
+assertEqual(list{0, 1, 2, 3, 4}->Belt.List.splitAt(2), Some((list{0, 1}, list{2, 3, 4})))
 ```
 */
 let splitAt: (t<'a>, int) => option<(list<'a>, list<'a>)>
@@ -247,7 +247,7 @@ Returns the list obtained by adding `secondList` after `firstList`.
 ## Examples
 
 ```rescript
-Belt.List.concat(list{1, 2, 3}, list{4, 5}) // list{1, 2, 3, 4, 5}
+assertEqual(Belt.List.concat(list{1, 2, 3}, list{4, 5}), list{1, 2, 3, 4, 5})
 ```
 */
 let concat: (t<'a>, t<'a>) => t<'a>
@@ -259,7 +259,7 @@ order.
 ## Examples
 
 ```rescript
-Belt.List.concatMany([list{1, 2, 3}, list{}, list{3}]) // list{1, 2, 3, 3}
+assertEqual(Belt.List.concatMany([list{1, 2, 3}, list{}, list{3}]), list{1, 2, 3, 3})
 ```
 */
 let concatMany: array<t<'a>> => t<'a>
@@ -270,7 +270,7 @@ Equivalent to writing: `concat(reverse(firstList, secondList)`
 ## Examples
 
 ```rescript
-Belt.List.reverseConcat(list{1, 2}, list{3, 4}) // list{2, 1, 3, 4}
+assertEqual(Belt.List.reverseConcat(list{1, 2}, list{3, 4}), list{2, 1, 3, 4})
 ```
 */
 let reverseConcat: (t<'a>, t<'a>) => t<'a>
@@ -281,7 +281,7 @@ Return the list obtained by concatenating all the lists in list `ls`, in order.
 ## Examples
 
 ```rescript
-Belt.List.flatten(list{list{1, 2, 3}, list{}, list{3}}) // list{1, 2, 3, 3}
+assertEqual(Belt.List.flatten(list{list{1, 2, 3}, list{}, list{3}}), list{1, 2, 3, 3})
 ```
 */
 let flatten: t<t<'a>> => t<'a>
@@ -296,7 +296,7 @@ Returns a new list with `f` applied to each element of `someList`.
 ## Examples
 
 ```rescript
-list{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}
+assertEqual(list{1, 2}->Belt.List.map(x => x + 1), list{2, 3})
 ```
 */
 let map: (t<'a>, 'a => 'b) => t<'b>
@@ -307,7 +307,7 @@ Returns a list of pairs from the two lists with the length of the shorter list.
 ## Examples
 
 ```rescript
-Belt.List.zip(list{1, 2}, list{3, 4, 5}) // list{(1, 3), (2, 4)}
+assertEqual(Belt.List.zip(list{1, 2}, list{3, 4, 5}), list{(1, 3), (2, 4)})
 ```
 */
 let zip: (t<'a>, t<'b>) => t<('a, 'b)>
@@ -322,7 +322,7 @@ See [Belt.List.zip](#zip)
 ## Examples
 
 ```rescript
-Belt.List.zipBy(list{1, 2, 3}, list{4, 5}, (a, b) => 2 * a + b) // list{6, 9}
+assertEqual(Belt.List.zipBy(list{1, 2, 3}, list{4, 5}, (a, b) => 2 * a + b), list{6, 9})
 ```
 */
 let zipBy: (t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>
@@ -338,7 +338,7 @@ Function `f` takes two arguments: the index starting from 0 and the element from
 ## Examples
 
 ```rescript
-list{1, 2, 3}->Belt.List.mapWithIndex((index, x) => index + x) // list{1, 3, 5}
+assertEqual(list{1, 2, 3}->Belt.List.mapWithIndex((index, x) => index + x), list{1, 3, 5})
 ```
 */
 let mapWithIndex: (t<'a>, (int, 'a) => 'b) => t<'b>
@@ -349,7 +349,7 @@ Converts the given array to a list.
 ## Examples
 
 ```rescript
-Belt.List.fromArray([1, 2, 3]) // list{1, 2, 3}
+assertEqual(Belt.List.fromArray([1, 2, 3]), list{1, 2, 3})
 ```
 */
 let fromArray: array<'a> => t<'a>
@@ -360,7 +360,7 @@ Converts the given list to an array.
 ## Examples
 
 ```rescript
-Belt.List.toArray(list{1, 2, 3}) // [1, 2, 3]
+assertEqual(Belt.List.toArray(list{1, 2, 3}), [1, 2, 3])
 ```
 */
 let toArray: t<'a> => array<'a>
@@ -376,7 +376,7 @@ Returns a new list whose elements are those of `someList` in reversed order.
 ## Examples
 
 ```rescript
-Belt.List.reverse(list{1, 2, 3}) /* list{3, 2, 1} */
+assertEqual(Belt.List.reverse(list{1, 2, 3}), list{3, 2, 1})
 ```
 */
 let reverse: t<'a> => t<'a>
@@ -454,11 +454,11 @@ Applies `f` to each element of `someList` from beginning to end. Function `f` ha
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->Belt.List.reduce(0, (a, b) => a + b) /* 10 */
+assertEqual(list{1, 2, 3, 4}->Belt.List.reduce(0, (a, b) => a + b), 10)
 
 /* same as */
 
-list{1, 2, 3, 4}->Belt.List.reduce(0, (acc, item) => acc + item) /* 10 */
+assertEqual(list{1, 2, 3, 4}->Belt.List.reduce(0, (acc, item) => acc + item), 10)
 ```
 */
 let reduce: (t<'a>, 'b, ('b, 'a) => 'b) => 'b
@@ -473,7 +473,10 @@ Applies `f` to each element of `someList` from beginning to end. Function `f` ha
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->Belt.List.reduceWithIndex(0, (acc, item, index) => acc + item + index) /* 16 */
+assertEqual(
+  list{1, 2, 3, 4}->Belt.List.reduceWithIndex(0, (acc, item, index) => acc + item + index),
+  16
+)
 ```
 */
 let reduceWithIndex: (t<'a>, 'b, ('b, 'a, int) => 'b) => 'b
@@ -489,11 +492,11 @@ item of `someList` from the last back to the first.
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->Belt.List.reduceReverse(0, (a, b) => a + b) /* 10 */
+assertEqual(list{1, 2, 3, 4}->Belt.List.reduceReverse(0, (a, b) => a + b), 10)
 
-list{1, 2, 3, 4}->Belt.List.reduceReverse(10, (a, b) => a - b) /* 0 */
+assertEqual(list{1, 2, 3, 4}->Belt.List.reduceReverse(10, (a, b) => a - b), 0)
 
-list{1, 2, 3, 4}->Belt.List.reduceReverse(list{}, Belt.List.add) // list{1, 2, 3, 4}
+assertEqual(list{1, 2, 3, 4}->Belt.List.reduceReverse(list{}, Belt.List.add), list{1, 2, 3, 4})
 ```
 */
 let reduceReverse: (t<'a>, 'b, ('b, 'a) => 'b) => 'b
@@ -508,8 +511,7 @@ Equivalent to: `zipBy(xs, ys, f)->reverse`
 ## Examples
 
 ```rescript
-
-Belt.List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}
+assertEqual(Belt.List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b), list{4, 2})
 ```
 */
 let mapReverse2: (t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>
@@ -545,7 +547,10 @@ Applies `f` to each element of `firstList` and `secondList` from beginning to en
 ## Examples
 
 ```rescript
-Belt.List.reduce2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) /* 0 + (1 * 1 + 4) + (2 * 2 + 5) */
+assertEqual(
+  Belt.List.reduce2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y),
+  0 + (1 * 1 + 4) + (2 * 2 + 5)
+)
 ```
 */
 let reduce2: (t<'b>, t<'c>, 'a, ('a, 'b, 'c) => 'a) => 'a
@@ -564,7 +569,10 @@ accumulator.
 ## Examples
 
 ```rescript
-Belt.List.reduceReverse2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) /*  + (1 * 1 + 4) + (2 * 2 + 5) */
+assertEqual(
+  Belt.List.reduceReverse2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y),
+  0 + (1 * 1 + 4) + (2 * 2 + 5)
+)
 ```
 */
 let reduceReverse2: (t<'a>, t<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
@@ -581,9 +589,9 @@ Returns `true` if all elements satisfy `pred`, where `pred` is a predicate: a fu
 ```rescript
 let isBelow10 = value => value < 10
 
-list{1, 9, 8, 2}->Belt.List.every(isBelow10) /* true */
+assertEqual(list{1, 9, 8, 2}->Belt.List.every(isBelow10), true)
 
-list{1, 99, 8, 2}->Belt.List.every(isBelow10) /* false */
+assertEqual(list{1, 99, 8, 2}->Belt.List.every(isBelow10), false)
 ```
 */
 let every: (t<'a>, 'a => bool) => bool
@@ -602,9 +610,9 @@ returning a bool.
 ```rescript
 let isAbove100 = value => value > 100
 
-list{101, 1, 2, 3}->Belt.List.some(isAbove100) /* true */
+assertEqual(list{101, 1, 2, 3}->Belt.List.some(isAbove100), true)
 
-list{1, 2, 3, 4}->Belt.List.some(isAbove100) /* false */
+assertEqual(list{1, 2, 3, 4}->Belt.List.some(isAbove100), false)
 ```
 */
 let some: (t<'a>, 'a => bool) => bool
@@ -620,13 +628,13 @@ up to the shorter length (i.e. `min(length(firstList), length(secondList))`)
 ## Examples
 
 ```rescript
-Belt.List.every2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.every2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b), true)
 
-Belt.List.every2(list{}, list{1}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.every2(list{}, list{1}, (a, b) => a > b), true)
 
-Belt.List.every2(list{2, 3}, list{1}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.every2(list{2, 3}, list{1}, (a, b) => a > b), true)
 
-Belt.List.every2(list{0, 1}, list{5, 0}, (a, b) => a > b) /* false */
+assertEqual(Belt.List.every2(list{0, 1}, list{5, 0}, (a, b) => a > b), false)
 ```
 */
 let every2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
@@ -642,13 +650,13 @@ to the shorter length (i.e. `min(length(firstList), length(secondList))`)
 ## Examples
 
 ```rescript
-Belt.List.some2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.some2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b), true)
 
-Belt.List.some2(list{}, list{1}, (a, b) => a > b) /* false */
+assertEqual(Belt.List.some2(list{}, list{1}, (a, b) => a > b), false)
 
-Belt.List.some2(list{2, 3}, list{1}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.some2(list{2, 3}, list{1}, (a, b) => a > b), true)
 
-Belt.List.some2(list{0, 1}, list{5, 0}, (a, b) => a > b) /* true */
+assertEqual(Belt.List.some2(list{0, 1}, list{5, 0}, (a, b) => a > b), true)
 ```
 */
 let some2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
@@ -662,11 +670,11 @@ less than `length(secondList)`, `0` if `length(firstList)` equals
 ## Examples
 
 ```rescript
-Belt.List.cmpByLength(list{1, 2}, list{3, 4, 5, 6}) /* -1 */
+assertEqual(Belt.List.cmpByLength(list{1, 2}, list{3, 4, 5, 6}), -1)
 
-Belt.List.cmpByLength(list{1, 2, 3}, list{4, 5, 6}) /* = 0 */
+assertEqual(Belt.List.cmpByLength(list{1, 2, 3}, list{4, 5, 6}), 0)
 
-Belt.List.cmpByLength(list{1, 2, 3, 4}, list{5, 6}) /* = 1 */
+assertEqual(Belt.List.cmpByLength(list{1, 2, 3, 4}, list{5, 6}), 1)
 ```
 */
 let cmpByLength: (t<'a>, t<'a>) => int
@@ -686,15 +694,15 @@ If all items have compared equal, but `secondList` is exhausted first, return `1
 ## Examples
 
 ```rescript
-Belt.List.cmp(list{3}, list{3, 7}, (a, b) => compare(a, b)) /* (-1) */
+assertEqual(Belt.List.cmp(list{3}, list{3, 7}, (a, b) => compare(a, b)), (-1))
 
-Belt.List.cmp(list{5, 3}, list{5}, (a, b) => compare(a, b)) /* 1 */
+assertEqual(Belt.List.cmp(list{5, 3}, list{5}, (a, b) => compare(a, b)), 1)
 
-Belt.List.cmp(list{1, 3, 5}, list{1, 4, 2}, (a, b) => compare(a, b)) /* (-1) */
+assertEqual(Belt.List.cmp(list{1, 3, 5}, list{1, 4, 2}, (a, b) => compare(a, b)), (-1))
 
-Belt.List.cmp(list{1, 3, 5}, list{1, 2, 3}, (a, b) => compare(a, b)) /* 1 */
+assertEqual(Belt.List.cmp(list{1, 3, 5}, list{1, 2, 3}, (a, b) => compare(a, b)), 1)
 
-Belt.List.cmp(list{1, 3, 5}, list{1, 3, 5}, (a, b) => compare(a, b)) /* 0 */
+assertEqual(Belt.List.cmp(list{1, 3, 5}, list{1, 3, 5}, (a, b) => compare(a, b)), 0)
 ```
 
 **Please note:** The total ordering of List is different from Array,
@@ -716,11 +724,11 @@ of `firstList` and `secondList` are not the same.
 ## Examples
 
 ```rescript
-Belt.List.eq(list{1, 2, 3}, list{1, 2}, (a, b) => a == b) /* false */
+assertEqual(Belt.List.eq(list{1, 2, 3}, list{1, 2}, (a, b) => a == b), false)
 
-Belt.List.eq(list{1, 2}, list{1, 2}, (a, b) => a == b) /* true */
+assertEqual(Belt.List.eq(list{1, 2}, list{1, 2}, (a, b) => a == b), true)
 
-Belt.List.eq(list{1, 2, 3}, list{(-1), (-2), (-3)}, (a, b) => abs(a) == abs(b)) /* true */
+assertEqual(Belt.List.eq(list{1, 2, 3}, list{(-1), (-2), (-3)}, (a, b) => abs(a) == abs(b)), true)
 ```
 */
 let eq: (t<'a>, t<'a>, ('a, 'a) => bool) => bool
@@ -736,11 +744,11 @@ Returns `true` if the list contains at least one element for which
 ## Examples
 
 ```rescript
-list{1, 2, 3}->Belt.List.has(2, (a, b) => a == b) /* true */
+assertEqual(list{1, 2, 3}->Belt.List.has(2, (a, b) => a == b), true)
 
-list{1, 2, 3}->Belt.List.has(4, (a, b) => a == b) /* false */
+assertEqual(list{1, 2, 3}->Belt.List.has(4, (a, b) => a == b), false)
 
-list{(-1), (-2), (-3)}->Belt.List.has(2, (a, b) => abs(a) == abs(b)) /* true */
+assertEqual(list{(-1), (-2), (-3)}->Belt.List.has(2, (a, b) => abs(a) == abs(b)), true)
 ```
 */
 let has: (t<'a>, 'b, ('a, 'b) => bool) => bool
@@ -756,9 +764,9 @@ predicate function `pred`. Returns `None` if no element satisfies the function.
 ## Examples
 
 ```rescript
-Belt.List.getBy(list{1, 4, 3, 2}, x => x > 3) /* Some(4) */
+assertEqual(Belt.List.getBy(list{1, 4, 3, 2}, x => x > 3), Some(4))
 
-Belt.List.getBy(list{1, 4, 3, 2}, x => x > 4) /* None */
+assertEqual(Belt.List.getBy(list{1, 4, 3, 2}, x => x > 4), None)
 ```
 */
 let getBy: (t<'a>, 'a => bool) => option<'a>
@@ -775,9 +783,9 @@ Returns a list of all elements in `someList` which satisfy the predicate functio
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-Belt.List.keep(list{1, 2, 3, 4}, isEven) /* list{2, 4} */
+assertEqual(Belt.List.keep(list{1, 2, 3, 4}, isEven), list{2, 4})
 
-Belt.List.keep(list{None, Some(2), Some(3), None}, Belt.Option.isSome) /* list{Some(2), Some(3)} */
+assertEqual(Belt.List.keep(list{None, Some(2), Some(3), None}, Belt.Option.isSome), list{Some(2), Some(3)})
 ```
 */
 let keep: (t<'a>, 'a => bool) => t<'a>
@@ -791,9 +799,9 @@ Returns a list of all elements in `someList` which satisfy the predicate functio
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-Belt.List.filter(list{1, 2, 3, 4}, isEven) /* list{2, 4} */
+assertEqual(Belt.List.filter(list{1, 2, 3, 4}, isEven), list{2, 4})
 
-Belt.List.filter(list{None, Some(2), Some(3), None}, Belt.Option.isSome) /* list{Some(2), Some(3)} */
+assertEqual(Belt.List.filter(list{None, Some(2), Some(3), None}, Belt.Option.isSome), list{Some(2), Some(3)})
 ```
 */
 let filter: (t<'a>, 'a => bool) => t<'a>
@@ -810,7 +818,7 @@ Returns a list of all elements in `someList` which satisfy the predicate functio
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-Belt.List.keepWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)) /* list{1, 3} */
+assertEqual(Belt.List.keepWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)), list{1, 3})
 ```
 */
 let keepWithIndex: (t<'a>, ('a, int) => bool) => t<'a>
@@ -827,7 +835,7 @@ Returns a list of all elements in `someList` which satisfy the predicate functio
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-Belt.List.filterWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)) /* list{1, 3} */
+assertEqual(Belt.List.filterWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)), list{1, 3})
 ```
 */
 let filterWithIndex: (t<'a>, ('a, int) => bool) => t<'a>
@@ -854,7 +862,7 @@ list{1, 2, 3, 4}
     }
   ) /* list{2, 4} */
 
-list{Some(1), Some(2), None}->Belt.List.keepMap(x => x) /* list{1, 2} */
+assertEqual(list{Some(1), Some(2), None}->Belt.List.keepMap(x => x), list{1, 2})
 ```
 */
 let keepMap: (t<'a>, 'a => option<'b>) => t<'b>
@@ -888,10 +896,12 @@ Takes a list of pairs and creates a pair of lists. The first list contains all t
 ## Examples
 
 ```rescript
-Belt.List.unzip(list{(1, 2), (3, 4)}) /* (list{1, 3}, list{2, 4}) */
+assertEqual(Belt.List.unzip(list{(1, 2), (3, 4)}), (list{1, 3}, list{2, 4}))
 
-Belt.List.unzip(list{("H", "W"), ("e", "o"), ("l", "r"), ("l", "l"), ("o", "d"), (" ", "!")})
-/* (list{"H", "e", "l", "l", "o", " "}, list{"W", "o", "r", "l", "d", "!"}) */
+assertEqual(
+  Belt.List.unzip(list{("H", "W"), ("e", "o"), ("l", "r"), ("l", "l"), ("o", "d"), (" ", "!")}),
+  (list{"H", "e", "l", "l", "o", " "}, list{"W", "o", "r", "l", "d", "!"})
+)
 ```
 */
 let unzip: t<('a, 'b)> => (t<'a>, t<'b>)
@@ -908,9 +918,11 @@ Return the second element of a pair in `someList` where the first element equals
 ```rescript
 list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.getAssoc(3, (a, b) => a == b) /* Some("c") */
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->Belt.List.getAssoc(15, (k, item) => k /* 15 */ == item /* 9, 5, 22 */)
-/* Some("afternoon") */
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+  ->Belt.List.getAssoc(15, (k, item) => k /* 15 */ == item /* 9, 5, 22 */),
+  Some("afternoon")
+)
 ```
 */
 let getAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => option<'c>
@@ -925,10 +937,15 @@ Returns `true` if there is a pair in `someList` where the first element equals `
 ## Examples
 
 ```rescript
-list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.hasAssoc(1, (a, b) => a == b) /* true */
+assertEqual(
+  list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.hasAssoc(1, (a, b) => a == b),
+  true
+)
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->Belt.List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */) /* false */
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}->Belt.List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */),
+  false
+)
 ```
 */
 let hasAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => bool
@@ -943,11 +960,16 @@ Return a list after removing the first pair whose first value is `k` per the equ
 ## Examples
 
 ```rescript
-list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.removeAssoc(1, (a, b) => a == b) /* list{(2, "b"), (3, "c")} */
+assertEqual(
+  list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.removeAssoc(1, (a, b) => a == b),
+  list{(2, "b"), (3, "c")}
+)
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->Belt.List.removeAssoc(9, (k, item) => k /* 9 */ == item /* 9, 5, 22 */)
-/* list{(15, "afternoon"), (22, "night")} */
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+  ->Belt.List.removeAssoc(9, (k, item) => k /* 9 */ == item /* 9, 5, 22 */),
+  list{(15, "afternoon"), (22, "night")}
+)
 ```
 */
 let removeAssoc: (t<('a, 'c)>, 'b, ('a, 'b) => bool) => t<('a, 'c)>
@@ -962,13 +984,21 @@ If `k` exists in `someList` by satisfying the `eqFunction` predicate, return a n
 ## Examples
 
 ```rescript
-list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.setAssoc(2, "x", (a, b) => a == b) /* list{(1, "a"), (2, "x"), (3, "c")} */
+assertEqual(
+  list{(1, "a"), (2, "b"), (3, "c")}->Belt.List.setAssoc(2, "x", (a, b) => a == b),
+  list{(1, "a"), (2, "x"), (3, "c")}
+)
 
-list{(1, "a"), (3, "c")}->Belt.List.setAssoc(2, "b", (a, b) => a == b) /* list{(2, "b"), (1, "a"), (3, "c")} */
+assertEqual(
+  list{(1, "a"), (3, "c")}->Belt.List.setAssoc(2, "b", (a, b) => a == b),
+  list{(2, "b"), (1, "a"), (3, "c")}
+)
 
-list{(9, "morning"), (3, "morning?!"), (22, "night")}
-->Belt.List.setAssoc(15, "afternoon", (a, b) => mod(a, 12) == mod(b, 12))
-/* list{(9, "morning"), (15, "afternoon"), (22, "night")} */
+assertEqual(
+  list{(9, "morning"), (3, "morning?!"), (22, "night")}
+  ->Belt.List.setAssoc(15, "afternoon", (a, b) => mod(a, 12) == mod(b, 12)),
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+)
 ```
 
 **Please note**
@@ -989,7 +1019,10 @@ Returns a sorted list.
 ## Examples
 
 ```rescript
-Belt.List.sort(list{5, 4, 9, 3, 7}, (a, b) => a - b) // list{3, 4, 5, 7, 9}
+assertEqual(
+  Belt.List.sort(list{5, 4, 9, 3, 7}, (a, b) => a - b),
+  list{3, 4, 5, 7, 9}
+)
 ```
 */
 let sort: (t<'a>, ('a, 'a) => int) => t<'a>

--- a/runtime/Belt_Map.resi
+++ b/runtime/Belt_Map.resi
@@ -160,7 +160,6 @@ let acc = ref(list{})
 
 Belt.Map.forEach(s0, (k, v) => acc := list{(k, v), ...acc.contents})
 
-Console.log(acc.contents)
 assertEqual(acc.contents, list{(4, "4"), (3, "3"),  (2, "2"), (1, "1")})
 ```
 */

--- a/runtime/Belt_Map.resi
+++ b/runtime/Belt_Map.resi
@@ -75,7 +75,7 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.isEmpty(Belt.Map.fromArray([(1, "1")], ~id=module(IntCmp))) == false
+assertEqual(Belt.Map.isEmpty(Belt.Map.fromArray([(1, "1")], ~id=module(IntCmp))), false)
 ```
 */
 let isEmpty: t<_> => bool
@@ -91,7 +91,7 @@ module IntCmp = Belt.Id.MakeComparable({
     let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.has(Belt.Map.fromArray([(1, "1")], ~id=module(IntCmp)), 1) == true
+assertEqual(Belt.Map.has(Belt.Map.fromArray([(1, "1")], ~id=module(IntCmp)), 1), true)
 ```
 */
 let has: (t<'k, 'v, 'id>, 'k) => bool
@@ -154,13 +154,14 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-let s0 = Belt.Map.fromArray(~id=module(IntCmp), [(4, "4"), (1, "1"), (2, "2"), (3, "")])
+let s0 = Belt.Map.fromArray(~id=module(IntCmp), [(4, "4"), (1, "1"), (2, "2"), (3, "3")])
 
 let acc = ref(list{})
 
 Belt.Map.forEach(s0, (k, v) => acc := list{(k, v), ...acc.contents})
 
-acc.contents == list{(4, "4"), (3, "3"), (2, "2"), (1, "1")}
+Console.log(acc.contents)
+assertEqual(acc.contents, list{(4, "4"), (3, "3"),  (2, "2"), (1, "1")})
 ```
 */
 let forEach: (t<'k, 'v, 'id>, ('k, 'v) => unit) => unit
@@ -182,10 +183,13 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Map.fromArray(~id=module(IntCmp), [(4, "4"), (1, "1"), (2, "2"), (3, "3")])
 
-Belt.Map.reduce(s0, list{}, (acc, k, v) => list{
-    (k, v),
-    ...acc,
-}) /* [(4, "4"), (3, "3"), (2, "2"), (1, "1"), 0] */
+assertEqual(
+  Belt.Map.reduce(s0, list{}, (acc, k, v) => list{
+      (k, v),
+      ...acc,
+  }),
+  list{(4, "4"), (3, "3"), (2, "2"), (1, "1")}
+)
 ```
 */
 let reduce: (t<'k, 'v, 'id>, 'acc, ('acc, 'k, 'v) => 'acc) => 'acc
@@ -216,7 +220,10 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.size(Belt.Map.fromArray([(2, "2"), (2, "1"), (3, "3")], ~id=module(IntCmp))) == 2
+assertEqual(
+  Belt.Map.size(Belt.Map.fromArray([(2, "2"), (2, "1"), (3, "3")], ~id=module(IntCmp))),
+  2
+)
 ```
 */
 let size: t<'k, 'v, 'id> => int
@@ -232,11 +239,14 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.toArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))) == [
-  (1, "1"),
-  (2, "2"),
-  (3, "3"),
+assertEqual(
+  Belt.Map.toArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))),
+  [
+    (1, "1"),
+    (2, "2"),
+    (3, "3"),
   ]
+)
 ```
 */
 let toArray: t<'k, 'v, 'id> => array<('k, 'v)>
@@ -255,11 +265,14 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.toArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))) == [
+assertEqual(
+  Belt.Map.toArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))),
+  [
     (1, "1"),
     (2, "2"),
     (3, "3"),
   ]
+)
 ```
 */
 let fromArray: (array<('k, 'v)>, ~id: id<'k, 'id>) => t<'k, 'v, 'id>
@@ -275,11 +288,10 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.keysToArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))) == [
-    1,
-    2,
-    3,
-  ]
+assertEqual(
+  Belt.Map.keysToArray(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))),
+  [1, 2, 3]
+)
 ```
 */
 let keysToArray: t<'k, 'v, 'id> => array<'k>
@@ -295,9 +307,12 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.valuesToArray(
-  Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)),
-) == ["1", "2", "3"]
+assertEqual(
+  Belt.Map.valuesToArray(
+    Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)),
+  ),
+  ["1", "2", "3"]
+)
 ```
 */
 let valuesToArray: t<'k, 'v, 'id> => array<'v>
@@ -337,10 +352,15 @@ module IntCmp = Belt.Id.MakeComparable({
   let cmp = (a, b) => Pervasives.compare(a, b)
 })
 
-Belt.Map.get(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)), 2) ==
+assertEqual(
+  Belt.Map.get(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)), 2),
   Some("2")
+)
 
-Belt.Map.get(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)), 2) == None
+assertEqual(
+  Belt.Map.get(Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp)), 4),
+  None
+)
 ```
 */
 let get: (t<'k, 'v, 'id>, 'k) => option<'v>
@@ -385,9 +405,9 @@ let s1 = Belt.Map.remove(s0, 1)
 
 let s2 = Belt.Map.remove(s1, 1)
 
-s1 === s2
+assertEqual(s1, s2)
 
-Belt.Map.keysToArray(s1) == [2, 3]
+assertEqual(Belt.Map.keysToArray(s1), [2, 3])
 ```
 */
 let remove: (t<'k, 'v, 'id>, 'k) => t<'k, 'v, 'id>
@@ -417,7 +437,7 @@ let s0 = Belt.Map.fromArray([(2, "2"), (1, "1"), (3, "3")], ~id=module(IntCmp))
 
 let s1 = Belt.Map.set(s0, 2, "3")
 
-Belt.Map.valuesToArray(s1) == ["1", "3", "3"]
+assertEqual(Belt.Map.valuesToArray(s1), ["1", "3", "3"])
 ```
 */
 let set: (t<'k, 'v, 'id>, 'k, 'v) => t<'k, 'v, 'id>

--- a/runtime/Belt_MapDict.resi
+++ b/runtime/Belt_MapDict.resi
@@ -78,7 +78,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Map.Dict.fromArray([(4, "4"), (1, "1"), (2, "2"), (3, "3")], ~cmp=IntCmp.cmp)
 
-Belt.Map.Dict.findFirstBy(s0, (k, _) => k == 4) == Some((4, "4"))
+assertEqual(Belt.Map.Dict.findFirstBy(s0, (k, _) => k == 4), Some((4, "4")))
 ```
 */
 let findFirstBy: (t<'k, 'v, 'id>, ('k, 'v) => bool) => option<('k, 'v)>

--- a/runtime/Belt_MutableSet.resi
+++ b/runtime/Belt_MutableSet.resi
@@ -81,7 +81,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([1, 3, 2, 4], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.toArray /* [1, 2, 3, 4] */
+assertEqual(s0->Belt.MutableSet.toArray, [1, 2, 3, 4])
 ```
 */
 let fromArray: (array<'value>, ~id: id<'value, 'id>) => t<'value, 'id>
@@ -105,7 +105,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([1, 3, 2, 4], ~id=module(IntCmp))
 
 let copied = s0->Belt.MutableSet.copy
-copied->Belt.MutableSet.toArray /* [1, 2, 3, 4] */
+assertEqual(copied->Belt.MutableSet.toArray, [1, 2, 3, 4])
 ```
 */
 let copy: t<'value, 'id> => t<'value, 'id>
@@ -124,8 +124,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let empty = Belt.MutableSet.fromArray([], ~id=module(IntCmp))
 let notEmpty = Belt.MutableSet.fromArray([1], ~id=module(IntCmp))
 
-Belt.MutableSet.isEmpty(empty) /* true */
-Belt.MutableSet.isEmpty(notEmpty) /* false */
+assertEqual(Belt.MutableSet.isEmpty(empty), true)
+assertEqual(Belt.MutableSet.isEmpty(notEmpty), false)
 ```
 */
 let isEmpty: t<_> => bool
@@ -143,8 +143,8 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let set = Belt.MutableSet.fromArray([1, 4, 2, 5], ~id=module(IntCmp))
 
-set->Belt.MutableSet.has(3) /* false */
-set->Belt.MutableSet.has(1) /* true */
+assertEqual(set->Belt.MutableSet.has(3), false)
+assertEqual(set->Belt.MutableSet.has(1), true)
 ```
 */
 let has: (t<'value, 'id>, 'value) => bool
@@ -165,7 +165,7 @@ s0->Belt.MutableSet.add(1)
 s0->Belt.MutableSet.add(2)
 s0->Belt.MutableSet.add(2)
 
-s0->Belt.MutableSet.toArray /* [1, 2] */
+assertEqual(s0->Belt.MutableSet.toArray, [1, 2])
 ```
 */
 let add: (t<'value, 'id>, 'value) => unit
@@ -186,7 +186,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let set = Belt.MutableSet.make(~id=module(IntCmp))
 
 set->Belt.MutableSet.mergeMany([5, 4, 3, 2, 1])
-set->Belt.MutableSet.toArray /* [1, 2, 3, 4, 5] */
+assertEqual(set->Belt.MutableSet.toArray, [1, 2, 3, 4, 5])
 ```
 */
 let mergeMany: (t<'value, 'id>, array<'value>) => unit
@@ -207,7 +207,7 @@ s0->Belt.MutableSet.remove(1)
 s0->Belt.MutableSet.remove(3)
 s0->Belt.MutableSet.remove(3)
 
-s0->Belt.MutableSet.toArray /* [2,4,5] */
+assertEqual(s0->Belt.MutableSet.toArray, [2,4,5])
 ```
 */
 let remove: (t<'value, 'id>, 'value) => unit
@@ -229,7 +229,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let set = Belt.MutableSet.fromArray([1, 2, 3, 4], ~id=module(IntCmp))
 
 set->Belt.MutableSet.removeMany([5, 4, 3, 2, 1])
-set->Belt.MutableSet.toArray /* [] */
+assertEqual(set->Belt.MutableSet.toArray, [])
 ```
 */
 let removeMany: (t<'value, 'id>, array<'value>) => unit
@@ -248,7 +248,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([5, 2, 3, 1, 5, 4], ~id=module(IntCmp))
 let union = Belt.MutableSet.union(s0, s1)
-union->Belt.MutableSet.toArray /* [1,2,3,4,5,6] */
+assertEqual(union->Belt.MutableSet.toArray, [1,2,3,4,5,6])
 ```
 */
 let union: (t<'value, 'id>, t<'value, 'id>) => t<'value, 'id>
@@ -267,7 +267,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([5, 2, 3, 1, 5, 4], ~id=module(IntCmp))
 let intersect = Belt.MutableSet.intersect(s0, s1)
-intersect->Belt.MutableSet.toArray /* [2,3,5] */
+assertEqual(intersect->Belt.MutableSet.toArray, [2,3,5])
 ```
 */
 let intersect: (t<'value, 'id>, t<'value, 'id>) => t<'value, 'id>
@@ -285,8 +285,8 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([5, 2, 3, 1, 5, 4], ~id=module(IntCmp))
-Belt.MutableSet.toArray(Belt.MutableSet.diff(s0, s1)) /* [6] */
-Belt.MutableSet.toArray(Belt.MutableSet.diff(s1, s0)) /* [1,4] */
+assertEqual(Belt.MutableSet.toArray(Belt.MutableSet.diff(s0, s1)), [6])
+assertEqual(Belt.MutableSet.toArray(Belt.MutableSet.diff(s1, s0)), [1,4])
 ```
 */
 let diff: (t<'value, 'id>, t<'value, 'id>) => t<'value, 'id>
@@ -305,9 +305,9 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([5, 2, 3, 1, 5, 4], ~id=module(IntCmp))
 let s2 = Belt.MutableSet.intersect(s0, s1)
-Belt.MutableSet.subset(s2, s0) /* true */
-Belt.MutableSet.subset(s2, s1) /* true */
-Belt.MutableSet.subset(s1, s0) /* false */
+assertEqual(Belt.MutableSet.subset(s2, s0), true)
+assertEqual(Belt.MutableSet.subset(s2, s1), true)
+assertEqual(Belt.MutableSet.subset(s1, s0), false)
 ```
 */
 let subset: (t<'value, 'id>, t<'value, 'id>) => bool
@@ -332,7 +332,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([5, 2, 3], ~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([3, 2, 5], ~id=module(IntCmp))
 
-Belt.MutableSet.eq(s0, s1) /* true */
+assertEqual(Belt.MutableSet.eq(s0, s1), true)
 ```
 */
 let eq: (t<'value, 'id>, t<'value, 'id>) => bool
@@ -357,7 +357,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
 let acc = ref(list{})
 s0->Belt.MutableSet.forEach(x => acc := Belt.List.add(acc.contents, x))
-acc /* [6,5,3,2] */
+assertEqual(acc.contents, list{6, 5, 3, 2})
 ```
 */
 let forEach: (t<'value, 'id>, 'value => unit) => unit
@@ -377,7 +377,10 @@ module IntCmp = Belt.Id.MakeComparable({
 })
 
 let s0 = Belt.MutableSet.fromArray([5, 2, 3, 5, 6], ~id=module(IntCmp))
-s0->Belt.MutableSet.reduce(list{}, (acc, element) => acc->Belt.List.add(element)) /* [6,5,3,2] */
+assertEqual(
+  s0->Belt.MutableSet.reduce(list{}, (acc, element) => acc->Belt.List.add(element)),
+  list{6, 5, 3, 2}
+)
 ```
 */
 let reduce: (t<'value, 'id>, 'a, ('a, 'value) => 'a) => 'a
@@ -399,7 +402,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let isEven = x => mod(x, 2) == 0
 
 let s0 = Belt.MutableSet.fromArray([2, 4, 6, 8], ~id=module(IntCmp))
-s0->Belt.MutableSet.every(isEven) /* true */
+assertEqual(s0->Belt.MutableSet.every(isEven), true)
 ```
 */
 let every: (t<'value, 'id>, 'value => bool) => bool
@@ -421,7 +424,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let isOdd = x => mod(x, 2) != 0
 
 let s0 = Belt.MutableSet.fromArray([1, 2, 4, 6, 8], ~id=module(IntCmp))
-s0->Belt.MutableSet.some(isOdd) /* true */
+assertEqual(s0->Belt.MutableSet.some(isOdd), true)
 ```
 */
 let some: (t<'value, 'id>, 'value => bool) => bool
@@ -445,7 +448,7 @@ let isEven = x => mod(x, 2) == 0
 let s0 = Belt.MutableSet.fromArray([1, 2, 3, 4, 5], ~id=module(IntCmp))
 let s1 = s0->Belt.MutableSet.keep(isEven)
 
-s1->Belt.MutableSet.toArray /* [2, 4] */
+assertEqual(s1->Belt.MutableSet.toArray, [2, 4])
 ```
 */
 let keep: (t<'value, 'id>, 'value => bool) => t<'value, 'id>
@@ -467,8 +470,8 @@ let isOdd = x => mod(x, 2) != 0
 let s0 = Belt.MutableSet.fromArray([1, 2, 3, 4, 5], ~id=module(IntCmp))
 let (s1, s2) = s0->Belt.MutableSet.partition(isOdd)
 
-s1->Belt.MutableSet.toArray /* [1,3,5] */
-s2->Belt.MutableSet.toArray /* [2,4] */
+assertEqual(s1->Belt.MutableSet.toArray, [1,3,5])
+assertEqual(s2->Belt.MutableSet.toArray, [2,4])
 ```
 */
 let partition: (t<'value, 'id>, 'value => bool) => (t<'value, 'id>, t<'value, 'id>)
@@ -486,7 +489,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([1, 2, 3, 4], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.size /* 4 */
+assertEqual(s0->Belt.MutableSet.size, 4)
 ```
 */
 let size: t<'value, 'id> => int
@@ -504,7 +507,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.toList /* [1,2,3,5] */
+assertEqual(s0->Belt.MutableSet.toList, list{1, 2, 3, 5})
 ```
 */
 let toList: t<'value, 'id> => list<'value>
@@ -522,7 +525,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.toArray /* [1,2,3,5] */
+assertEqual(s0->Belt.MutableSet.toArray, [1,2,3,5])
 ```
 */
 let toArray: t<'value, 'id> => array<'value>
@@ -541,8 +544,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.make(~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.minimum /* None */
-s1->Belt.MutableSet.minimum /* Some(1) */
+assertEqual(s0->Belt.MutableSet.minimum, None)
+assertEqual(s1->Belt.MutableSet.minimum, Some(1))
 ```
 */
 let minimum: t<'value, 'id> => option<'value>
@@ -561,8 +564,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.make(~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.minUndefined /* undefined */
-s1->Belt.MutableSet.minUndefined /* 1 */
+assertEqual(s0->Belt.MutableSet.minUndefined, Js.undefined)
+assertEqual(s1->Belt.MutableSet.minUndefined, Js.Undefined.return(1))
 ```
 */
 let minUndefined: t<'value, 'id> => Js.undefined<'value>
@@ -581,8 +584,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.make(~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.maximum /* None */
-s1->Belt.MutableSet.maximum /* Some(5) */
+assertEqual(s0->Belt.MutableSet.maximum, None)
+assertEqual(s1->Belt.MutableSet.maximum, Some(5))
 ```
 */
 let maximum: t<'value, 'id> => option<'value>
@@ -601,8 +604,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.MutableSet.make(~id=module(IntCmp))
 let s1 = Belt.MutableSet.fromArray([3, 2, 1, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.maxUndefined /* undefined */
-s1->Belt.MutableSet.maxUndefined /* 5 */
+assertEqual(s0->Belt.MutableSet.maxUndefined, Js.undefined)
+assertEqual(s1->Belt.MutableSet.maxUndefined, Js.Undefined.return(5))
 ```
 */
 let maxUndefined: t<'value, 'id> => Js.undefined<'value>
@@ -620,8 +623,8 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.MutableSet.fromArray([1, 2, 3, 4, 5], ~id=module(IntCmp))
 
-s0->Belt.MutableSet.get(3) /* Some(3) */
-s0->Belt.MutableSet.get(20) /* None */
+assertEqual(s0->Belt.MutableSet.get(3), Some(3))
+assertEqual(s0->Belt.MutableSet.get(20), None)
 ```
 */
 let get: (t<'value, 'id>, 'value) => option<'value>
@@ -651,9 +654,9 @@ let s0 = Belt.MutableSet.fromArray([1, 2, 3, 4, 5], ~id=module(IntCmp))
 
 let ((smaller, larger), present) = s0->Belt.MutableSet.split(3)
 
-present /* true */
-smaller->Belt.MutableSet.toArray /* [1,2] */
-larger->Belt.MutableSet.toArray /* [4,5] */
+assertEqual(present, true)
+assertEqual(smaller->Belt.MutableSet.toArray, [1,2])
+assertEqual(larger->Belt.MutableSet.toArray, [4,5])
 ```
 */
 let split: (t<'value, 'id>, 'value) => ((t<'value, 'id>, t<'value, 'id>), bool)

--- a/runtime/Belt_Option.resi
+++ b/runtime/Belt_Option.resi
@@ -50,9 +50,9 @@ If `optionValue` is `Some(value)` and `p(value) = true`, it returns `Some(value)
 ## Examples
 
 ```rescript
-Belt.Option.keep(Some(10), x => x > 5) /* returns `Some(10)` */
-Belt.Option.keep(Some(4), x => x > 5) /* returns `None` */
-Belt.Option.keep(None, x => x > 5) /* returns `None` */
+assertEqual(Belt.Option.keep(Some(10), x => x > 5), Some(10))
+assertEqual(Belt.Option.keep(Some(4), x => x > 5), None)
+assertEqual(Belt.Option.keep(None, x => x > 5), None)
 ```
 */
 let keep: (option<'a>, 'a => bool) => option<'a>
@@ -113,10 +113,10 @@ If `optionValue` is `None`, the default is returned.
 
 ```rescript
 let someValue = Some(3)
-someValue->Belt.Option.mapWithDefault(0, x => x + 5) /* 8 */
+assertEqual(someValue->Belt.Option.mapWithDefault(0, x => x + 5), 8)
 
 let noneValue = None
-noneValue->Belt.Option.mapWithDefault(0, x => x + 5) /* 0 */
+assertEqual(noneValue->Belt.Option.mapWithDefault(0, x => x + 5), 0)
 ```
 */
 let mapWithDefault: (option<'a>, 'b, 'a => 'b) => 'b
@@ -131,9 +131,9 @@ If `optionValue` is `Some(value)` this returns `f(value)`, otherwise it returns 
 ## Examples
 
 ```rescript
-Belt.Option.map(Some(3), x => x * x) /* Some(9) */
+assertEqual(Belt.Option.map(Some(3), x => x * x), Some(9))
 
-Belt.Option.map(None, x => x * x) /* None */
+assertEqual(Belt.Option.map(None, x => x * x), None)
 ```
 */
 let map: (option<'a>, 'a => 'b) => option<'b>
@@ -157,11 +157,11 @@ let addIfAboveOne = value =>
       None
    }
 
-Belt.Option.flatMap(Some(2), addIfAboveOne) /* Some(3) */
+assertEqual(Belt.Option.flatMap(Some(2), addIfAboveOne), Some(3))
 
-Belt.Option.flatMap(Some(-4), addIfAboveOne) /* None */
+assertEqual(Belt.Option.flatMap(Some(-4), addIfAboveOne), None)
 
-Belt.Option.flatMap(None, addIfAboveOne) /* None */
+assertEqual(Belt.Option.flatMap(None, addIfAboveOne), None)
 ```
 */
 let flatMap: (option<'a>, 'a => option<'b>) => option<'b>
@@ -172,18 +172,18 @@ If `optionalValue` is `Some(value)`, returns `value`, otherwise default.
 ## Examples
 
 ```rescript
-Belt.Option.getWithDefault(None, "Banana") /* Banana */
+assertEqual(Belt.Option.getWithDefault(None, "Banana"), "Banana")
 
-Belt.Option.getWithDefault(Some("Apple"), "Banana") /* Apple */
+assertEqual(Belt.Option.getWithDefault(Some("Apple"), "Banana"), "Apple")
 ```
 
 ```rescript
 let greet = (firstName: option<string>) =>
    "Greetings " ++ firstName->Belt.Option.getWithDefault("Anonymous")
 
-Some("Jane")->greet /* "Greetings Jane" */
+assertEqual(Some("Jane")->greet, "Greetings Jane")
 
-None->greet /* "Greetings Anonymous" */
+assertEqual(None->greet, "Greetings Anonymous")
 ```
 */
 let getWithDefault: (option<'a>, 'a) => 'a
@@ -195,9 +195,9 @@ returns `Some(value)`, otherwise `otherOptional`
 ## Examples
 
 ```rescript
-Belt.Option.orElse(Some(1812), Some(1066)) == Some(1812)
-Belt.Option.orElse(None, Some(1066)) == Some(1066)
-Belt.Option.orElse(None, None) == None
+assertEqual(Belt.Option.orElse(Some(1812), Some(1066)), Some(1812))
+assertEqual(Belt.Option.orElse(None, Some(1066)), Some(1066))
+assertEqual(Belt.Option.orElse(None, None), None)
 ```
 */
 let orElse: (option<'a>, option<'a>) => option<'a>
@@ -208,9 +208,9 @@ Returns `true` if the argument is `Some(value)`, `false` otherwise.
 ## Examples
 
 ```rescript
-Belt.Option.isSome(None) /* false */
+assertEqual(Belt.Option.isSome(None), false)
 
-Belt.Option.isSome(Some(1)) /* true */
+assertEqual(Belt.Option.isSome(Some(1)), true)
 ```
 */
 let isSome: option<'a> => bool
@@ -221,9 +221,9 @@ Returns `true` if the argument is `None`, `false` otherwise.
 ## Examples
 
 ```rescript
-Belt.Option.isNone(None) /* true */
+assertEqual(Belt.Option.isNone(None), true)
 
-Belt.Option.isNone(Some(1)) /* false */
+assertEqual(Belt.Option.isNone(Some(1)), false)
 ```
 */
 let isNone: option<'a> => bool
@@ -250,13 +250,13 @@ let clockEqual = (a, b) => mod(a, 12) == mod(b, 12)
 
 open Belt.Option
 
-eq(Some(3), Some(15), clockEqual) /* true */
+assertEqual(eq(Some(3), Some(15), clockEqual), true)
 
-eq(Some(3), None, clockEqual) /* false */
+assertEqual(eq(Some(3), None, clockEqual), false)
 
-eq(None, Some(3), clockEqual) /* false */
+assertEqual(eq(None, Some(3), clockEqual), false)
 
-eq(None, None, clockEqual) /* true */
+assertEqual(eq(None, None, clockEqual), true)
 ```
 */
 let eq: (option<'a>, option<'b>, ('a, 'b) => bool) => bool
@@ -291,17 +291,17 @@ let clockCompare = (a, b) => compare(mod(a, 12), mod(b, 12))
 
 open Belt.Option
 
-cmp(Some(3), Some(15), clockCompare) /* 0 */
+assertEqual(cmp(Some(3), Some(15), clockCompare), 0)
 
-cmp(Some(3), Some(14), clockCompare) /* 1 */
+assertEqual(cmp(Some(3), Some(14), clockCompare), 1)
 
-cmp(Some(2), Some(15), clockCompare) /* (-1) */
+assertEqual(cmp(Some(2), Some(15), clockCompare), (-1))
 
-cmp(None, Some(15), clockCompare) /* (-1) */
+assertEqual(cmp(None, Some(15), clockCompare), (-1))
 
-cmp(Some(14), None, clockCompare) /* 1 */
+assertEqual(cmp(Some(14), None, clockCompare), 1)
 
-cmp(None, None, clockCompare) /* 0 */
+assertEqual(cmp(None, None, clockCompare), 0)
 ```
 */
 let cmp: (option<'a>, option<'b>, ('a, 'b) => int) => int

--- a/runtime/Belt_Range.resi
+++ b/runtime/Belt_Range.resi
@@ -57,9 +57,9 @@ let everyU: (int, int, int => bool) => bool
 ## Examples
 
 ```rescript
-Belt.Range.every(0, 4, (i) => i < 5) /* true */
+assertEqual(Belt.Range.every(0, 4, (i) => i < 5), true)
 
-Belt.Range.every(0, 4, (i) => i < 4) /* false */
+assertEqual(Belt.Range.every(0, 4, (i) => i < 4), false)
 ```
 */
 let every: (int, int, int => bool) => bool
@@ -74,9 +74,9 @@ let everyByU: (int, int, ~step: int, int => bool) => bool
 ## Examples
 
 ```rescript
-Belt.Range.everyBy(0, 4, ~step=1, (i) => mod(i, 2) === 0) /* false */
+assertEqual(Belt.Range.everyBy(0, 4, ~step=1, (i) => mod(i, 2) === 0), false)
 
-Belt.Range.everyBy(0, 4, ~step=2, (i) => mod(i, 2) === 0) /* true */
+assertEqual(Belt.Range.everyBy(0, 4, ~step=2, (i) => mod(i, 2) === 0), true)
 ```
 */
 let everyBy: (int, int, ~step: int, int => bool) => bool
@@ -90,9 +90,9 @@ let someU: (int, int, int => bool) => bool
 ## Examples
 
 ```rescript
-Belt.Range.some(0, 4, (i) => i > 5) /* false */
+assertEqual(Belt.Range.some(0, 4, (i) => i > 5), false)
 
-Belt.Range.some(0, 4, (i) => i > 2) /* true */
+assertEqual(Belt.Range.some(0, 4, (i) => i > 2), true)
 ```
 */
 let some: (int, int, int => bool) => bool
@@ -107,8 +107,8 @@ let someByU: (int, int, ~step: int, int => bool) => bool
 ## Examples
 
 ```rescript
-Belt.Range.someBy(1, 5, ~step=2, (i) => mod(i, 2) === 0) /* false */
-Belt.Range.someBy(0, 4, ~step=2, (i) => mod(i, 2) === 0) /* true */
+assertEqual(Belt.Range.someBy(1, 5, ~step=2, (i) => mod(i, 2) === 0), false)
+assertEqual(Belt.Range.someBy(0, 4, ~step=2, (i) => mod(i, 2) === 0), true)
 ```
 */
 let someBy: (int, int, ~step: int, int => bool) => bool

--- a/runtime/Belt_Result.resi
+++ b/runtime/Belt_Result.resi
@@ -62,10 +62,10 @@ otherwise `default`.
 
 ```rescript
 let ok = Belt.Result.Ok(42)
-Belt.Result.mapWithDefault(ok, 0, (x) => x / 2) == 21
+assertEqual(Belt.Result.mapWithDefault(ok, 0, (x) => x / 2), 21)
 
 let error = Belt.Result.Error("Invalid data")
-Belt.Result.mapWithDefault(error, 0, (x) => x / 2) == 0
+assertEqual(Belt.Result.mapWithDefault(error, 0, (x) => x / 2), 0)
 ```
 */
 let mapWithDefault: (t<'a, 'c>, 'b, 'a => 'b) => 'b
@@ -82,9 +82,9 @@ ordinary value.
 ```rescript
 let f = (x) => sqrt(Belt.Int.toFloat(x))
 
-Belt.Result.map(Ok(64), f) == Ok(8.0)
+assertEqual(Belt.Result.map(Ok(64), f), Ok(8.0))
 
-Belt.Result.map(Error("Invalid data"), f) == Error("Invalid data")
+assertEqual(Belt.Result.map(Error("Invalid data"), f), Error("Invalid data"))
 ```
 */
 let map: (t<'a, 'c>, 'a => 'b) => t<'b, 'c>
@@ -106,11 +106,11 @@ let recip = (x) =>
     Belt.Result.Error("Divide by zero")
   }
 
-Belt.Result.flatMap(Ok(2.0), recip) == Ok(0.5)
+assertEqual(Belt.Result.flatMap(Ok(2.0), recip), Ok(0.5))
 
-Belt.Result.flatMap(Ok(0.0), recip) == Error("Divide by zero")
+assertEqual(Belt.Result.flatMap(Ok(0.0), recip), Error("Divide by zero"))
 
-Belt.Result.flatMap(Error("Already bad"), recip) == Error("Already bad")
+assertEqual(Belt.Result.flatMap(Error("Already bad"), recip), Error("Already bad"))
 ```
 */
 let flatMap: (t<'a, 'c>, 'a => t<'b, 'c>) => t<'b, 'c>
@@ -122,9 +122,9 @@ otherwise `default`
 ## Examples
 
 ```rescript
-Belt.Result.getWithDefault(Ok(42), 0) == 42
+assertEqual(Belt.Result.getWithDefault(Ok(42), 0), 42)
 
-Belt.Result.getWithDefault(Error("Invalid Data"), 0) == 0
+assertEqual(Belt.Result.getWithDefault(Error("Invalid Data"), 0), 0)
 ```
 */
 let getWithDefault: (t<'a, 'b>, 'a) => 'a
@@ -163,13 +163,13 @@ let bad2 = Belt.Result.Error("really invalid")
 
 let mod10equal = (a, b) => mod(a, 10) === mod(b, 10)
 
-Belt.Result.eq(good1, good2, mod10equal) == true
+assertEqual(Belt.Result.eq(good1, good2, mod10equal), true)
 
-Belt.Result.eq(good1, bad1, mod10equal) == false
+assertEqual(Belt.Result.eq(good1, bad1, mod10equal), false)
 
-Belt.Result.eq(bad2, good2, mod10equal) == false
+assertEqual(Belt.Result.eq(bad2, good2, mod10equal), false)
 
-Belt.Result.eq(bad1, bad2, mod10equal) == true
+assertEqual(Belt.Result.eq(bad1, bad2, mod10equal), true)
 ```
 */
 let eq: (t<'a, 'c>, t<'b, 'd>, ('a, 'b) => bool) => bool
@@ -201,15 +201,15 @@ let bad2 = Belt.Result.Error("really invalid")
 
 let mod10cmp = (a, b) => Pervasives.compare(mod(a, 10), mod(b, 10))
 
-Belt.Result.cmp(Ok(39), Ok(57), mod10cmp) == 1
+assertEqual(Belt.Result.cmp(Ok(39), Ok(57), mod10cmp), 1)
 
-Belt.Result.cmp(Ok(57), Ok(39), mod10cmp) == (-1)
+assertEqual(Belt.Result.cmp(Ok(57), Ok(39), mod10cmp), (-1))
 
-Belt.Result.cmp(Ok(39), Error("y"), mod10cmp) == 1
+assertEqual(Belt.Result.cmp(Ok(39), Error("y"), mod10cmp), 1)
 
-Belt.Result.cmp(Error("x"), Ok(57), mod10cmp) == (-1)
+assertEqual(Belt.Result.cmp(Error("x"), Ok(57), mod10cmp), (-1))
 
-Belt.Result.cmp(Error("x"), Error("y"), mod10cmp) == 0
+assertEqual(Belt.Result.cmp(Error("x"), Error("y"), mod10cmp), 0)
 ```
 */
 let cmp: (t<'a, 'c>, t<'b, 'd>, ('a, 'b) => int) => int

--- a/runtime/Belt_SetDict.resi
+++ b/runtime/Belt_SetDict.resi
@@ -62,7 +62,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Set.Dict.fromArray([1, 3, 2, 4], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.toArray /* [1, 2, 3, 4] */
+assertEqual(s0->Belt.Set.Dict.toArray, [1, 2, 3, 4])
 ```
 */
 let fromArray: (array<'value>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -87,8 +87,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let empty = Belt.Set.Dict.fromArray([], ~cmp=IntCmp.cmp)
 let notEmpty = Belt.Set.Dict.fromArray([1], ~cmp=IntCmp.cmp)
 
-Belt.Set.Dict.isEmpty(empty) /* true */
-Belt.Set.Dict.isEmpty(notEmpty) /* false */
+assertEqual(Belt.Set.Dict.isEmpty(empty), true)
+assertEqual(Belt.Set.Dict.isEmpty(notEmpty), false)
 ```
 */
 let isEmpty: t<_> => bool
@@ -106,8 +106,8 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let set = Belt.Set.Dict.fromArray([1, 4, 2, 5], ~cmp=IntCmp.cmp)
 
-set->Belt.Set.Dict.has(3, ~cmp=IntCmp.cmp) /* false */
-set->Belt.Set.Dict.has(1, ~cmp=IntCmp.cmp) /* true */
+assertEqual(set->Belt.Set.Dict.has(3, ~cmp=IntCmp.cmp), false)
+assertEqual(set->Belt.Set.Dict.has(1, ~cmp=IntCmp.cmp), true)
 ```
 */
 let has: (t<'value, 'id>, 'value, ~cmp: cmp<'value, 'id>) => bool
@@ -127,11 +127,11 @@ let s0 = Belt.Set.Dict.empty
 let s1 = s0->Belt.Set.Dict.add(1, ~cmp=IntCmp.cmp)
 let s2 = s1->Belt.Set.Dict.add(2, ~cmp=IntCmp.cmp)
 let s3 = s2->Belt.Set.Dict.add(2, ~cmp=IntCmp.cmp)
-s0->Belt.Set.Dict.toArray /* [] */
-s1->Belt.Set.Dict.toArray /* [1] */
-s2->Belt.Set.Dict.toArray /* [1, 2] */
-s3->Belt.Set.Dict.toArray /* [1,2 ] */
-s2 == s3 /* true */
+assertEqual(s0->Belt.Set.Dict.toArray, [])
+assertEqual(s1->Belt.Set.Dict.toArray, [1])
+assertEqual(s2->Belt.Set.Dict.toArray, [1, 2])
+assertEqual(s3->Belt.Set.Dict.toArray, [1, 2])
+assertEqual(s2, s3)
 ```
 */
 let add: (t<'value, 'id>, 'value, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -150,7 +150,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let set = Belt.Set.Dict.empty
 
 let newSet = set->Belt.Set.Dict.mergeMany([5, 4, 3, 2, 1], ~cmp=IntCmp.cmp)
-newSet->Belt.Set.Dict.toArray /* [1, 2, 3, 4, 5] */
+assertEqual(newSet->Belt.Set.Dict.toArray, [1, 2, 3, 4, 5])
 ```
 */
 let mergeMany: (t<'value, 'id>, array<'value>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -171,9 +171,9 @@ let s1 = s0->Belt.Set.Dict.remove(1, ~cmp=IntCmp.cmp)
 let s2 = s1->Belt.Set.Dict.remove(3, ~cmp=IntCmp.cmp)
 let s3 = s2->Belt.Set.Dict.remove(3, ~cmp=IntCmp.cmp)
 
-s1->Belt.Set.Dict.toArray /* [2,3,4,5] */
-s2->Belt.Set.Dict.toArray /* [2,4,5] */
-s2 == s3 /* true */
+assertEqual(s1->Belt.Set.Dict.toArray, [2,3,4,5])
+assertEqual(s2->Belt.Set.Dict.toArray, [2,4,5])
+assertEqual(s2, s3)
 ```
 */
 let remove: (t<'value, 'id>, 'value, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -192,7 +192,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let set = Belt.Set.Dict.fromArray([1, 2, 3, 4], ~cmp=IntCmp.cmp)
 
 let newSet = set->Belt.Set.Dict.removeMany([5, 4, 3, 2, 1], ~cmp=IntCmp.cmp)
-newSet->Belt.Set.Dict.toArray /* [] */
+assertEqual(newSet->Belt.Set.Dict.toArray, [])
 ```
 */
 let removeMany: (t<'value, 'id>, array<'value>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -211,7 +211,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3, 5, 6], ~cmp=IntCmp.cmp)
 let s1 = Belt.Set.Dict.fromArray([5, 2, 3, 1, 5, 4], ~cmp=IntCmp.cmp)
 let union = Belt.Set.Dict.union(s0, s1, ~cmp=IntCmp.cmp)
-union->Belt.Set.Dict.toArray /* [1,2,3,4,5,6] */
+assertEqual(union->Belt.Set.Dict.toArray, [1,2,3,4,5,6])
 ```
 */
 let union: (t<'value, 'id>, t<'value, 'id>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -230,7 +230,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3, 5, 6], ~cmp=IntCmp.cmp)
 let s1 = Belt.Set.Dict.fromArray([5, 2, 3, 1, 5, 4], ~cmp=IntCmp.cmp)
 let intersect = Belt.Set.Dict.intersect(s0, s1, ~cmp=IntCmp.cmp)
-intersect->Belt.Set.Dict.toArray /* [2,3,5] */
+assertEqual(intersect->Belt.Set.Dict.toArray, [2,3,5])
 ```
 */
 let intersect: (t<'value, 'id>, t<'value, 'id>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -252,8 +252,8 @@ let s1 = Belt.Set.Dict.fromArray([5, 2, 3, 1, 5, 4], ~cmp=IntCmp.cmp)
 let diff1 = Belt.Set.Dict.diff(s0, s1, ~cmp=IntCmp.cmp)
 let diff2 = Belt.Set.Dict.diff(s1, s0, ~cmp=IntCmp.cmp)
 
-diff1->Belt.Set.Dict.toArray /* [6] */
-diff2->Belt.Set.Dict.toArray /* [1,4] */
+assertEqual(diff1->Belt.Set.Dict.toArray, [6])
+assertEqual(diff2->Belt.Set.Dict.toArray, [1,4])
 ```
 */
 let diff: (t<'value, 'id>, t<'value, 'id>, ~cmp: cmp<'value, 'id>) => t<'value, 'id>
@@ -272,9 +272,9 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3, 5, 6], ~cmp=IntCmp.cmp)
 let s1 = Belt.Set.Dict.fromArray([5, 2, 3, 1, 5, 4], ~cmp=IntCmp.cmp)
 let s2 = Belt.Set.Dict.intersect(s0, s1, ~cmp=IntCmp.cmp)
-Belt.Set.Dict.subset(s2, s0, ~cmp=IntCmp.cmp) /* true */
-Belt.Set.Dict.subset(s2, s1, ~cmp=IntCmp.cmp) /* true */
-Belt.Set.Dict.subset(s1, s0, ~cmp=IntCmp.cmp) /* false */
+assertEqual(Belt.Set.Dict.subset(s2, s0, ~cmp=IntCmp.cmp), true)
+assertEqual(Belt.Set.Dict.subset(s2, s1, ~cmp=IntCmp.cmp), true)
+assertEqual(Belt.Set.Dict.subset(s1, s0, ~cmp=IntCmp.cmp), false)
 ```
 */
 let subset: (t<'value, 'id>, t<'value, 'id>, ~cmp: cmp<'value, 'id>) => bool
@@ -300,7 +300,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3], ~cmp=IntCmp.cmp)
 let s1 = Belt.Set.Dict.fromArray([3, 2, 5], ~cmp=IntCmp.cmp)
 
-Belt.Set.Dict.eq(s0, s1, ~cmp=IntCmp.cmp) /* true */
+assertEqual(Belt.Set.Dict.eq(s0, s1, ~cmp=IntCmp.cmp), true)
 ```
 */
 let eq: (t<'value, 'id>, t<'value, 'id>, ~cmp: cmp<'value, 'id>) => bool
@@ -325,7 +325,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3, 5, 6], ~cmp=IntCmp.cmp)
 let acc = ref(list{})
 s0->Belt.Set.Dict.forEach(x => acc := Belt.List.add(acc.contents, x))
-acc /* [6,5,3,2] */
+assertEqual(acc.contents, list{6, 5, 3, 2})
 ```
 */
 let forEach: (t<'value, 'id>, 'value => unit) => unit
@@ -345,7 +345,10 @@ module IntCmp = Belt.Id.MakeComparable({
 })
 
 let s0 = Belt.Set.Dict.fromArray([5, 2, 3, 5, 6], ~cmp=IntCmp.cmp)
-s0->Belt.Set.Dict.reduce(list{}, (acc, element) => acc->Belt.List.add(element)) /* [6,5,3,2] */
+assertEqual(
+  s0->Belt.Set.Dict.reduce(list{}, (acc, element) => acc->Belt.List.add(element)),
+  list{6, 5, 3, 2}
+)
 ```
 */
 let reduce: (t<'value, 'id>, 'a, ('a, 'value) => 'a) => 'a
@@ -367,7 +370,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let isEven = x => mod(x, 2) == 0
 
 let s0 = Belt.Set.Dict.fromArray([2, 4, 6, 8], ~cmp=IntCmp.cmp)
-s0->Belt.Set.Dict.every(isEven) /* true */
+assertEqual(s0->Belt.Set.Dict.every(isEven), true)
 ```
 */
 let every: (t<'value, 'id>, 'value => bool) => bool
@@ -389,7 +392,7 @@ module IntCmp = Belt.Id.MakeComparable({
 let isOdd = x => mod(x, 2) != 0
 
 let s0 = Belt.Set.Dict.fromArray([1, 2, 4, 6, 8], ~cmp=IntCmp.cmp)
-s0->Belt.Set.Dict.some(isOdd) /* true */
+assertEqual(s0->Belt.Set.Dict.some(isOdd), true)
 ```
 */
 let some: (t<'value, 'id>, 'value => bool) => bool
@@ -413,7 +416,7 @@ let isEven = x => mod(x, 2) == 0
 let s0 = Belt.Set.Dict.fromArray([1, 2, 3, 4, 5], ~cmp=IntCmp.cmp)
 let s1 = s0->Belt.Set.Dict.keep(isEven)
 
-s1->Belt.Set.Dict.toArray /* [2,4] */
+assertEqual(s1->Belt.Set.Dict.toArray, [2,4])
 ```
 */
 let keep: (t<'value, 'id>, 'value => bool) => t<'value, 'id>
@@ -437,8 +440,8 @@ let isOdd = x => mod(x, 2) != 0
 let s0 = Belt.Set.Dict.fromArray([1, 2, 3, 4, 5], ~cmp=IntCmp.cmp)
 let (s1, s2) = s0->Belt.Set.Dict.partition(isOdd)
 
-s1->Belt.Set.Dict.toArray /* [1,3,5] */
-s2->Belt.Set.Dict.toArray /* [2,4] */
+assertEqual(s1->Belt.Set.Dict.toArray, [1,3,5])
+assertEqual(s2->Belt.Set.Dict.toArray, [2,4])
 ```
 */
 let partition: (t<'value, 'id>, 'value => bool) => (t<'value, 'id>, t<'value, 'id>)
@@ -456,7 +459,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Set.Dict.fromArray([1, 2, 3, 4], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.size /* 4 */
+assertEqual(s0->Belt.Set.Dict.size, 4)
 ```
 */
 let size: t<'value, 'id> => int
@@ -474,7 +477,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.toList /* [1,2,3,5] */
+assertEqual(s0->Belt.Set.Dict.toList, list{1, 2, 3, 5})
 ```
 */
 let toList: t<'value, 'id> => list<'value>
@@ -492,7 +495,7 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.toArray /* [1,2,3,5] */
+assertEqual(s0->Belt.Set.Dict.toArray, [1,2,3,5])
 ```
 */
 let toArray: t<'value, 'id> => array<'value>
@@ -511,8 +514,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.empty
 let s1 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.minimum /* None */
-s1->Belt.Set.Dict.minimum /* Some(1) */
+assertEqual(s0->Belt.Set.Dict.minimum, None)
+assertEqual(s1->Belt.Set.Dict.minimum, Some(1))
 ```
 */
 let minimum: t<'value, 'id> => option<'value>
@@ -531,8 +534,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.empty
 let s1 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.minUndefined /* undefined */
-s1->Belt.Set.Dict.minUndefined /* 1 */
+assertEqual(s0->Belt.Set.Dict.minUndefined, Js.undefined)
+assertEqual(s1->Belt.Set.Dict.minUndefined, Js.Undefined.return(1))
 ```
 */
 let minUndefined: t<'value, 'id> => Js.undefined<'value>
@@ -551,8 +554,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.empty
 let s1 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.maximum /* None */
-s1->Belt.Set.Dict.maximum /* Some(5) */
+assertEqual(s0->Belt.Set.Dict.maximum, None)
+assertEqual(s1->Belt.Set.Dict.maximum, Some(5))
 ```
 */
 let maximum: t<'value, 'id> => option<'value>
@@ -571,8 +574,8 @@ module IntCmp = Belt.Id.MakeComparable({
 let s0 = Belt.Set.Dict.empty
 let s1 = Belt.Set.Dict.fromArray([3, 2, 1, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.maxUndefined /* undefined */
-s1->Belt.Set.Dict.maxUndefined /* 5 */
+assertEqual(s0->Belt.Set.Dict.maxUndefined, Js.undefined)
+assertEqual(s1->Belt.Set.Dict.maxUndefined, Js.Undefined.return(5))
 ```
 */
 let maxUndefined: t<'value, 'id> => Js.undefined<'value>
@@ -591,8 +594,8 @@ module IntCmp = Belt.Id.MakeComparable({
 
 let s0 = Belt.Set.Dict.fromArray([1, 2, 3, 4, 5], ~cmp=IntCmp.cmp)
 
-s0->Belt.Set.Dict.get(3, ~cmp=IntCmp.cmp) /* Some(3) */
-s0->Belt.Set.Dict.get(20, ~cmp=IntCmp.cmp) /* None */
+assertEqual(s0->Belt.Set.Dict.get(3, ~cmp=IntCmp.cmp), Some(3))
+assertEqual(s0->Belt.Set.Dict.get(20, ~cmp=IntCmp.cmp), None)
 ```
 */
 let get: (t<'value, 'id>, 'value, ~cmp: cmp<'value, 'id>) => option<'value>
@@ -622,9 +625,9 @@ let s0 = Belt.Set.Dict.fromArray([1, 2, 3, 4, 5], ~cmp=IntCmp.cmp)
 
 let ((smaller, larger), present) = s0->Belt.Set.Dict.split(3, ~cmp=IntCmp.cmp)
 
-present /* true */
-smaller->Belt.Set.Dict.toArray /* [1,2] */
-larger->Belt.Set.Dict.toArray /* [4,5] */
+assertEqual(present, true)
+assertEqual(smaller->Belt.Set.Dict.toArray, [1,2])
+assertEqual(larger->Belt.Set.Dict.toArray, [4,5])
 ```
 */
 let split: (

--- a/runtime/Belt_SortArray.resi
+++ b/runtime/Belt_SortArray.resi
@@ -45,13 +45,13 @@ let strictlySortedLengthU: (array<'a>, ('a, 'a) => bool) => int
 ## Examples
 
 ```rescript
-Belt.SortArray.strictlySortedLength([1, 2, 3, 4, 3], (x, y) => x < y) == 4
+assertEqual(Belt.SortArray.strictlySortedLength([1, 2, 3, 4, 3], (x, y) => x < y), 4)
 
-Belt.SortArray.strictlySortedLength([], (x, y) => x < y) == 0
+assertEqual(Belt.SortArray.strictlySortedLength([], (x, y) => x < y), 0)
 
-Belt.SortArray.strictlySortedLength([1], (x, y) => x < y) == 1
+assertEqual(Belt.SortArray.strictlySortedLength([1], (x, y) => x < y), 1)
 
-Belt.SortArray.strictlySortedLength([4, 3, 2, 1], (x, y) => x < y) == -4
+assertEqual(Belt.SortArray.strictlySortedLength([4, 3, 2, 1], (x, y) => x < y), -4)
 ```
 */
 let strictlySortedLength: (array<'a>, ('a, 'a) => bool) => int
@@ -93,9 +93,9 @@ than all elements return `lnot(-1) == 0` since `lnot(- (len + 1)) == len`
 ## Examples
 
 ```rescript
-Belt.SortArray.binarySearchBy([1, 2, 3, 4, 33, 35, 36], 33, Pervasives.compare) == 4
+assertEqual(Belt.SortArray.binarySearchBy([1, 2, 3, 4, 33, 35, 36], 33, Pervasives.compare), 4)
 
-lnot(Belt.SortArray.binarySearchBy([1, 3, 5, 7], 4, Pervasives.compare)) == 2
+assertEqual(lnot(Belt.SortArray.binarySearchBy([1, 3, 5, 7], 4, Pervasives.compare)), 2)
 ```
 */
 let binarySearchBy: (array<'a>, 'a, ('a, 'a) => int) => int

--- a/runtime/Stdlib_List.resi
+++ b/runtime/Stdlib_List.resi
@@ -42,7 +42,7 @@ type t<'a> = list<'a>
 ## Examples
 
 ```rescript
-List.length(list{1, 2, 3}) // 3
+assertEqual(List.length(list{1, 2, 3}), 3)
 ```
 */
 let length: list<'a> => int
@@ -53,7 +53,7 @@ let length: list<'a> => int
 ## Examples
 
 ```rescript
-List.size(list{1, 2, 3}) // 3
+assertEqual(List.size(list{1, 2, 3}), 3)
 ```
 */
 let size: list<'a> => int
@@ -65,8 +65,8 @@ list, or `None` if `list` is an empty list.
 ## Examples
 
 ```rescript
-List.head(list{}) // None
-List.head(list{1, 2, 3}) // Some(1)
+assertEqual(List.head(list{}), None)
+assertEqual(List.head(list{1, 2, 3}), Some(1))
 ```
 */
 let head: list<'a> => option<'a>
@@ -99,9 +99,9 @@ where `tail` is everything except the first element of `list`.
 ## Examples
 
 ```rescript
-List.tail(list{1, 2, 3}) // Some(list{2, 3})
+assertEqual(List.tail(list{1, 2, 3}), Some(list{2, 3}))
 
-List.tail(list{}) // None
+assertEqual(List.tail(list{}), None)
 ```
 */
 let tail: list<'a> => option<list<'a>>
@@ -132,9 +132,9 @@ let tailExn: list<'a> => list<'a>
 ## Examples
 
 ```rescript
-List.add(list{2, 3}, 1) // list{1, 2, 3}
+assertEqual(List.add(list{2, 3}, 1), list{1, 2, 3})
 
-List.add(list{"World", "!"}, "Hello") // list{"Hello", "World", "!"}
+assertEqual(List.add(list{"World", "!"}, "Hello"), list{"Hello", "World", "!"})
 ```
 */
 let add: (list<'a>, 'a) => list<'a>
@@ -148,9 +148,9 @@ is larger than the length of list `list`.
 ```rescript
 let abc = list{"A", "B", "C"}
 
-abc->List.get(1) // Some("B")
+assertEqual(abc->List.get(1), Some("B"))
 
-abc->List.get(4) // None
+assertEqual(abc->List.get(4), None)
 ```
 */
 let get: (list<'a>, int) => option<'a>
@@ -186,7 +186,7 @@ with `value`. Returns an empty list if `value` is negative.
 ## Examples
 
 ```rescript
-List.make(~length=3, 1) // list{1, 1, 1}
+assertEqual(List.make(~length=3, 1), list{1, 1, 1})
 ```
 */
 let make: (~length: int, 'a) => list<'a>
@@ -198,9 +198,9 @@ with `f`. Returns an empty list if `length` is negative.
 ## Examples
 
 ```rescript
-List.fromInitializer(~length=5, i => i) // list{0, 1, 2, 3, 4}
+assertEqual(List.fromInitializer(~length=5, i => i), list{0, 1, 2, 3, 4})
 
-List.fromInitializer(~length=5, i => i * i) // list{0, 1, 4, 9, 16}
+assertEqual(List.fromInitializer(~length=5, i => i * i), list{0, 1, 4, 9, 16})
 ```
 */
 let fromInitializer: (~length: int, int => 'a) => list<'a>
@@ -235,11 +235,11 @@ Returns `None` if `list` has fewer than `value` elements.
 ## Examples
 
 ```rescript
-list{1, 2, 3}->List.drop(2) // Some(list{3})
+assertEqual(list{1, 2, 3}->List.drop(2), Some(list{3}))
 
-list{1, 2, 3}->List.drop(3) // Some(list{})
+assertEqual(list{1, 2, 3}->List.drop(3), Some(list{}))
 
-list{1, 2, 3}->List.drop(4) // None
+assertEqual(list{1, 2, 3}->List.drop(4), None)
 ```
 */
 let drop: (list<'a>, int) => option<list<'a>>
@@ -251,11 +251,11 @@ or `None` if `list` has fewer than `value` elements.
 ## Examples
 
 ```rescript
-list{1, 2, 3}->List.take(1) // Some(list{1})
+assertEqual(list{1, 2, 3}->List.take(1), Some(list{1}))
 
-list{1, 2, 3}->List.take(2) // Some(list{1, 2})
+assertEqual(list{1, 2, 3}->List.take(2), Some(list{1, 2}))
 
-list{1, 2, 3}->List.take(4) // None
+assertEqual(list{1, 2, 3}->List.take(4), None)
 ```
 */
 let take: (list<'a>, int) => option<list<'a>>
@@ -267,9 +267,9 @@ of `list` is less than `n`.
 ## Examples
 
 ```rescript
-list{"Hello", "World"}->List.splitAt(1) // Some((list{"Hello"}, list{"World"}))
+assertEqual(list{"Hello", "World"}->List.splitAt(1), Some((list{"Hello"}, list{"World"})))
 
-list{0, 1, 2, 3, 4}->List.splitAt(2) // Some((list{0, 1}, list{2, 3, 4}))
+assertEqual(list{0, 1, 2, 3, 4}->List.splitAt(2), Some((list{0, 1}, list{2, 3, 4})))
 ```
 */
 let splitAt: (list<'a>, int) => option<(list<'a>, list<'a>)>
@@ -292,7 +292,7 @@ array `arr`, in order.
 ## Examples
 
 ```rescript
-List.concatMany([list{1, 2, 3}, list{}, list{3}]) // list{1, 2, 3, 3}
+assertEqual(List.concatMany([list{1, 2, 3}, list{}, list{3}]), list{1, 2, 3, 3})
 ```
 */
 let concatMany: array<list<'a>> => list<'a>
@@ -303,7 +303,7 @@ let concatMany: array<list<'a>> => list<'a>
 ## Examples
 
 ```rescript
-List.reverseConcat(list{1, 2}, list{3, 4}) // list{2, 1, 3, 4}
+assertEqual(List.reverseConcat(list{1, 2}, list{3, 4}), list{2, 1, 3, 4})
 ```
 */
 let reverseConcat: (list<'a>, list<'a>) => list<'a>
@@ -315,7 +315,7 @@ let reverseConcat: (list<'a>, list<'a>) => list<'a>
 ## Examples
 
 ```rescript
-List.flat(list{list{1, 2, 3}, list{}, list{3}}) // list{1, 2, 3, 3}
+assertEqual(List.flat(list{list{1, 2, 3}, list{}, list{3}}), list{1, 2, 3, 3})
 ```
 */
 let flat: list<list<'a>> => list<'a>
@@ -326,7 +326,7 @@ let flat: list<list<'a>> => list<'a>
 ## Examples
 
 ```rescript
-list{1, 2}->List.map(x => x + 1) // list{3, 4}
+assertEqual(list{1, 2}->List.map(x => x + 1), list{2, 3})
 ```
 */
 let map: (list<'a>, 'a => 'b) => list<'b>
@@ -338,7 +338,7 @@ of the shorter list.
 ## Examples
 
 ```rescript
-List.zip(list{1, 2}, list{3, 4, 5}) // list{(1, 3), (2, 4)}
+assertEqual(List.zip(list{1, 2}, list{3, 4, 5}), list{(1, 3), (2, 4)})
 ```
 */
 let zip: (list<'a>, list<'b>) => list<('a, 'b)>
@@ -349,7 +349,7 @@ let zip: (list<'a>, list<'b>) => list<('a, 'b)>
 ## Examples
 
 ```rescript
-List.zipBy(list{1, 2, 3}, list{4, 5}, (a, b) => 2 * a + b) // list{6, 9}
+assertEqual(List.zipBy(list{1, 2, 3}, list{4, 5}, (a, b) => 2 * a + b), list{6, 9})
 ```
 */
 let zipBy: (list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>
@@ -362,7 +362,7 @@ that order.
 ## Examples
 
 ```rescript
-list{1, 2, 3}->List.mapWithIndex((x, index) => index + x) // list{1, 3, 5}
+assertEqual(list{1, 2, 3}->List.mapWithIndex((x, index) => index + x), list{1, 3, 5})
 ```
 */
 let mapWithIndex: (list<'a>, ('a, int) => 'b) => list<'b>
@@ -373,7 +373,7 @@ let mapWithIndex: (list<'a>, ('a, int) => 'b) => list<'b>
 ## Examples
 
 ```rescript
-List.fromArray([1, 2, 3]) // list{1, 2, 3}
+assertEqual(List.fromArray([1, 2, 3]), list{1, 2, 3})
 ```
 */
 let fromArray: array<'a> => list<'a>
@@ -384,7 +384,7 @@ let fromArray: array<'a> => list<'a>
 ## Examples
 
 ```rescript
-List.toArray(list{1, 2, 3}) // [1, 2, 3]
+assertEqual(List.toArray(list{1, 2, 3}), [1, 2, 3])
 ```
 */
 let toArray: list<'a> => array<'a>
@@ -396,7 +396,7 @@ reversed order.
 ## Examples
 
 ```rescript
-List.reverse(list{1, 2, 3}) // list{3, 2, 1}
+assertEqual(List.reverse(list{1, 2, 3}), list{3, 2, 1})
 ```
 */
 let reverse: list<'a> => list<'a>
@@ -467,11 +467,11 @@ the final value of the accumulator.
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->List.reduce(0, (a, b) => a + b) // 10
+assertEqual(list{1, 2, 3, 4}->List.reduce(0, (a, b) => a + b), 10)
 
 // same as
 
-list{1, 2, 3, 4}->List.reduce(0, (acc, item) => acc + item) // 10
+assertEqual(list{1, 2, 3, 4}->List.reduce(0, (acc, item) => acc + item), 10)
 ```
 */
 let reduce: (list<'a>, 'b, ('b, 'a) => 'b) => 'b
@@ -485,7 +485,7 @@ of each element. `reduceWithIndex` returns the final value of the accumulator.
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->List.reduceWithIndex(0, (acc, item, index) => acc + item + index) // 16
+assertEqual(list{1, 2, 3, 4}->List.reduceWithIndex(0, (acc, item, index) => acc + item + index), 16)
 ```
 */
 let reduceWithIndex: (list<'a>, 'b, ('b, 'a, int) => 'b) => 'b
@@ -497,11 +497,11 @@ function `f` is applied to each item of `list` from the last back to the first.
 ## Examples
 
 ```rescript
-list{1, 2, 3, 4}->List.reduceReverse(0, (a, b) => a + b) // 10
+assertEqual(list{1, 2, 3, 4}->List.reduceReverse(0, (a, b) => a + b), 10)
 
-list{1, 2, 3, 4}->List.reduceReverse(10, (a, b) => a - b) // 0
+assertEqual(list{1, 2, 3, 4}->List.reduceReverse(10, (a, b) => a - b), 0)
 
-list{1, 2, 3, 4}->List.reduceReverse(list{}, List.add) // list{1, 2, 3, 4}
+assertEqual(list{1, 2, 3, 4}->List.reduceReverse(list{}, List.add), list{1, 2, 3, 4})
 ```
 */
 let reduceReverse: (list<'a>, 'b, ('b, 'a) => 'b) => 'b
@@ -512,7 +512,7 @@ let reduceReverse: (list<'a>, 'b, ('b, 'a) => 'b) => 'b
 ## Examples
 
 ```rescript
-List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}
+assertEqual(List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b), list{4, 2})
 ```
 */
 let mapReverse2: (list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>
@@ -545,7 +545,10 @@ accumulator.
 ## Examples
 
 ```rescript
-List.reduce2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) // 0 + (1 * 1 + 4) + (2 * 2 + 5)
+assertEqual(
+  List.reduce2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y),
+  0 + (1 * 1 + 4) + (2 * 2 + 5)
+)
 ```
 */
 let reduce2: (list<'b>, list<'c>, 'a, ('a, 'b, 'c) => 'a) => 'a
@@ -560,7 +563,10 @@ final value of the accumulator.
 ## Examples
 
 ```rescript
-List.reduceReverse2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y) //  + (1 * 1 + 4) + (2 * 2 + 5)
+assertEqual(
+  List.reduceReverse2(list{1, 2, 3}, list{4, 5}, 0, (acc, x, y) => acc + x * x + y),
+  0  + (1 * 1 + 4) + (2 * 2 + 5)
+)
 ```
 */
 let reduceReverse2: (list<'a>, list<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
@@ -574,9 +580,9 @@ is a predicate: a function taking an element and returning a bool.
 ```rescript
 let isBelow10 = value => value < 10
 
-list{1, 9, 8, 2}->List.every(isBelow10) // true
+assertEqual(list{1, 9, 8, 2}->List.every(isBelow10), true)
 
-list{1, 99, 8, 2}->List.every(isBelow10) // false
+assertEqual(list{1, 99, 8, 2}->List.every(isBelow10), false)
 ```
 */
 let every: (list<'a>, 'a => bool) => bool
@@ -591,9 +597,9 @@ returning a bool.
 ```rescript
 let isAbove100 = value => value > 100
 
-list{101, 1, 2, 3}->List.some(isAbove100) // true
+assertEqual(list{101, 1, 2, 3}->List.some(isAbove100), true)
 
-list{1, 2, 3, 4}->List.some(isAbove100) // false
+assertEqual(list{1, 2, 3, 4}->List.some(isAbove100), false)
 ```
 */
 let some: (list<'a>, 'a => bool) => bool
@@ -605,13 +611,13 @@ pairs of elements up to the shorter length (i.e. `min(length(list1), length(list
 ## Examples
 
 ```rescript
-List.every2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b) // true
+assertEqual(List.every2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b), true)
 
-List.every2(list{}, list{1}, (a, b) => a > b) // true
+assertEqual(List.every2(list{}, list{1}, (a, b) => a > b), true)
 
-List.every2(list{2, 3}, list{1}, (a, b) => a > b) // true
+assertEqual(List.every2(list{2, 3}, list{1}, (a, b) => a > b), true)
 
-List.every2(list{0, 1}, list{5, 0}, (a, b) => a > b) // false
+assertEqual(List.every2(list{0, 1}, list{5, 0}, (a, b) => a > b), false)
 ```
 */
 let every2: (list<'a>, list<'b>, ('a, 'b) => bool) => bool
@@ -623,13 +629,13 @@ of elements up to the shorter length (i.e. `min(length(list1), length(list2))`)
 ## Examples
 
 ```rescript
-List.some2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b) // true
+assertEqual(List.some2(list{1, 2, 3}, list{0, 1}, (a, b) => a > b), true)
 
-List.some2(list{}, list{1}, (a, b) => a > b) // false
+assertEqual(List.some2(list{}, list{1}, (a, b) => a > b), false)
 
-List.some2(list{2, 3}, list{1}, (a, b) => a > b) // true
+assertEqual(List.some2(list{2, 3}, list{1}, (a, b) => a > b), true)
 
-List.some2(list{0, 1}, list{5, 0}, (a, b) => a > b) // true
+assertEqual(List.some2(list{0, 1}, list{5, 0}, (a, b) => a > b), true)
 ```
 */
 let some2: (list<'a>, list<'b>, ('a, 'b) => bool) => bool
@@ -642,11 +648,11 @@ let some2: (list<'a>, list<'b>, ('a, 'b) => bool) => bool
 ## Examples
 
 ```rescript
-List.compareLength(list{1, 2}, list{3, 4, 5, 6}) // -1.
+assertEqual(List.compareLength(list{1, 2}, list{3, 4, 5, 6}), -1.)
 
-List.compareLength(list{1, 2, 3}, list{4, 5, 6}) // 0.
+assertEqual(List.compareLength(list{1, 2, 3}, list{4, 5, 6}), 0.)
 
-List.compareLength(list{1, 2, 3, 4}, list{5, 6}) // 1.
+assertEqual(List.compareLength(list{1, 2, 3, 4}, list{5, 6}), 1.)
 ```
 */
 let compareLength: (list<'a>, list<'a>) => Stdlib_Ordering.t
@@ -665,11 +671,11 @@ zero for all `list1` and `list2`.
 ## Examples
 
 ```rescript
-List.compare(list{3}, list{3, 7}, (a, b) => Int.compare(a, b)) // -1.
-List.compare(list{5, 3}, list{5}, (a, b) => Int.compare(a, b)) // 1.
-List.compare(list{1, 3, 5}, list{1, 4, 2}, (a, b) => Int.compare(a, b)) // -1.
-List.compare(list{1, 3, 5}, list{1, 2, 3}, (a, b) => Int.compare(a, b)) // 1.
-List.compare(list{1, 3, 5}, list{1, 3, 5}, (a, b) => Int.compare(a, b)) // 0.
+assertEqual(List.compare(list{3}, list{3, 7}, (a, b) => Int.compare(a, b)), -1.)
+assertEqual(List.compare(list{5, 3}, list{5}, (a, b) => Int.compare(a, b)), 1.)
+assertEqual(List.compare(list{1, 3, 5}, list{1, 4, 2}, (a, b) => Int.compare(a, b)), -1.)
+assertEqual(List.compare(list{1, 3, 5}, list{1, 2, 3}, (a, b) => Int.compare(a, b)), 1.)
+assertEqual(List.compare(list{1, 3, 5}, list{1, 3, 5}, (a, b) => Int.compare(a, b)), 0.)
 ```
 
 **Please note:** The total ordering of List is different from Array,
@@ -687,11 +693,11 @@ of `list1` and `list2` are not the same.
 ## Examples
 
 ```rescript
-List.equal(list{1, 2, 3}, list{1, 2}, (a, b) => a == b) // false
+assertEqual(List.equal(list{1, 2, 3}, list{1, 2}, (a, b) => a == b), false)
 
-List.equal(list{1, 2}, list{1, 2}, (a, b) => a == b) // true
+assertEqual(List.equal(list{1, 2}, list{1, 2}, (a, b) => a == b), true)
 
-List.equal(list{1, 2, 3}, list{(-1), (-2), (-3)}, (a, b) => abs(a) == abs(b)) // true
+assertEqual(List.equal(list{1, 2, 3}, list{(-1), (-2), (-3)}, (a, b) => abs(a) == abs(b)), true)
 ```
 */
 let equal: (list<'a>, list<'a>, ('a, 'a) => bool) => bool
@@ -703,11 +709,11 @@ let equal: (list<'a>, list<'a>, ('a, 'a) => bool) => bool
 ## Examples
 
 ```rescript
-list{1, 2, 3}->List.has(2, (a, b) => a == b) // true
+assertEqual(list{1, 2, 3}->List.has(2, (a, b) => a == b), true)
 
-list{1, 2, 3}->List.has(4, (a, b) => a == b) // false
+assertEqual(list{1, 2, 3}->List.has(4, (a, b) => a == b), false)
 
-list{(-1), (-2), (-3)}->List.has(2, (a, b) => abs(a) == abs(b)) // true
+assertEqual(list{(-1), (-2), (-3)}->List.has(2, (a, b) => abs(a) == abs(b)), true)
 ```
 */
 let has: (list<'a>, 'b, ('a, 'b) => bool) => bool
@@ -720,9 +726,9 @@ the function.
 ## Examples
 
 ```rescript
-List.find(list{1, 4, 3, 2}, x => x > 3) // Some(4)
+assertEqual(List.find(list{1, 4, 3, 2}, x => x > 3), Some(4))
 
-List.find(list{1, 4, 3, 2}, x => x > 4) // None
+assertEqual(List.find(list{1, 4, 3, 2}, x => x > 4), None)
 ```
 */
 let find: (list<'a>, 'a => bool) => option<'a>
@@ -736,9 +742,9 @@ predicate function `f`.
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-List.filter(list{1, 2, 3, 4}, isEven) // list{2, 4}
+assertEqual(List.filter(list{1, 2, 3, 4}, isEven), list{2, 4})
 
-List.filter(list{None, Some(2), Some(3), None}, Option.isSome) // list{Some(2), Some(3)}
+assertEqual(List.filter(list{None, Some(2), Some(3), None}, Option.isSome), list{Some(2), Some(3)})
 ```
 */
 let filter: (list<'a>, 'a => bool) => list<'a>
@@ -752,7 +758,7 @@ satisfy the predicate function `f`.
 ```rescript
 let isEven = x => mod(x, 2) == 0
 
-List.filterWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)) // list{1, 3}
+assertEqual(List.filterWithIndex(list{1, 2, 3, 4}, (_x, index) => isEven(index)), list{1, 3})
 ```
 */
 let filterWithIndex: (list<'a>, ('a, int) => bool) => list<'a>
@@ -776,7 +782,7 @@ list{1, 2, 3, 4}
     }
   ) // list{2, 4}
 
-list{Some(1), Some(2), None}->List.filterMap(x => x) // list{1, 2}
+assertEqual(list{Some(1), Some(2), None}->List.filterMap(x => x), list{1, 2})
 ```
 */
 let filterMap: (list<'a>, 'a => option<'b>) => list<'b>
@@ -791,7 +797,7 @@ consists of all elements of `list` that _do not_ satisfy `f`.
 ```rescript
 // (elementsThatSatisfies, elementsThatDoesNotSatisfy)
 
-List.partition(list{1, 2, 3, 4}, x => x > 2) // (list{3, 4}, list{1, 2})
+assertEqual(List.partition(list{1, 2, 3, 4}, x => x > 2), (list{3, 4}, list{1, 2}))
 ```
 */
 let partition: (list<'a>, 'a => bool) => (list<'a>, list<'a>)
@@ -806,8 +812,10 @@ second items.
 ```rescript
 List.unzip(list{(1, 2), (3, 4)}) // (list{1, 3}, list{2, 4})
 
-List.unzip(list{("H", "W"), ("e", "o"), ("l", "r"), ("l", "l"), ("o", "d"), (" ", "!")})
-// (list{"H", "e", "l", "l", "o", " "}, list{"W", "o", "r", "l", "d", "!"})
+assertEqual(
+  List.unzip(list{("H", "W"), ("e", "o"), ("l", "r"), ("l", "l"), ("o", "d"), (" ", "!")}),
+  (list{"H", "e", "l", "l", "o", " "}, list{"W", "o", "r", "l", "d", "!"})
+)
 ```
 */
 let unzip: list<('a, 'b)> => (list<'a>, list<'b>)
@@ -822,9 +830,11 @@ not found.
 ```rescript
 list{(1, "a"), (2, "b"), (3, "c")}->List.getAssoc(3, (a, b) => a == b) // Some("c")
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->List.getAssoc(15, (k, item) => k /* 15 */ == item /* 9, 5, 22 */)
-// Some("afternoon")
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+  ->List.getAssoc(15, (k, item) => k /* 15 */ == item /* 9, 5, 22 */),
+  Some("afternoon")
+)
 ```
 */
 @deprecated("Use a `Map` instead")
@@ -839,8 +849,11 @@ first element equals `k` as per the predicate function `f`.
 ```rescript
 list{(1, "a"), (2, "b"), (3, "c")}->List.hasAssoc(1, (a, b) => a == b) // true
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */) // false
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+  ->List.hasAssoc(25, (k, item) => k /* 25 */ == item /* 9, 5, 22 */),
+  false
+)
 ```
 */
 @deprecated("Use a `Map` instead")
@@ -856,9 +869,11 @@ list identical to `list`.
 ```rescript
 list{(1, "a"), (2, "b"), (3, "c")}->List.removeAssoc(1, (a, b) => a == b) // list{(2, "b"), (3, "c")}
 
-list{(9, "morning"), (15, "afternoon"), (22, "night")}
-->List.removeAssoc(9, (k, item) => k /* 9 */ == item /* 9, 5, 22 */)
-// list{(15, "afternoon"), (22, "night")}
+assertEqual(
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+  ->List.removeAssoc(9, (k, item) => k /* 9 */ == item /* 9, 5, 22 */),
+  list{(15, "afternoon"), (22, "night")}
+)
 ```
 */
 @deprecated("Use a `Map` instead")
@@ -873,13 +888,21 @@ predicate, return a new list with the key and value replaced by the new `k` and
 ## Examples
 
 ```rescript
-list{(1, "a"), (2, "b"), (3, "c")}->List.setAssoc(2, "x", (a, b) => a == b) // list{(1, "a"), (2, "x"), (3, "c")}
+assertEqual(
+  list{(1, "a"), (2, "b"), (3, "c")}->List.setAssoc(2, "x", (a, b) => a == b),
+  list{(1, "a"), (2, "x"), (3, "c")}
+)
 
-list{(1, "a"), (3, "c")}->List.setAssoc(2, "b", (a, b) => a == b) // list{(2, "b"), (1, "a"), (3, "c")}
+assertEqual(
+  list{(1, "a"), (3, "c")}->List.setAssoc(2, "b", (a, b) => a == b),
+  list{(2, "b"), (1, "a"), (3, "c")}
+)
 
-list{(9, "morning"), (3, "morning?!"), (22, "night")}
-->List.setAssoc(15, "afternoon", (a, b) => mod(a, 12) == mod(b, 12))
-// list{(9, "morning"), (15, "afternoon"), (22, "night")}
+assertEqual(
+  list{(9, "morning"), (3, "morning?!"), (22, "night")}
+  ->List.setAssoc(15, "afternoon", (a, b) => mod(a, 12) == mod(b, 12)),
+  list{(9, "morning"), (15, "afternoon"), (22, "night")}
+)
 ```
 
 **Please note**: In the last example, since: `15 mod 12` equals `3 mod 12`. Both
@@ -894,7 +917,10 @@ let setAssoc: (list<('a, 'c)>, 'a, 'c, ('a, 'a) => bool) => list<('a, 'c)>
 ## Examples
 
 ```rescript
-List.sort(list{5, 4, 9, 3, 7}, Int.compare) // list{3, 4, 5, 7, 9}
+assertEqual(
+  List.sort(list{5, 4, 9, 3, 7}, Int.compare),
+  list{3, 4, 5, 7, 9}
+)
 ```
 */
 let sort: (list<'a>, ('a, 'a) => Stdlib_Ordering.t) => list<'a>

--- a/runtime/Stdlib_Math.resi
+++ b/runtime/Stdlib_Math.resi
@@ -145,8 +145,8 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.abs(-2) // 2
-  Math.Int.abs(3) // 3
+  assertEqual(Math.Int.abs(-2), 2)
+  assertEqual(Math.Int.abs(3), 3)
   ```
   */
   @val
@@ -161,9 +161,9 @@ module Int: {
 
   ```rescript
   // 00000000000000000000000000000001
-  Math.Int.clz32(1) // 31
+  assertEqual(Math.Int.clz32(1), 31)
   // 00000000000000000000000000000100
-  Math.Int.clz32(4) // 29
+  assertEqual(Math.Int.clz32(4), 29)
   ```
   */
   @val
@@ -178,8 +178,8 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.imul(3, 4) // 12
-  Math.Int.imul(-5, 12) // 60
+  assertEqual(Math.Int.imul(3, 4), 12)
+  assertEqual(Math.Int.imul(-5, 12), -60)
   ```
   */
   @val
@@ -192,8 +192,8 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.min(1, 2) // 1
-  Math.Int.min(-1, -2) // -2
+  assertEqual(Math.Int.min(1, 2), 1)
+  assertEqual(Math.Int.min(-1, -2), -2)
   ```
   */
   @val
@@ -207,9 +207,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.minMany([1, 2]) // 1
-  Math.Int.minMany([-1, -2]) // -2
-  Math.Int.minMany([])->Int.toFloat->Float.isFinite // false
+  assertEqual(Math.Int.minMany([1, 2]), 1)
+  assertEqual(Math.Int.minMany([-1, -2]), -2)
+  assertEqual(Math.Int.minMany([])->Int.toFloat->Float.isFinite, false)
   ```
   */
   @variadic
@@ -223,8 +223,8 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.max(1, 2) // 2
-  Math.Int.max(-1, -2) // -1
+  assertEqual(Math.Int.max(1, 2), 2)
+  assertEqual(Math.Int.max(-1, -2), -1)
   ```
   */
   @val
@@ -238,9 +238,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.maxMany([1, 2]) // 2
-  Math.Int.maxMany([-1, -2]) // -1
-  Math.Int.maxMany([])->Int.toFloat->Float.isFinite // false
+  assertEqual(Math.Int.maxMany([1, 2]), 2)
+  assertEqual(Math.Int.maxMany([-1, -2]), -1)
+  assertEqual(Math.Int.maxMany([])->Int.toFloat->Float.isFinite, false)
   ```
   */
   @variadic
@@ -254,8 +254,8 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.pow(2, ~exp=4) // 16
-  Math.Int.pow(3, ~exp=4) // 81
+  assertEqual(Math.Int.pow(2, ~exp=4), 16)
+  assertEqual(Math.Int.pow(3, ~exp=4), 81)
   ```
   */
   @val
@@ -269,9 +269,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.sign(3) // 1
-  Math.Int.sign(-3) // -1
-  Math.Int.sign(0) // 0
+  assertEqual(Math.Int.sign(3), 1)
+  assertEqual(Math.Int.sign(-3), -1)
+  assertEqual(Math.Int.sign(0), 0)
   ```
   */
   @val
@@ -285,9 +285,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.floor(3.7) == 3
-  Math.Int.floor(3.0) == 3
-  Math.Int.floor(-3.1) == -4
+  assertEqual(Math.Int.floor(3.7), 3)
+  assertEqual(Math.Int.floor(3.0), 3)
+  assertEqual(Math.Int.floor(-3.1), -4)
   ```
   */
   let floor: float => int
@@ -300,9 +300,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.ceil(3.7) == 4
-  Math.Int.ceil(3.0) == 3
-  Math.Int.ceil(-3.1) == -3
+  assertEqual(Math.Int.ceil(3.7), 4)
+  assertEqual(Math.Int.ceil(3.0), 3)
+  assertEqual(Math.Int.ceil(-3.1), -3)
   ```
   */
   let ceil: float => int
@@ -315,9 +315,9 @@ module Int: {
   ## Examples
 
   ```rescript
-  Math.Int.random(2, 5) == 4
-  Math.Int.random(505, 2000) == 1276
-  Math.Int.random(-7, -2) == -4
+  Math.Int.random(2, 5)
+  Math.Int.random(505, 2000)
+  Math.Int.random(-7, -2)
   ```
   */
   let random: (int, int) => int
@@ -330,8 +330,8 @@ See [`Math.abs`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.abs(-2.0) // 2.0
-Math.abs(3.0) // 3.0
+assertEqual(Math.abs(-2.0), 2.0)
+assertEqual(Math.abs(3.0), 3.0)
 ```
   */
 @val
@@ -345,8 +345,8 @@ See [`Math.acos`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.acos(-1.0) // 3.141592653589793
-Math.acos(-3.0)->Float.isNaN // true
+assertEqual(Math.acos(-1.0), 3.141592653589793)
+assertEqual(Math.acos(-3.0)->Float.isNaN, true)
 ```
 */
 @val
@@ -360,8 +360,8 @@ See [`Math.acosh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.acosh(1.0) // 0.0
-Math.acosh(0.5)->Float.isNaN // true
+assertEqual(Math.acosh(1.0), 0.0)
+assertEqual(Math.acosh(0.5)->Float.isNaN, true)
 ```
 */
 @val
@@ -375,8 +375,8 @@ See [`Math.asin`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.asin(-1.0) // -1.5707963267948966
-Math.asin(-2.0)->Float.isNaN // true
+assertEqual(Math.asin(-1.0), -1.5707963267948966)
+assertEqual(Math.asin(-2.0)->Float.isNaN, true)
 ```
 */
 @val
@@ -389,8 +389,8 @@ See [`Math.asinh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.asinh(-1.0) // -0.881373587019543
-Math.asinh(-0.0) // -0.0
+assertEqual(Math.asinh(-1.0), -0.881373587019543)
+assertEqual(Math.asinh(-0.0), -0.0)
 ```
 */
 @val
@@ -403,9 +403,9 @@ See [`Math.atan`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.atan(-0.0) // -0.0
-Math.atan(0.0) // 0.0
-Math.atan(1.0) // 0.7853981633974483
+assertEqual(Math.atan(-0.0), -0.0)
+assertEqual(Math.atan(0.0), 0.0)
+assertEqual(Math.atan(1.0), 0.7853981633974483)
 ```
 */
 @val
@@ -420,11 +420,11 @@ See [`Math.atanh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.atanh(-2.0)->Float.isNaN // true
-Math.atanh(-1.0)->Float.isFinite // false
-Math.atanh(-0.0) // -0.0
-Math.atanh(0.0) // 0.0
-Math.atanh(0.5) // 0.5493061443340548
+assertEqual(Math.atanh(-2.0)->Float.isNaN, true)
+assertEqual(Math.atanh(-1.0)->Float.isFinite, false)
+assertEqual(Math.atanh(-0.0), -0.0)
+assertEqual(Math.atanh(0.0), 0.0)
+assertEqual(Math.atanh(0.5), 0.5493061443340548)
 ```
 */
 @val
@@ -438,10 +438,10 @@ See [`Math.atan2`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.atan2(~y=0.0, ~x=10.0) == 0.0
-Math.atan2(~x=5.0, ~y=5.0) == Math.Constants.pi /. 4.0
-Math.atan2(~x=90.0, ~y=15.0) // 1.4056476493802699
-Math.atan2(~x=15.0, ~y=90.0) // 0.16514867741462683
+assertEqual(Math.atan2(~y=0.0, ~x=10.0), 0.0)
+assertEqual(Math.atan2(~x=5.0, ~y=5.0), Math.Constants.pi /. 4.0)
+assertEqual(Math.atan2(~x=90.0, ~y=15.0),0.16514867741462683)
+assertEqual(Math.atan2(~x=15.0, ~y=90.0), 1.4056476493802699)
 ```
 */
 @val
@@ -454,9 +454,9 @@ See [`Math.cbrt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.cbrt(-1.0) // -1.0
-Math.cbrt(-0.0) // -0.0
-Math.cbrt(0.0) // 0.0
+assertEqual(Math.cbrt(-1.0), -1.0)
+assertEqual(Math.cbrt(-0.0), -0.0)
+assertEqual(Math.cbrt(0.0), 0.0)
 ```
 */
 @val
@@ -471,10 +471,10 @@ See [`Math.ceil`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.ceil(3.1) == 4.0
-Math.ceil(3.0) == 3.0
-Math.ceil(-3.1) == -3.0
-Math.ceil(2_150_000_000.3) == 2_150_000_001.0
+assertEqual(Math.ceil(3.1), 4.0)
+assertEqual(Math.ceil(3.0), 3.0)
+assertEqual(Math.ceil(-3.1), -3.0)
+assertEqual(Math.ceil(2_150_000_000.3), 2_150_000_001.0)
 ```
 */
 @val
@@ -487,9 +487,9 @@ See [`Math.cos`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.cos(-0.0) // 1.0
-Math.cos(0.0) // 1.0
-Math.cos(1.0) // 0.5403023058681398
+assertEqual(Math.cos(-0.0), 1.0)
+assertEqual(Math.cos(0.0), 1.0)
+assertEqual(Math.cos(1.0), 0.5403023058681398)
 ```
 */
 @val
@@ -503,9 +503,9 @@ See [`Math.cosh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.cosh(-1.0) // 1.5430806348152437
-Math.cosh(-0.0) // 1.0
-Math.cosh(0.0) // 1.0
+assertEqual(Math.cosh(-1.0), 1.5430806348152437)
+assertEqual(Math.cosh(-0.0), 1.0)
+assertEqual(Math.cosh(0.0), 1.0)
 ```
 */
 @val
@@ -519,8 +519,8 @@ See [`Math.exp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.exp(-1.0) // 0.36787944117144233
-Math.exp(0.0) // 1.0
+assertEqual(Math.exp(-1.0), 0.36787944117144233)
+assertEqual(Math.exp(0.0), 1.0)
 ```
 */
 @val
@@ -534,8 +534,8 @@ See [`Math.expm1`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.expm1(-1.0) // -0.6321205588285577
-Math.expm1(-0.0) // -0
+assertEqual(Math.expm1(-1.0), -0.6321205588285577)
+assertEqual(Math.expm1(-0.0), -0.0)
 ```
 */
 @val
@@ -549,9 +549,9 @@ See [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.floor(-45.95) // -46.0
-Math.floor(-45.05) // -46.0
-Math.floor(-0.0) // -0.0
+assertEqual(Math.floor(-45.95), -46.0)
+assertEqual(Math.floor(-45.05), -46.0)
+assertEqual(Math.floor(-0.0), -0.0)
 ```
 */
 @val
@@ -564,8 +564,8 @@ See [`Math.fround`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 ## Examples
 
 ```rescript
-Math.fround(5.5) == 5.5
-Math.fround(5.05) == 5.050000190734863
+assertEqual(Math.fround(5.5), 5.5)
+assertEqual(Math.fround(5.05), 5.050000190734863)
 ```
 */
 @val
@@ -579,8 +579,8 @@ See [`Math.hypot`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.hypot(3.0, 4.0) // 5.0
-Math.hypot(3.0, 5.0) // 5.8309518948453
+assertEqual(Math.hypot(3.0, 4.0), 5.0)
+assertEqual(Math.hypot(3.0, 5.0), 5.8309518948453)
 ```
 */
 @val
@@ -595,8 +595,8 @@ See [`Math.hypot`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.hypotMany([3.0, 4.0, 5.0]) // 7.0710678118654755
-Math.hypotMany([]) // 0.0
+assertEqual(Math.hypotMany([3.0, 4.0, 5.0]), 7.0710678118654755)
+assertEqual(Math.hypotMany([]), 0.0)
 ```
 */
 @variadic
@@ -612,10 +612,10 @@ See [`Math.log`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.log(-1.0)->Float.isNaN // true
-Math.log(-0.0)->Float.isFinite // false
-Math.log(0.0)->Float.isFinite // false
-Math.log(1.0) // 0
+assertEqual(Math.log(-1.0)->Float.isNaN, true)
+assertEqual(Math.log(-0.0)->Float.isFinite, false)
+assertEqual(Math.log(0.0)->Float.isFinite, false)
+assertEqual(Math.log(1.0), 0.0)
 ```
 */
 @val
@@ -629,9 +629,9 @@ See [`Math.log1p`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.log1p(-2.0)->Float.isNaN // true
-Math.log1p(-1.0)->Float.isFinite // false
-Math.log1p(-0.0) // -0
+assertEqual(Math.log1p(-2.0)->Float.isNaN, true)
+assertEqual(Math.log1p(-1.0)->Float.isFinite, false)
+assertEqual(Math.log1p(-0.0), -0.0)
 ```
 */
 @val
@@ -645,10 +645,10 @@ See [`Math.log10`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.log10(-2.0)->Float.isNaN // true
-Math.log10(-0.0)->Float.isFinite // false
-Math.log10(0.0)->Float.isFinite // false
-Math.log10(1.0) // 0
+assertEqual(Math.log10(-2.0)->Float.isNaN, true)
+assertEqual(Math.log10(-0.0)->Float.isFinite, false)
+assertEqual(Math.log10(0.0)->Float.isFinite, false)
+assertEqual(Math.log10(1.0), 0.0)
 ```
 */
 @val
@@ -662,10 +662,10 @@ See [`Math.log2`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.log2(-2.0)->Float.isNaN // true
-Math.log2(-0.0)->Float.isFinite // false
-Math.log2(0.0)->Float.isFinite // false
-Math.log2(1.0) // 0.0
+assertEqual(Math.log2(-2.0)->Float.isNaN, true)
+assertEqual(Math.log2(-0.0)->Float.isFinite, false)
+assertEqual(Math.log2(0.0)->Float.isFinite, false)
+assertEqual(Math.log2(1.0), 0.0)
 ```
 */
 @val
@@ -678,8 +678,8 @@ See [`Math.min`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.min(1.0, 2.0) // 1.0
-Math.min(-1.0, -2.0) // -2.0
+assertEqual(Math.min(1.0, 2.0), 1.0)
+assertEqual(Math.min(-1.0, -2.0), -2.0)
 ```
 */
 @val
@@ -693,9 +693,9 @@ See [`Math.min`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.minMany([1.0, 2.0]) // 1.0
-Math.minMany([-1.0, -2.0]) // -2.0
-Math.minMany([])->Float.isFinite // false
+assertEqual(Math.minMany([1.0, 2.0]), 1.0)
+assertEqual(Math.minMany([-1.0, -2.0]), -2.0)
+assertEqual(Math.minMany([])->Float.isFinite, false)
 ```
 */
 @variadic
@@ -709,8 +709,8 @@ See [`Math.max`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.max(1.0, 2.0) // 2.0
-Math.max(-1.0, -2.0) // -1.0
+assertEqual(Math.max(1.0, 2.0), 2.0)
+assertEqual(Math.max(-1.0, -2.0), -1.0)
 ```
 */
 @val
@@ -724,9 +724,9 @@ See [`Math.max`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.maxMany([1.0, 2.0]) // 2.0
-Math.maxMany([-1.0, -2.0]) // -1.0
-Math.maxMany([])->Float.isFinite // false
+assertEqual(Math.maxMany([1.0, 2.0]), 2.0)
+assertEqual(Math.maxMany([-1.0, -2.0]), -1.0)
+assertEqual(Math.maxMany([])->Float.isFinite, false)
 ```
 */
 @variadic
@@ -740,8 +740,8 @@ See [`Math.pow`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.pow(2.0, ~exp=4.0) // 16.0
-Math.pow(3.0, ~exp=4.0) // 81.0
+assertEqual(Math.pow(2.0, ~exp=4.0), 16.0)
+assertEqual(Math.pow(3.0, ~exp=4.0), 81.0)
 ```
 */
 @val
@@ -770,10 +770,10 @@ See [`Math.round`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.round(-20.5) // -20.0
-Math.round(-0.1) // -0.0
-Math.round(0.0) // 0.0
-Math.round(-0.0) // -0.0
+assertEqual(Math.round(-20.5), -20.0)
+assertEqual(Math.round(-0.1), -0.0)
+assertEqual(Math.round(0.0), 0.0)
+assertEqual(Math.round(-0.0), -0.0)
 ```
 */
 @val
@@ -787,9 +787,9 @@ See [`Math.sign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.sign(3.0) // 1.0
-Math.sign(-3.0) // 1.0
-Math.sign(0.0) // 0.0
+assertEqual(Math.sign(3.0), 1.0)
+assertEqual(Math.sign(-3.0), -1.0)
+assertEqual(Math.sign(0.0), 0.0)
 ```
 */
 @val
@@ -802,9 +802,9 @@ See [`Math.sin`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.sin(-0.0) // -0.0
-Math.sin(0.0) // 0.0
-Math.sin(1.0) // 0.8414709848078965
+assertEqual(Math.sin(-0.0), -0.0)
+assertEqual(Math.sin(0.0), 0.0)
+assertEqual(Math.sin(1.0), 0.8414709848078965)
 ```
 */
 @val
@@ -818,9 +818,9 @@ See [`Math.sinh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.sinh(-0.0) // -0.0
-Math.sinh(0.0) // 0.0
-Math.sinh(1.0) // 1.1752011936438014
+assertEqual(Math.sinh(-0.0), -0.0)
+assertEqual(Math.sinh(0.0), 0.0)
+assertEqual(Math.sinh(1.0), 1.1752011936438014)
 ```
 */
 @val
@@ -833,11 +833,11 @@ See [`Math.sqrt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.sqrt(-1.0)->Float.isNaN // true
-Math.sqrt(-0.0) // -0.0
-Math.sqrt(0.0) // 0.0
-Math.sqrt(1.0) // 1.0
-Math.sqrt(9.0) // 3.0
+assertEqual(Math.sqrt(-1.0)->Float.isNaN, true)
+assertEqual(Math.sqrt(-0.0), -0.0)
+assertEqual(Math.sqrt(0.0), 0.0)
+assertEqual(Math.sqrt(1.0), 1.0)
+assertEqual(Math.sqrt(9.0), 3.0)
 ```
 */
 @val
@@ -851,9 +851,9 @@ See [`Math.tan`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 ## Examples
 
 ```rescript
-Math.tan(-0.0) // -0.0
-Math.tan(0.0) // 0.0
-Math.tan(1.0) // 1.5574077246549023
+assertEqual(Math.tan(-0.0), -0.0)
+assertEqual(Math.tan(0.0), 0.0)
+assertEqual(Math.tan(1.0), 1.5574077246549023)
 ```
 */
 @val
@@ -867,9 +867,9 @@ See [`Math.tanh`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 ## Examples
 
 ```rescript
-Math.tanh(-0.0) // -0.0
-Math.tanh(0.0) // 0.0
-Math.tanh(1.0) // 0.7615941559557649
+assertEqual(Math.tanh(-0.0), -0.0)
+assertEqual(Math.tanh(0.0), 0.0)
+assertEqual(Math.tanh(1.0), 0.7615941559557649)
 ```
 */
 @val
@@ -882,10 +882,10 @@ See [`Math.trunc`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 ## Examples
 
 ```rescript
-Math.trunc(0.123) // 0.0
-Math.trunc(1.999) // 1.0
-Math.trunc(13.37) // 13.0
-Math.trunc(42.84) // 42.0
+assertEqual(Math.trunc(0.123), 0.0)
+assertEqual(Math.trunc(1.999), 1.0)
+assertEqual(Math.trunc(13.37), 13.0)
+assertEqual(Math.trunc(42.84), 42.0)
 ```
 */
 @val

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -17,25 +17,25 @@ Path MyList.m
     "kind": 12,
     "tags": [],
     "detail": "(list<'a>, list<'b>, ('a, 'b) => 'c) => list<'c>",
-    "documentation": {"kind": "markdown", "value": "\n`mapReverse2(list1, list2, f)` is equivalent to `List.zipBy(list1, list2, f)->List.reverse`.\n\n## Examples\n\n```rescript\nList.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b) // list{4, 2}\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`mapReverse2(list1, list2, f)` is equivalent to `List.zipBy(list1, list2, f)->List.reverse`.\n\n## Examples\n\n```rescript\nassertEqual(List.mapReverse2(list{1, 2, 3}, list{1, 2}, (a, b) => a + b), list{4, 2})\n```\n"}
   }, {
     "label": "make",
     "kind": 12,
     "tags": [],
     "detail": "(~length: int, 'a) => list<'a>",
-    "documentation": {"kind": "markdown", "value": "\n`make(length, value)` returns a list of length `length` with each element filled\nwith `value`. Returns an empty list if `value` is negative.\n\n## Examples\n\n```rescript\nList.make(~length=3, 1) // list{1, 1, 1}\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`make(length, value)` returns a list of length `length` with each element filled\nwith `value`. Returns an empty list if `value` is negative.\n\n## Examples\n\n```rescript\nassertEqual(List.make(~length=3, 1), list{1, 1, 1})\n```\n"}
   }, {
     "label": "mapWithIndex",
     "kind": 12,
     "tags": [],
     "detail": "(list<'a>, ('a, int) => 'b) => list<'b>",
-    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(list, f)` applies `f` to each element of `list`. Function `f`\ntakes two arguments: the index starting from 0 and the element from `list`, in\nthat order.\n\n## Examples\n\n```rescript\nlist{1, 2, 3}->List.mapWithIndex((x, index) => index + x) // list{1, 3, 5}\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`mapWithIndex(list, f)` applies `f` to each element of `list`. Function `f`\ntakes two arguments: the index starting from 0 and the element from `list`, in\nthat order.\n\n## Examples\n\n```rescript\nassertEqual(list{1, 2, 3}->List.mapWithIndex((x, index) => index + x), list{1, 3, 5})\n```\n"}
   }, {
     "label": "map",
     "kind": 12,
     "tags": [],
     "detail": "(list<'a>, 'a => 'b) => list<'b>",
-    "documentation": {"kind": "markdown", "value": "\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}
+    "documentation": {"kind": "markdown", "value": "\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nassertEqual(list{1, 2}->List.map(x => x + 1), list{2, 3})\n```\n"}
   }]
 
 Complete src/Completion.res 3:9

--- a/tests/analysis_tests/tests/src/expected/Definition.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Definition.res.txt
@@ -5,7 +5,7 @@ Definition src/Definition.res 10:23
 {"uri": "Definition.res", "range": {"start": {"line": 6, "character": 7}, "end": {"line": 6, "character": 13}}}
 
 Hover src/Definition.res 14:14
-{"contents": {"kind": "markdown", "value": "```rescript\n(list<'a>, 'a => 'b) => list<'b>\n```\n---\n\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nlist{1, 2}->List.map(x => x + 1) // list{3, 4}\n```\n"}}
+{"contents": {"kind": "markdown", "value": "```rescript\n(list<'a>, 'a => 'b) => list<'b>\n```\n---\n\n`map(list, f)` returns a new list with `f` applied to each element of `list`.\n\n## Examples\n\n```rescript\nassertEqual(list{1, 2}->List.map(x => x + 1), list{2, 3})\n```\n"}}
 
 Hover src/Definition.res 18:14
 {"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```"}}


### PR DESCRIPTION
adds `assertEqual` to missing stdlib modules:

- `Belt`
  - `Array`
  - `Float`
  - `HashMap`
  - `List`
  - `Map`
  - `MapDict`
  - `MutableSet`
  - `Option`
  - `Range`
  - `Result`
  - `SetDict`
  - `SortArray`
- `Stdlib`
  - `SortArray`
  - `List`
  - `Math`

closes #7374
