### PR TITLE
Do not error on `ref` as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add shift (`<<`, `>>`, `>>>`) operators for `int` and `bigint`. https://github.com/rescript-lang/rescript/pull/7183
 - Add bitwise AND (`&`) operator for `int` and `bigint`. https://github.com/rescript-lang/rescript/pull/7415
 - Significantly reduced the download size by splitting binaries into optional platform-specific dependencies (e.g, `@rescript/linux-x64`). https://github.com/rescript-lang/rescript/pull/7395
+- JSX: do not error on ref as prop anymore (which is allowed in React 19). https://github.com/rescript-lang/rescript/pull/7420
 
 #### :bug: Bug fix
 

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -251,10 +251,6 @@ let rec recursively_transform_named_args_for_make expr args newtypes core_type =
     Jsx_common.raise_error ~loc:expr.pexp_loc
       "Key cannot be accessed inside of a component. Don't worry - you can \
        always key a component from its parent!"
-  | Pexp_fun {arg_label = Labelled {txt = "ref"} | Optional {txt = "ref"}} ->
-    Jsx_common.raise_error ~loc:expr.pexp_loc
-      "Ref cannot be passed as a normal prop. Please use `forwardRef` API \
-       instead."
   | Pexp_fun {arg_label = arg; default; lhs = pattern; rhs = expression}
     when is_optional arg || is_labelled arg ->
     let () =


### PR DESCRIPTION
`ref` as prop is now allowed in React 19, see https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop