### PR TITLE
Add @react.componentWithProps to MyWeirdComponent test

### DIFF
--- a/tests/tests/src/preserve_jsx_test.mjs
+++ b/tests/tests/src/preserve_jsx_test.mjs
@@ -111,7 +111,7 @@ let _external_component_with_children = <QueryClientProvider>
 <Preserve_jsx_test$B/>
 </QueryClientProvider>;
 
-function make(props) {
+function Preserve_jsx_test$MyWeirdComponent(props) {
   return <p>
   {"foo"}
   {props["\\\"MyWeirdProp\""]}
@@ -119,10 +119,10 @@ function make(props) {
 }
 
 let MyWeirdComponent = {
-  make: make
+  make: Preserve_jsx_test$MyWeirdComponent
 };
 
-let _escaped_jsx_prop = <make MyWeirdProp={"bar"}/>;
+let _escaped_jsx_prop = <Preserve_jsx_test$MyWeirdComponent MyWeirdProp={"bar"}/>;
 
 export {
   React,

--- a/tests/tests/src/preserve_jsx_test.res
+++ b/tests/tests/src/preserve_jsx_test.res
@@ -159,6 +159,7 @@ let _external_component_with_children =
 module MyWeirdComponent = {
   type props = {\"MyWeirdProp": string}
 
+  @react.componentWithProps
   let make = props =>
     <p>
       {React.string("foo")}


### PR DESCRIPTION
I am slowly coming to terms with the potential limitation of the `preserve-jsx` feature, which may require `@react.component` or `@react.componentWithProps`.