### PR TITLE
Recommend stdlib functions over Belt for converting between float/int/string

### DIFF
--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -676,12 +676,12 @@ let rec bottom_aliases = function
 
 let simple_conversions =
   [
-    (("float", "int"), "Belt.Float.toInt");
-    (("float", "string"), "Belt.Float.toString");
-    (("int", "float"), "Belt.Int.toFloat");
-    (("int", "string"), "Belt.Int.toString");
-    (("string", "float"), "Belt.Float.fromString");
-    (("string", "int"), "Belt.Int.fromString");
+    (("float", "int"), "Float.toInt");
+    (("float", "string"), "Float.toString");
+    (("int", "float"), "Int.toFloat");
+    (("int", "string"), "Int.toString");
+    (("string", "float"), "Float.fromString");
+    (("string", "int"), "Int.fromString");
   ]
 
 let print_simple_conversion ppf (actual, expected) =

--- a/tests/build_tests/super_errors/expected/array_item_type_mismatch.res.expected
+++ b/tests/build_tests/super_errors/expected/array_item_type_mismatch.res.expected
@@ -14,4 +14,4 @@
   - Convert all values in the array to the same type.
   - Use a tuple, if your array is of fixed length. Tuples can mix types freely, and compiles to a JavaScript array. Example of a tuple: `let myTuple = (10, "hello", 15.5, true)
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/collections.res.expected
+++ b/tests/build_tests/super_errors/expected/collections.res.expected
@@ -9,4 +9,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/dict_inference.res.expected
+++ b/tests/build_tests/super_errors/expected/dict_inference.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mstring[0m
   But this function argument is expecting: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/dict_pattern_inference_constrained.res.expected
+++ b/tests/build_tests/super_errors/expected/dict_pattern_inference_constrained.res.expected
@@ -14,4 +14,4 @@
   The incompatible parts:
     [1;31mint[0m vs [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/function_argument_mismatch.res.expected
+++ b/tests/build_tests/super_errors/expected/function_argument_mismatch.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mint[0m
   But this function argument is expecting: [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/highlighting1.res.expected
+++ b/tests/build_tests/super_errors/expected/highlighting1.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/highlighting2.res.expected
+++ b/tests/build_tests/super_errors/expected/highlighting2.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/highlighting3.res.expected
+++ b/tests/build_tests/super_errors/expected/highlighting3.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/highlighting5.res.expected
+++ b/tests/build_tests/super_errors/expected/highlighting5.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/if_branch_mismatch.res.expected
+++ b/tests/build_tests/super_errors/expected/if_branch_mismatch.res.expected
@@ -13,4 +13,4 @@
 
   [1;33mif[0m expressions must return the same type in all branches ([1;33mif[0m, [1;33melse if[0m, [1;33melse[0m).
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/inline_types_record_type_params.res.expected
+++ b/tests/build_tests/super_errors/expected/inline_types_record_type_params.res.expected
@@ -11,4 +11,4 @@
   This has type: [1;31mint[0m
   But it's expected to have type: [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/math_operator_constant.res.expected
+++ b/tests/build_tests/super_errors/expected/math_operator_constant.res.expected
@@ -10,5 +10,5 @@
   This has type: [1;31mfloat[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mfloat[0m to [1;33mint[0m with [1;33mBelt.Float.toInt[0m.
+  You can convert [1;33mfloat[0m to [1;33mint[0m with [1;33mFloat.toInt[0m.
   If this is a literal, try a number without a trailing dot (e.g. [1;33m20[0m).

--- a/tests/build_tests/super_errors/expected/math_operator_float.res.expected
+++ b/tests/build_tests/super_errors/expected/math_operator_float.res.expected
@@ -16,5 +16,5 @@
   - Ensure all values in this calculation has the type [1;33mfloat[0m. You can convert between floats and ints via [1;33mBelt.Float.toInt[0m and [1;33mBelt.Int.fromFloat[0m.
   - Change the operator to [1;33m+[0m, which works on [1;33mint[0m
   
-  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mBelt.Int.toFloat[0m.
+  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mInt.toFloat[0m.
   If this is a literal, try a number with a trailing dot (e.g. [1;33m20.[0m).

--- a/tests/build_tests/super_errors/expected/primitives1.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives1.res.expected
@@ -9,5 +9,5 @@
   This has type: [1;31mint[0m
   But it's expected to have type: [1;33mfloat[0m
   
-  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mBelt.Int.toFloat[0m.
+  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mInt.toFloat[0m.
   If this is a literal, try a number with a trailing dot (e.g. [1;33m20.[0m).

--- a/tests/build_tests/super_errors/expected/primitives11.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives11.res.expected
@@ -16,4 +16,4 @@
     Further expanded:
       [1;31mint[0m vs [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/primitives2.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives2.res.expected
@@ -9,4 +9,4 @@
   This has type: [1;31mint[0m
   But string concatenation is expecting: [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/primitives6.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives6.res.expected
@@ -10,5 +10,5 @@
   This has type: [1;31mint[0m
   But it's expected to have type: [1;33mfloat[0m
   
-  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mBelt.Int.toFloat[0m.
+  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mInt.toFloat[0m.
   If this is a literal, try a number with a trailing dot (e.g. [1;33m20.[0m).

--- a/tests/build_tests/super_errors/expected/primitives7.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives7.res.expected
@@ -16,5 +16,5 @@
   - Ensure all values in this calculation has the type [1;33mfloat[0m. You can convert between floats and ints via [1;33mBelt.Float.toInt[0m and [1;33mBelt.Int.fromFloat[0m.
   - Change the operator to [1;33m+[0m, which works on [1;33mint[0m
   
-  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mBelt.Int.toFloat[0m.
+  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mInt.toFloat[0m.
   If this is a literal, try a number with a trailing dot (e.g. [1;33m20.[0m).

--- a/tests/build_tests/super_errors/expected/primitives9.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives9.res.expected
@@ -8,4 +8,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/record_type_spreads_deep_sub.res.expected
+++ b/tests/build_tests/super_errors/expected/record_type_spreads_deep_sub.res.expected
@@ -11,4 +11,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/set_record_field_type_match.res.expected
+++ b/tests/build_tests/super_errors/expected/set_record_field_type_match.res.expected
@@ -10,4 +10,4 @@
   You're assigning something to this field that has type: [1;31mint[0m
   But this record field is of type: [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.

--- a/tests/build_tests/super_errors/expected/stdlib_removed_in_error.res.expected
+++ b/tests/build_tests/super_errors/expected/stdlib_removed_in_error.res.expected
@@ -13,4 +13,4 @@
   The incompatible parts:
     [1;31mstring[0m vs [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/syntaxErrors4.res.expected
+++ b/tests/build_tests/super_errors/expected/syntaxErrors4.res.expected
@@ -15,4 +15,4 @@
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/type1.res.expected
+++ b/tests/build_tests/super_errors/expected/type1.res.expected
@@ -8,5 +8,5 @@
   This has type: [1;31mint[0m
   But it's expected to have type: [1;33mfloat[0m
   
-  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mBelt.Int.toFloat[0m.
+  You can convert [1;33mint[0m to [1;33mfloat[0m with [1;33mInt.toFloat[0m.
   If this is a literal, try a number with a trailing dot (e.g. [1;33m20.[0m).

--- a/tests/build_tests/super_errors/expected/type2.res.expected
+++ b/tests/build_tests/super_errors/expected/type2.res.expected
@@ -11,4 +11,4 @@
   This has type: [1;31mstring[0m
   But this function argument is expecting: [1;33mint[0m
   
-  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mBelt.Int.fromString[0m.
+  You can convert [1;33mstring[0m to [1;33mint[0m with [1;33mInt.fromString[0m.

--- a/tests/build_tests/super_errors/expected/unicode_location.res.expected
+++ b/tests/build_tests/super_errors/expected/unicode_location.res.expected
@@ -10,4 +10,4 @@
   This has type: [1;31mint[0m
   But string concatenation is expecting: [1;33mstring[0m
   
-  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mInt.toString[0m.


### PR DESCRIPTION
Updates the tip shown in type errors like `You can convert string to int with Belt.Int.toString` to instead recommend stdlib (e.g. `Int.toString`)