### PR TITLE
Remove unused type Jsx.ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 - In type errors, recommend stdlib over Belt functions for converting between float/int/string. https://github.com/rescript-lang/rescript/pull/7453
 - Make `Jsx.element` a private empty record to avoid unnecessary `Primitive_option.some`. https://github.com/rescript-lang/rescript/pull/7450
+- Remove unused type `Jsx.ref`. https://github.com/rescript-lang/rescript/pull/7459
 
 # 12.0.0-alpha.12
 

--- a/runtime/Jsx.res
+++ b/runtime/Jsx.res
@@ -26,8 +26,6 @@
 // unnecessarily add `Primitive_option.some` calls for optional props.
 type element = private {}
 
-type ref
-
 @val external null: element = "null"
 
 external float: float => element = "%identity"


### PR DESCRIPTION
Tested successfully against a project using both React web and React Native.