### PR TITLE
Add optional `~options` argument to `Console.dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Add `RegExp.flags`. https://github.com/rescript-lang/rescript/pull/7461
+- Add `options` argument to `Console.dir`. https://github.com/rescript-lang/rescript/pull/7504
 
 #### :bug: Bug fix
 

--- a/runtime/Stdlib_Console.res
+++ b/runtime/Stdlib_Console.res
@@ -22,7 +22,7 @@
 type dirOptions = {
   colors?: bool,
   depth?: Stdlib_Nullable.t<int>,
-  showHidden?: bool
+  showHidden?: bool,
 }
 @val external dir: ('a, ~options: dirOptions=?) => unit = "console.dir"
 @val external dirxml: 'a => unit = "console.dirxml"

--- a/runtime/Stdlib_Console.res
+++ b/runtime/Stdlib_Console.res
@@ -19,7 +19,12 @@
 @val external debug6: ('a, 'b, 'c, 'd, 'e, 'f) => unit = "console.debug"
 @val @variadic external debugMany: array<_> => unit = "console.debug"
 
-@val external dir: 'a => unit = "console.dir"
+type dirOptions = {
+  colors?: bool,
+  depth?: Stdlib_Nullable.t<int>,
+  showHidden?: bool
+}
+@val external dir: ('a, ~options: dirOptions=?) => unit = "console.dir"
 @val external dirxml: 'a => unit = "console.dirxml"
 
 @val external error: 'a => unit = "console.error"

--- a/runtime/Stdlib_Console.resi
+++ b/runtime/Stdlib_Console.resi
@@ -244,8 +244,13 @@ Console.debugMany([1, 2, 3])
 @variadic
 external debugMany: array<_> => unit = "console.debug"
 
+type dirOptions = {
+  colors?: bool,
+  depth?: Stdlib_Nullable.t<int>,
+  showHidden?: bool
+}
 /**
-`dir(object)` displays an interactive view of the object in the console.
+`dir(object, options)` displays an interactive view of the object in the console.
 
 See [`console.dir`](https://developer.mozilla.org/en-US/docs/Web/API/console/dir)
 on MDN.
@@ -254,10 +259,11 @@ on MDN.
 
 ```rescript
 Console.dir({"language": "rescript", "version": "10.1.2"})
+Console.dir({"language": "rescript", "version": {"major": "10", "minor": "1", "patch": "2"}}, ~options={depth: null})
 ```
 */
 @val
-external dir: 'a => unit = "console.dir"
+external dir: ('a, ~options: dirOptions=?) => unit = "console.dir"
 
 /**
 `dirxml(object)` displays an interactive tree view of an XML/HTML element in the console.

--- a/runtime/Stdlib_Console.resi
+++ b/runtime/Stdlib_Console.resi
@@ -247,7 +247,7 @@ external debugMany: array<_> => unit = "console.debug"
 type dirOptions = {
   colors?: bool,
   depth?: Stdlib_Nullable.t<int>,
-  showHidden?: bool
+  showHidden?: bool,
 }
 /**
 `dir(object, options)` displays an interactive view of the object in the console.


### PR DESCRIPTION
`console.dir` supports an [optional `options` argument](https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static#options), with `options.depth` being particularly useful for logging nested data structures.