### PR TITLE
Refactor the ast for record expressions and pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Remove deprecated pipe last (`|>`) syntax. https://github.com/rescript-lang/rescript/pull/7512
 - Improve error message for pipe (`->`) syntax. https://github.com/rescript-lang/rescript/pull/7520
 - Improve a few error messages around various subtyping issues. https://github.com/rescript-lang/rescript/pull/7404
+- Refactor the ast for record expressions and patterns. https://github.com/rescript-lang/rescript/pull/7528
 
 # 12.0.0-alpha.13
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -518,16 +518,15 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
           :: patternPath)
         ?contextPath p
     | Ppat_record (fields, _) ->
-      fields
-      |> List.iter (fun (fname, p, _) ->
-             match fname with
-             | {Location.txt = Longident.Lident fname} ->
-               scopePattern
-                 ~patternPath:
-                   (Completable.NFollowRecordField {fieldName = fname}
-                   :: patternPath)
-                 ?contextPath p
-             | _ -> ())
+      Ext_list.iter fields (fun {lid = fname; x = p} ->
+          match fname with
+          | {Location.txt = Longident.Lident fname} ->
+            scopePattern
+              ~patternPath:
+                (Completable.NFollowRecordField {fieldName = fname}
+                :: patternPath)
+              ?contextPath p
+          | _ -> ())
     | Ppat_array pl ->
       pl
       |> List.iter
@@ -926,7 +925,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
                    ( {
                        pexp_desc =
                          Pexp_record
-                           (({txt = Lident "from"}, fromExpr, _) :: _, _);
+                           ({lid = {txt = Lident "from"}; x = fromExpr} :: _, _);
                      },
                      _ );
              };

--- a/analysis/src/DumpAst.ml
+++ b/analysis/src/DumpAst.ml
@@ -103,13 +103,12 @@ let rec printPattern pattern ~pos ~indentation =
     "Ppat_record(\n"
     ^ addIndentation (indentation + 1)
     ^ "fields:\n"
-    ^ (fields
-      |> List.map (fun ((Location.{txt} as loc), pat, _) ->
-             addIndentation (indentation + 2)
-             ^ (loc |> printLocDenominatorLoc ~pos)
-             ^ (Utils.flattenLongIdent txt |> ident |> str)
-             ^ ": "
-             ^ printPattern pat ~pos ~indentation:(indentation + 2))
+    ^ (Ext_list.map fields (fun {lid; x = pat} ->
+           addIndentation (indentation + 2)
+           ^ (lid |> printLocDenominatorLoc ~pos)
+           ^ (Utils.flattenLongIdent lid.txt |> ident |> str)
+           ^ ": "
+           ^ printPattern pat ~pos ~indentation:(indentation + 2))
       |> String.concat "\n")
     ^ "\n" ^ addIndentation indentation ^ ")"
   | Ppat_tuple patterns ->
@@ -244,13 +243,12 @@ and printExprItem expr ~pos ~indentation =
     "Pexp_record(\n"
     ^ addIndentation (indentation + 1)
     ^ "fields:\n"
-    ^ (fields
-      |> List.map (fun ((Location.{txt} as loc), expr, _) ->
-             addIndentation (indentation + 2)
-             ^ (loc |> printLocDenominatorLoc ~pos)
-             ^ (Utils.flattenLongIdent txt |> ident |> str)
-             ^ ": "
-             ^ printExprItem expr ~pos ~indentation:(indentation + 2))
+    ^ (Ext_list.map fields (fun {lid; x = expr} ->
+           addIndentation (indentation + 2)
+           ^ (lid |> printLocDenominatorLoc ~pos)
+           ^ (Utils.flattenLongIdent lid.txt |> ident |> str)
+           ^ ": "
+           ^ printExprItem expr ~pos ~indentation:(indentation + 2))
       |> String.concat "\n")
     ^ "\n" ^ addIndentation indentation ^ ")"
   | Pexp_tuple exprs ->

--- a/analysis/src/Hint.ml
+++ b/analysis/src/Hint.ml
@@ -44,7 +44,7 @@ let inlay ~path ~pos ~maxLength ~debug =
     match pat.ppat_desc with
     | Ppat_tuple pl -> pl |> List.iter processPattern
     | Ppat_record (fields, _) ->
-      fields |> List.iter (fun (_, p, _) -> processPattern p)
+      Ext_list.iter fields (fun {x = p} -> processPattern p)
     | Ppat_array fields -> fields |> List.iter processPattern
     | Ppat_var {loc} -> push loc Type
     | _ -> ()

--- a/analysis/src/SemanticTokens.ml
+++ b/analysis/src/SemanticTokens.ml
@@ -223,9 +223,8 @@ let command ~debug ~emitter ~path =
       (* Don't emit true or false *)
       Ast_iterator.default_iterator.pat iterator p
     | Ppat_record (cases, _) ->
-      cases
-      |> List.iter (fun (label, _, _) ->
-             emitter |> emitRecordLabel ~label ~debug);
+      Ext_list.iter cases (fun {lid = label} ->
+          emitter |> emitRecordLabel ~label ~debug);
       Ast_iterator.default_iterator.pat iterator p
     | Ppat_construct (name, _) ->
       emitter |> emitVariant ~name ~debug;
@@ -320,12 +319,11 @@ let command ~debug ~emitter ~path =
       emitter |> emitFromLoc ~loc ~type_:Operator;
       Ast_iterator.default_iterator.expr iterator e
     | Pexp_record (cases, _) ->
-      cases
-      |> List.filter_map (fun ((label : Longident.t Location.loc), _, _) ->
-             match label.txt with
-             | Longident.Lident s when not (Utils.isFirstCharUppercase s) ->
-               Some label
-             | _ -> None)
+      Ext_list.filter_map cases (fun {lid} ->
+          match lid.txt with
+          | Longident.Lident s when not (Utils.isFirstCharUppercase s) ->
+            Some lid
+          | _ -> None)
       |> List.iter (fun label -> emitter |> emitRecordLabel ~label ~debug);
       Ast_iterator.default_iterator.expr iterator e
     | Pexp_field (_, label) | Pexp_setfield (_, label, _) ->

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -629,10 +629,8 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                   fields
                   |> List.find_map
                        (fun
-                         (({loc; txt}, expr, _) :
-                           Longident.t Location.loc
-                           * Parsetree.expression
-                           * bool)
+                         ({lid = {loc; txt}; x = expr} :
+                           Parsetree.expression Parsetree.record_element)
                        ->
                          if
                            posBeforeCursor >= Pos.ofLexing loc.loc_start
@@ -673,8 +671,8 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                   fields
                   |> List.find_map
                        (fun
-                         (({loc; txt}, pat, _) :
-                           Longident.t Location.loc * Parsetree.pattern * bool)
+                         ({lid = {loc; txt}; x = pat} :
+                           Parsetree.pattern Parsetree.record_element)
                        ->
                          if
                            posBeforeCursor >= Pos.ofLexing loc.loc_start

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -69,10 +69,10 @@ module IfThenElse = struct
       | None -> None
       | Some patList -> Some (mkPat (Ppat_tuple patList)))
     | Pexp_record (items, None) -> (
-      let itemToPat (x, e, o) =
+      let itemToPat {Parsetree.lid; x = e; opt} =
         match expToPat e with
         | None -> None
-        | Some p -> Some (x, p, o)
+        | Some p -> Some {Parsetree.lid; x = p; opt}
       in
       match listToPat ~itemToPat items with
       | None -> None

--- a/compiler/common/pattern_printer.ml
+++ b/compiler/common/pattern_printer.ml
@@ -33,7 +33,7 @@ let untype typed =
       let fields =
         List.map
           (fun (_, lbl, p, opt) ->
-            (mknoloc (Longident.Lident lbl.lbl_name), loop p, opt))
+            {lid = mknoloc (Longident.Lident lbl.lbl_name); x = loop p; opt})
           subpatterns
       in
       mkpat (Ppat_record (fields, closed_flag))

--- a/compiler/frontend/ast_derive_js_mapper.ml
+++ b/compiler/frontend/ast_derive_js_mapper.ml
@@ -38,14 +38,16 @@ let handle_config (config : Parsetree.expression option) =
     match config.pexp_desc with
     | Pexp_record
         ( [
-            ( {txt = Lident "newType"},
-              {
-                pexp_desc =
-                  ( Pexp_construct
-                      ({txt = Lident (("true" | "false") as x)}, None)
-                  | Pexp_ident {txt = Lident ("newType" as x)} );
-              },
-              _ );
+            {
+              lid = {txt = Lident "newType"};
+              x =
+                {
+                  pexp_desc =
+                    ( Pexp_construct
+                        ({txt = Lident (("true" | "false") as x)}, None)
+                    | Pexp_ident {txt = Lident ("newType" as x)} );
+                };
+            };
           ],
           None ) ->
       not (x = "false")
@@ -196,7 +198,11 @@ let init () =
                                            txt = Longident.Lident txt;
                                          }
                                        in
-                                       (label, Exp.field exp_param label, false)))
+                                       {
+                                         Parsetree.lid = label;
+                                         x = Exp.field exp_param label;
+                                         opt = false;
+                                       }))
                                   None);
                            ] ))
                 in
@@ -208,7 +214,11 @@ let init () =
                          let label =
                            {Asttypes.loc; txt = Longident.Lident txt}
                          in
-                         (label, js_field exp_param label, false)))
+                         {
+                           Parsetree.lid = label;
+                           x = js_field exp_param label;
+                           opt = false;
+                         }))
                     None
                 in
                 let from_js =

--- a/compiler/frontend/ast_tuple_pattern_flatten.ml
+++ b/compiler/frontend/ast_tuple_pattern_flatten.ml
@@ -65,7 +65,7 @@ let flattern_tuple_pattern_vb (self : Bs_ast_mapper.mapper)
           :: acc)
     | _ -> {pvb_pat; pvb_expr; pvb_loc = vb.pvb_loc; pvb_attributes} :: acc)
   | Ppat_record (lid_pats, _), Pexp_pack {pmod_desc = Pmod_ident id} ->
-    Ext_list.map_append lid_pats acc (fun (lid, pat, _) ->
+    Ext_list.map_append lid_pats acc (fun {lid; x = pat} ->
         match lid.txt with
         | Lident s ->
           {

--- a/compiler/frontend/ast_uncurry_gen.ml
+++ b/compiler/frontend/ast_uncurry_gen.ml
@@ -61,9 +61,11 @@ let to_method_callback loc (self : Bs_ast_mapper.mapper) label
             Exp.constraint_ ~loc
               (Exp.record ~loc
                  [
-                   ( {loc; txt = Ast_literal.Lid.hidden_field arity_s},
-                     body,
-                     false );
+                   {
+                     lid = {loc; txt = Ast_literal.Lid.hidden_field arity_s};
+                     x = body;
+                     opt = false;
+                   };
                  ]
                  None)
               (Typ.constr ~loc

--- a/compiler/frontend/ast_util.ml
+++ b/compiler/frontend/ast_util.ml
@@ -22,16 +22,15 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression * bool) list
-
 let js_property loc obj (name : string) =
   Parsetree.Pexp_send (obj, {loc; txt = name})
 
 let record_as_js_object loc (self : Bs_ast_mapper.mapper)
-    (label_exprs : label_exprs) : Parsetree.expression_desc =
+    (label_exprs : Parsetree.expression Parsetree.record_element list) :
+    Parsetree.expression_desc =
   let labels, args, arity =
     Ext_list.fold_right label_exprs ([], [], 0)
-      (fun ({txt; loc}, e, _) (labels, args, i) ->
+      (fun {lid = {txt; loc}; x = e} (labels, args, i) ->
         match txt with
         | Lident x ->
           ( {Asttypes.loc; txt = x} :: labels,

--- a/compiler/frontend/ast_util.mli
+++ b/compiler/frontend/ast_util.mli
@@ -28,10 +28,11 @@
     - convert a uncuried application to normal 
 *)
 
-type label_exprs = (Longident.t Asttypes.loc * Parsetree.expression * bool) list
-
 val record_as_js_object :
-  Location.t -> Bs_ast_mapper.mapper -> label_exprs -> Parsetree.expression_desc
+  Location.t ->
+  Bs_ast_mapper.mapper ->
+  Parsetree.expression Parsetree.record_element list ->
+  Parsetree.expression_desc
 
 val js_property :
   Location.t -> Parsetree.expression -> string -> Parsetree.expression_desc

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -69,7 +69,6 @@ type mapper = {
   with_constraint: mapper -> with_constraint -> with_constraint;
 }
 
-let id x = x
 let map_fst f (x, y) = (f x, y)
 let map_snd f (x, y) = (x, f y)
 let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
@@ -343,7 +342,10 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (List.map (map_tuple3 (map_loc sub) (sub.expr sub) id) l)
+        (List.map
+           (fun {lid; x = e; opt} ->
+             {lid = map_loc sub lid; x = sub.expr sub e; opt})
+           l)
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -426,7 +428,10 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (List.map (map_tuple3 (map_loc sub) (sub.pat sub) id) lpl)
+        (List.map
+           (fun {lid; x = p; opt} ->
+             {lid = map_loc sub lid; x = sub.pat sub p; opt})
+           lpl)
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -107,7 +107,7 @@ module Pat : sig
   val record :
     ?loc:loc ->
     ?attrs:attrs ->
-    (lid * pattern * bool) list ->
+    pattern record_element list ->
     closed_flag ->
     pattern
   val array : ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
@@ -162,7 +162,7 @@ module Exp : sig
   val record :
     ?loc:loc ->
     ?attrs:attrs ->
-    (lid * expression * bool) list ->
+    expression record_element list ->
     expression option ->
     expression
   val field : ?loc:loc -> ?attrs:attrs -> expression -> lid -> expression

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -310,7 +310,11 @@ module E = struct
       iter_opt (sub.expr sub) arg
     | Pexp_variant (_lab, eo) -> iter_opt (sub.expr sub) eo
     | Pexp_record (l, eo) ->
-      List.iter (iter_tuple3 (iter_loc sub) (sub.expr sub) (fun _ -> ())) l;
+      List.iter
+        (fun {lid; x = exp} ->
+          iter_loc sub lid;
+          sub.expr sub exp)
+        l;
       iter_opt (sub.expr sub) eo
     | Pexp_field (e, lid) ->
       sub.expr sub e;
@@ -397,7 +401,11 @@ module P = struct
       iter_opt (sub.pat sub) p
     | Ppat_variant (_l, p) -> iter_opt (sub.pat sub) p
     | Ppat_record (lpl, _cf) ->
-      List.iter (iter_tuple3 (iter_loc sub) (sub.pat sub) (fun _ -> ())) lpl
+      List.iter
+        (fun {lid; x = pat} ->
+          iter_loc sub lid;
+          sub.pat sub pat)
+        lpl
     | Ppat_array pl -> List.iter (sub.pat sub) pl
     | Ppat_or (p1, p2) ->
       sub.pat sub p1;

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -492,7 +492,11 @@ module E = struct
              let optional, attrs =
                Parsetree0.get_optional_attr e1.pexp_attributes
              in
-             (lid1, {e1 with pexp_attributes = attrs}, optional)))
+             {
+               Pt.lid = lid1;
+               x = {e1 with pexp_attributes = attrs};
+               opt = optional;
+             }))
         (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
       field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
@@ -565,7 +569,11 @@ module P = struct
              let optional, attrs =
                Parsetree0.get_optional_attr p1.ppat_attributes
              in
-             (lid1, {p1 with ppat_attributes = attrs}, optional)))
+             {
+               Pt.lid = lid1;
+               x = {p1 with ppat_attributes = attrs};
+               opt = optional;
+             }))
         cf
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -424,7 +424,7 @@ module E = struct
       variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
       record ~loc ~attrs
-        (Ext_list.map l (fun (lid, e, optional) ->
+        (Ext_list.map l (fun {lid; x = e; opt = optional} ->
              let lid1 = map_loc sub lid in
              let e1 = sub.expr sub e in
              let attr =
@@ -554,7 +554,7 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
       record ~loc ~attrs
-        (Ext_list.map lpl (fun (lid, p, optional) ->
+        (Ext_list.map lpl (fun {lid; x = p; opt = optional} ->
              let lid1 = map_loc sub lid in
              let p1 = sub.pat sub p in
              let attr =

--- a/compiler/ml/ast_payload.ml
+++ b/compiler/ml/ast_payload.ml
@@ -210,12 +210,13 @@ let ident_or_record_as_config loc (x : t) :
     | None ->
       Ext_list.map label_exprs (fun u ->
           match u with
-          | ( {txt = Lident name; loc},
-              {Parsetree.pexp_desc = Pexp_ident {txt = Lident name2}},
-              _ )
+          | {
+           lid = {txt = Lident name; loc};
+           x = {Parsetree.pexp_desc = Pexp_ident {txt = Lident name2}};
+          }
             when name2 = name ->
             ({Asttypes.txt = name; loc}, None)
-          | {txt = Lident name; loc}, y, _ ->
+          | {lid = {txt = Lident name; loc}; x = y} ->
             ({Asttypes.txt = name; loc}, Some y)
           | _ -> Location.raise_errorf ~loc "Qualified label is not allowed")
     | Some _ ->

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -185,7 +185,7 @@ let rec add_pattern bv pat =
     add_opt add_pattern bv op
   | Ppat_record (pl, _) ->
     List.iter
-      (fun (lbl, p, _) ->
+      (fun {lid = lbl; x = p} ->
         add bv lbl;
         add_pattern bv p)
       pl
@@ -236,7 +236,7 @@ let rec add_expr bv exp =
   | Pexp_variant (_, opte) -> add_opt add_expr bv opte
   | Pexp_record (lblel, opte) ->
     List.iter
-      (fun (lbl, e, _) ->
+      (fun {lid = lbl; x = e} ->
         add bv lbl;
         add_expr bv e)
       lblel;

--- a/compiler/ml/parmatch.ml
+++ b/compiler/ml/parmatch.ml
@@ -1986,7 +1986,7 @@ module Conv = struct
             (fun (_, lbl, p, optional) ->
               let id = fresh lbl.lbl_name in
               Hashtbl.add labels id lbl;
-              (mknoloc (Longident.Lident id), loop p, optional))
+              {lid = mknoloc (Longident.Lident id); x = loop p; opt = optional})
             subpatterns
         in
         mkpat (Ppat_record (fields, Open))

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -182,8 +182,7 @@ and pattern_desc =
     (* `A             (None)
        `A P           (Some P)
     *)
-  | Ppat_record of
-      (Longident.t loc * pattern * bool (* optional *)) list * closed_flag
+  | Ppat_record of pattern record_element list * closed_flag
     (* { l1=P1; ...; ln=Pn }     (flag = Closed)
        { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
@@ -203,8 +202,9 @@ and pattern_desc =
   | Ppat_open of Longident.t loc * pattern
 (* M.(P) *)
 
-(* Value expressions *)
+and pat_record_label = Longident.t loc * pattern * bool (* optional *)
 
+(* Value expressions *)
 and expression = {
   pexp_desc: expression_desc;
   pexp_loc: Location.t;
@@ -269,9 +269,7 @@ and expression_desc =
     (* `A             (None)
        `A E           (Some E)
     *)
-  | Pexp_record of
-      (Longident.t loc * expression * bool (* optional *)) list
-      * expression option
+  | Pexp_record of expression record_element list * expression option
     (* { l1=P1; ...; ln=Pn }     (None)
        { E0 with l1=P1; ...; ln=Pn }   (Some E0)
 
@@ -316,6 +314,9 @@ and expression_desc =
   (* . *)
   | Pexp_await of expression
   | Pexp_jsx_element of jsx_element
+
+(* an element of a record pattern or expression *)
+and 'a record_element = {lid: Longident.t loc; x: 'a; opt: bool (* optional *)}
 
 and jsx_element =
   | Jsx_fragment of jsx_fragment

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -458,7 +458,7 @@ and simple_pattern ctxt (f : Format.formatter) (x : pattern) : unit =
     | Ppat_unpack s -> pp f "(module@ %s)@ " s.txt
     | Ppat_type li -> pp f "#%a" longident_loc li
     | Ppat_record (l, closed) -> (
-      let longident_x_pattern f (li, p, opt) =
+      let longident_x_pattern f {lid = li; x = p; opt} =
         let opt_str = if opt then "?" else "" in
         match (li, p) with
         | ( {txt = Lident s; _},
@@ -764,7 +764,7 @@ and simple_expr ctxt f x =
       pp f "(%a :> %a)" (expression ctxt) e (core_type ctxt) ct
     | Pexp_variant (l, None) -> pp f "`%s" l
     | Pexp_record (l, eo) ->
-      let longident_x_expression f (li, e, opt) =
+      let longident_x_expression f {lid = li; x = e; opt} =
         let opt_str = if opt then "?" else "" in
         match e with
         | {pexp_desc = Pexp_ident {txt; _}; pexp_attributes = []; _}

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -672,7 +672,7 @@ and label_decl i ppf {pld_name; pld_mutable; pld_type; pld_loc; pld_attributes}
   line (i + 1) ppf "%a" fmt_string_loc pld_name;
   core_type (i + 1) ppf pld_type
 
-and longident_x_pattern i ppf (li, p, opt) =
+and longident_x_pattern i ppf {lid = li; x = p; opt} =
   line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");
   pattern (i + 1) ppf p
 
@@ -694,7 +694,7 @@ and value_binding i ppf x =
   pattern (i + 1) ppf x.pvb_pat;
   expression (i + 1) ppf x.pvb_expr
 
-and longident_x_expression i ppf (li, e, opt) =
+and longident_x_expression i ppf {lid = li; x = e; opt} =
   line i ppf "%a%s\n" fmt_longident_loc li (if opt then "?" else "");
   expression (i + 1) ppf e
 

--- a/compiler/syntax/src/jsx_ppx.ml
+++ b/compiler/syntax/src/jsx_ppx.ml
@@ -19,7 +19,7 @@ type config_key = Int | String
 let get_jsx_config_by_key ~key ~type_ record_fields =
   let values =
     List.filter_map
-      (fun ((lid, expr, _) : Longident.t Location.loc * expression * bool) ->
+      (fun ({lid; x = expr} : expression record_element) ->
         match (type_, lid, expr) with
         | ( Int,
             {txt = Lident k},

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -677,12 +677,15 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
         in
         if is_labelled arg_label || is_optional arg_label then
           returned_expression
-            (( {loc = ppat_loc; txt = Lident (get_label arg_label)},
-               {
-                 pattern_with_safe_label with
-                 ppat_attributes = pattern.ppat_attributes;
-               },
-               is_optional arg_label )
+            ({
+               lid = {loc = ppat_loc; txt = Lident (get_label arg_label)};
+               x =
+                 {
+                   pattern_with_safe_label with
+                   ppat_attributes = pattern.ppat_attributes;
+                 };
+               opt = is_optional arg_label;
+             }
             :: patterns_with_label)
             patterns_with_nolabel expr
         else
@@ -1151,13 +1154,17 @@ let mk_record_from_props mapper (jsx_expr_loc : Location.t) (props : jsx_props)
     props
     |> List.map (function
          | JSXPropPunning (is_optional, name) ->
-           ( {txt = Lident name.txt; loc = name.loc},
-             Exp.ident {txt = Lident name.txt; loc = name.loc},
-             is_optional )
+           {
+             lid = {txt = Lident name.txt; loc = name.loc};
+             x = Exp.ident {txt = Lident name.txt; loc = name.loc};
+             opt = is_optional;
+           }
          | JSXPropValue (name, is_optional, value) ->
-           ( {txt = Lident name.txt; loc = name.loc},
-             mapper.expr mapper value,
-             is_optional )
+           {
+             lid = {txt = Lident name.txt; loc = name.loc};
+             x = mapper.expr mapper value;
+             opt = is_optional;
+           }
          | JSXPropSpreading (loc, _) ->
            (* There can only be one spread expression and it is expected to be the first prop *)
            Jsx_common.raise_error ~loc

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -618,7 +618,7 @@ module SexpAst = struct
             Sexp.atom "Pexp_record";
             Sexp.list
               (map_empty
-                 ~f:(fun (longident_loc, expr, _) ->
+                 ~f:(fun {lid = longident_loc; x = expr} ->
                    Sexp.list
                      [longident longident_loc.Asttypes.txt; expression expr])
                  rows);
@@ -804,7 +804,7 @@ module SexpAst = struct
             closed_flag flag;
             Sexp.list
               (map_empty
-                 ~f:(fun (longident_loc, p, _) ->
+                 ~f:(fun {lid = longident_loc; x = p} ->
                    Sexp.list [longident longident_loc.Location.txt; pattern p])
                  rows);
           ]

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1107,7 +1107,7 @@ and walk_expression expr t comments =
         PStr [{pstr_desc = Pstr_eval ({pexp_desc = Pexp_record (rows, _)}, [])}]
       ) ->
     walk_list
-      (rows |> List.map (fun (li, e, _) -> ExprRecordRow (li, e)))
+      (Ext_list.map rows (fun {lid; x = e} -> ExprRecordRow (lid, e)))
       t comments
   | Pexp_extension extension -> walk_extension extension t comments
   | Pexp_letexception (extension_constructor, expr2) ->
@@ -1227,7 +1227,7 @@ and walk_expression expr t comments =
           rest
       in
       walk_list
-        (rows |> List.map (fun (li, e, _) -> ExprRecordRow (li, e)))
+        (Ext_list.map rows (fun {lid; x = e} -> ExprRecordRow (lid, e)))
         t comments
   | Pexp_field (expr, longident) ->
     let leading, inside, trailing = partition_by_loc comments expr.pexp_loc in
@@ -2068,7 +2068,7 @@ and walk_pattern pat t comments =
   | Ppat_type _ -> ()
   | Ppat_record (record_rows, _) ->
     walk_list
-      (record_rows |> List.map (fun (li, p, _) -> PatternRecordRow (li, p)))
+      (Ext_list.map record_rows (fun {lid; x = p} -> PatternRecordRow (lid, p)))
       t comments
   | Ppat_or _ ->
     walk_list


### PR DESCRIPTION
The record element is now represented as a record instead of a tuple. Because of the presence of several polymorphic functions in the type checker, a unique type `'a record_element` is defined, where `'a` will be instantiated with either expression or pattern depending on the context.