### PR TITLE
Turn eqeq in doc comments to asserts for testing

### DIFF
--- a/runtime/Belt_HashMap.resi
+++ b/runtime/Belt_HashMap.resi
@@ -174,7 +174,7 @@ let s1 = Belt.HashMap.copy(s0)
 
 Belt.HashMap.set(s0, 2, "3")
 
-assertEqual(Belt.HashMap.get(s0, 2) == Belt.HashMap.get(s1, 2), false)
+assertEqual(Belt.HashMap.get(s0, 2) != Belt.HashMap.get(s1, 2), true)
 ```
 */
 let copy: t<'key, 'value, 'id> => t<'key, 'value, 'id>

--- a/runtime/Stdlib_Console.resi
+++ b/runtime/Stdlib_Console.resi
@@ -14,7 +14,7 @@ on MDN.
 
 ```rescript
 Console.assert_(false, "Hello World!")
-Console.assert_(42 == 42, "The answer")
+Console.assert_(42 === 42, "The answer")
 ```
 */
 @val
@@ -27,7 +27,7 @@ external assert_: (bool, 'a) => unit = "console.assert"
 
 ```rescript
 Console.assert2(false, "Hello", "World")
-Console.assert2(42 == 42, [1, 2, 3], '4')
+Console.assert2(42 === 42, [1, 2, 3], '4')
 ```
 */
 @val
@@ -40,7 +40,7 @@ external assert2: (bool, 'a, 'b) => unit = "console.assert"
 
 ```rescript
 Console.assert3(false, "Hello", "World", "ReScript")
-Console.assert3(42 == 42, "One", 2, #3)
+Console.assert3(42 === 42, "One", 2, #3)
 ```
 */
 @val
@@ -54,7 +54,7 @@ external assert3: (bool, 'a, 'b, 'c) => unit = "console.assert"
 ```rescript
 let value = 42
 Console.assert4(false, "Hello", "World", "ReScript", "!!!")
-Console.assert4(value == 42, [1, 2], (3, 4), [#5, #6], #"polyvar")
+Console.assert4(value === 42, [1, 2], (3, 4), [#5, #6], #"polyvar")
 ```
 */
 @val
@@ -68,7 +68,7 @@ external assert4: (bool, 'a, 'b, 'c, 'd) => unit = "console.assert"
 ```rescript
 let value = 42
 Console.assert5(false, "Hello", "World", "JS", '!', '!')
-Console.assert5(value == 42, [1, 2], (3, 4), [#5, #6], #"polyvar", {"name": "ReScript"})
+Console.assert5(value === 42, [1, 2], (3, 4), [#5, #6], #"polyvar", {"name": "ReScript"})
 ```
 */
 @val
@@ -82,7 +82,7 @@ external assert5: (bool, 'a, 'b, 'c, 'd, 'e) => unit = "console.assert"
 ```rescript
 let value = 42
 Console.assert6(false, "Hello", "World", "JS", '!', '!', '?')
-Console.assert6(value == 42, [1, 2], (3, 4), [#5, #6], #"polyvar", {"name": "ReScript"}, 42)
+Console.assert6(value === 42, [1, 2], (3, 4), [#5, #6], #"polyvar", {"name": "ReScript"}, 42)
 ```
 */
 @val
@@ -96,7 +96,7 @@ external assert6: (bool, 'a, 'b, 'c, 'd, 'e, 'f) => unit = "console.assert"
 ```rescript
 let value = 42
 Console.assertMany(false, ["Hello", "World"])
-Console.assertMany(value == 42, [1, 2, 3])
+Console.assertMany(value === 42, [1, 2, 3])
 ```
 */
 @val

--- a/runtime/Stdlib_String.resi
+++ b/runtime/Stdlib_String.resi
@@ -891,11 +891,8 @@ See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 ## Examples
 
 ```rescript
-String.splitByRegExpAtMost("Hello World. How are you doing?", %re("/ /"), ~limit=3) == [
-  Some("Hello"),
-  Some("World."),
-  Some("How"),
-]
+String.splitByRegExpAtMost("Hello World. How are you doing?", / /, ~limit=3) ==
+  [Some("Hello"), Some("World."), Some("How")]
 ```
 */
 @send

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -21,7 +21,7 @@ case "$(uname -s)" in
     if ./cli/rescript.js format -check $files; then
       printf "${successGreen}✅ ReScript code formatting ok.${reset}\n"
     else
-      printf "${warningYellow}⚠️ ReScript code formatting issues found.${reset}\n"
+      printf "${warningYellow}⚠️ ReScript code formatting issues found. Run 'make format' to fix.${reset}\n"
       exit 1
     fi
     ;;

--- a/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionJsx.res.txt
@@ -802,7 +802,7 @@ Path s
     "kind": 12,
     "tags": [],
     "detail": "(string, RegExp.t, ~limit: int) => array<option<string>>",
-    "documentation": {"kind": "markdown", "value": "\n`splitByRegExpAtMost(str, regexp, ~limit)` splits the given `str` at every\noccurrence of `regexp` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings, the\narray will contain all the substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExpAtMost(\"Hello World. How are you doing?\", %re(\"/ /\"), ~limit=3) == [\n  Some(\"Hello\"),\n  Some(\"World.\"),\n  Some(\"How\"),\n]\n```\n"},
+    "documentation": {"kind": "markdown", "value": "\n`splitByRegExpAtMost(str, regexp, ~limit)` splits the given `str` at every\noccurrence of `regexp` and returns an array of the first `limit` resulting\nsubstrings. If `limit` is negative or greater than the number of substrings, the\narray will contain all the substrings.\nSee [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.\n\n## Examples\n\n```rescript\nString.splitByRegExpAtMost(\"Hello World. How are you doing?\", / /, ~limit=3) ==\n  [Some(\"Hello\"), Some(\"World.\"), Some(\"How\")]\n```\n"},
     "sortText": "splitByRegExpAtMost",
     "insertText": "->String.splitByRegExpAtMost",
     "additionalTextEdits": [{


### PR DESCRIPTION
Makes it possible to change `assertEqual` to `==` in doc comments to improve readability, while keeping the test safety