### PR TITLE
Editor mode config option

### DIFF
--- a/compiler/bsc/rescript_compiler_main.ml
+++ b/compiler/bsc/rescript_compiler_main.ml
@@ -392,6 +392,12 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
        print the transformed ReScript code to stdout" );
     ("-format", string_call format_file, "*internal* Format as Res syntax");
     ("-only-parse", set Clflags.only_parse, "*internal* stop after parsing");
+    ( "-editor-mode",
+      unit_call (fun () ->
+          Clflags.editor_mode := true;
+          Clflags.ignore_parse_errors := true;
+          Js_config.cmi_only := true),
+      "*internal* Enable editor mode." );
     ( "-ignore-parse-errors",
       set Clflags.ignore_parse_errors,
       "*internal* continue after parse errors" );

--- a/compiler/ml/clflags.ml
+++ b/compiler/ml/clflags.ml
@@ -40,6 +40,8 @@ and dump_lambda = ref false (* -dlambda *)
 
 and only_parse = ref false (* -only-parse *)
 
+and editor_mode = ref false (* -editor-mode *)
+
 and ignore_parse_errors = ref false (* -ignore-parse-errors *)
 
 let dont_write_files = ref false (* set to true under ocamldoc *)

--- a/compiler/ml/clflags.mli
+++ b/compiler/ml/clflags.mli
@@ -25,6 +25,7 @@ val dont_write_files : bool ref
 val keep_locs : bool ref
 val only_parse : bool ref
 val ignore_parse_errors : bool ref
+val editor_mode : bool ref
 
 val parse_color_setting : string -> Misc.Color.setting option
 val color : Misc.Color.setting option ref


### PR DESCRIPTION
This sets up an `-editor-mode` flag for `bsc`. The intention is that the editor tooling can set this as it calls `bsc` for the incremental compilation that powers the continuous feedback without saving in the editor.

It's mostly a placeholder for now, but it does set some configuration that's good for the editor tooling already:
- `ignore_parse_errors` lets the compiler continue even if it finds parse errors.
- `cmi_only` stops after type checking, so it never runs the JS generation related optimizations and the generation itself. This is because the generated JS is not interesting to the editor tooling, only the type checking (and type artifacts) are. Should in theory speed things up a little since `bsc` will do less work.

But mostly, this is a mode that we can use as we do more stuff in the compiler intended for the editor tooling.