### PR TITLE
Add flag for preserve jsx mode to rescript.json

### DIFF
--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -839,6 +839,10 @@ impl Package {
         self.config.get_jsx_module_args()
     }
 
+    pub fn get_jsx_preserve_args(&self) -> Vec<String> {
+        self.config.get_jsx_preserve_args()
+    }
+
     pub fn get_uncurried_args(&self, version: &str, root_package: &packages::Package) -> Vec<String> {
         root_package.config.get_uncurried_args(version)
     }

--- a/rewatch/src/build/parse.rs
+++ b/rewatch/src/build/parse.rs
@@ -272,6 +272,7 @@ pub fn parser_args(
     let jsx_args = root_config.get_jsx_args();
     let jsx_module_args = root_config.get_jsx_module_args();
     let jsx_mode_args = root_config.get_jsx_mode_args();
+    let jsx_preserve_args = root_config.get_jsx_preserve_args();
     let uncurried_args = root_config.get_uncurried_args(version);
     let bsc_flags = config::flatten_flags(&config.bsc_flags);
 
@@ -285,6 +286,7 @@ pub fn parser_args(
             jsx_args,
             jsx_module_args,
             jsx_mode_args,
+            jsx_preserve_args,
             uncurried_args,
             bsc_flags,
             vec![

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -184,6 +184,7 @@ pub struct JsxSpecs {
     pub mode: Option<JsxMode>,
     #[serde(rename = "v3-dependencies")]
     pub v3_dependencies: Option<Vec<String>>,
+    pub preserve: Option<bool>,
 }
 
 /// We do not care about the internal structure because the gentype config is loaded by bsc.
@@ -429,6 +430,16 @@ impl Config {
                     vec!["-bs-jsx-module".to_string(), module]
                 }
                 None => vec![],
+            },
+            _ => vec![],
+        }
+    }
+
+    pub fn get_jsx_preserve_args(&self) -> Vec<String> {
+        match self.jsx.to_owned() {
+            Some(jsx) => match jsx.preserve {
+                Some(true) => vec!["-bs-jsx-preserve".to_string()],
+                _ => vec![],
             },
             _ => vec![],
         }


### PR DESCRIPTION
@jfrolich I tried this after building locally, `cargo build --release`.
Then `../rescript/rewatch/target/release/rewatch` in my own project, and this didn't get picked up. Any ideas why?