### PR TITLE
Fix issue with partial application and user defined types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix `index out of bounds` exception thrown in rare cases by `rescript-editor-analysis.exe codeAction` command. https://github.com/rescript-lang/rescript/pull/7523
 - Don't produce duplicate type definitions for recursive types on hover. https://github.com/rescript-lang/rescript/pull/7524
 - Prop punning when types don't match results in I/O error: _none_: No such file or directory. https://github.com/rescript-lang/rescript/pull/7533
+- Fix partial application with user-defined function types. https://github.com/rescript-lang/rescript/pull/7548
 
 #### :nail_care: Polish
 

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -3481,10 +3481,9 @@ and type_application ~context total_app env funct (sargs : sargs) :
     | _ -> false
   in
   let has_arity funct =
-    let t = funct.exp_type in
     if force_tvar then Some (List.length sargs)
     else
-      match (Ctype.repr t).desc with
+      match (expand_head env funct.exp_type).desc with
       | Tarrow (_, _, _, _, Some arity) -> Some arity
       | _ -> None
   in
@@ -3538,7 +3537,7 @@ and type_application ~context total_app env funct (sargs : sargs) :
           | _ -> new_t
       in
       (fully_applied, new_t)
-    | _ -> (false, new_t)
+    | None -> (false, new_t)
   in
   let rec type_unknown_args max_arity ~(args : lazy_args) ~top_arity omitted
       ty_fun (syntax_args : sargs) : targs * _ =

--- a/tests/tests/src/PartialApplicationNoRuntimeCurry.mjs
+++ b/tests/tests/src/PartialApplicationNoRuntimeCurry.mjs
@@ -10,8 +10,17 @@ function f(u) {
   return extra => f$1(1, extra);
 }
 
+function add$1(a, b) {
+  return a + b | 0;
+}
+
+function add5(extra) {
+  return 5 + extra | 0;
+}
+
 export {
-  add,
   f,
+  add$1 as add,
+  add5,
 }
 /* No side effect */

--- a/tests/tests/src/PartialApplicationNoRuntimeCurry.res
+++ b/tests/tests/src/PartialApplicationNoRuntimeCurry.res
@@ -1,8 +1,11 @@
-@@uncurried
-
 let add = x => (y, z) => x + y + z
 
 let f = u => {
   let f = add(u)
   f(1, ...)
 }
+
+// Test partial application with user-defined function type
+type fn2 = (int, int) => int
+let add: fn2 = (a, b) => a + b
+let add5: int => int = add(5, ...)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7544

Fix an issue in type checking partial application in the presence of user-defined function types. The type checking code, when extracting the arity of the type annotation given to a function being applied, was expecting a concrete function type instead of looking up a possible type definition.