### PR TITLE
Add missing docstring for String

### DIFF
--- a/runtime/Stdlib_String.res
+++ b/runtime/Stdlib_String.res
@@ -1,6 +1,6 @@
 type t = string
 
-@val external make: 'a => string = "String"
+@new external make: 'a => string = "String"
 
 @val external fromCharCode: int => string = "String.fromCharCode"
 @variadic @val external fromCharCodeMany: array<int> => string = "String.fromCharCode"

--- a/runtime/Stdlib_String.resi
+++ b/runtime/Stdlib_String.resi
@@ -42,7 +42,7 @@ String.make(3.5) == "3.5"
 String.make([1, 2, 3]) == "1,2,3"
 ```
 */
-@val
+@new
 external make: 'a => string = "String"
 
 /**
@@ -121,8 +121,30 @@ String.fromCodePointMany([0xd55c, 0xae00, 0x1f63a]) == `한글😺`
 @variadic @val
 external fromCodePointMany: array<int> => string = "String.fromCodePoint"
 
+/**
+`equal(str1, str2)` checks if two strings are equal.
+
+## Examples
+
+```rescript
+String.equal("hello", "hello") == true
+String.equal("hello", "world") == false
+String.equal("", "") == true
+```
+*/
 external equal: (string, string) => bool = "%equal"
 
+/**
+`compare(str1, str2)` compares two strings, returns an `Ordering.t` value.
+
+## Examples
+
+```rescript
+String.compare("hello", "hello") == Ordering.equal
+String.compare("apple", "banana") == Ordering.less
+String.compare("zebra", "apple") == Ordering.greater
+```
+*/
 external compare: (string, string) => Stdlib_Ordering.t = "%compare"
 
 /**
@@ -1090,9 +1112,49 @@ String.padEnd("abc", 1, "") == "abc"
 @send
 external padEnd: (string, int, string) => string = "padEnd"
 
-// TODO: add docs
+/**
+`getSymbol(str, symbol)` returns the value associated with the given symbol on the string as an `option<'a>`.
+Returns `None` if the symbol property doesn't exist.
+
+## Examples
+
+```rescript
+let mySymbol = Symbol.make("test")
+let h = String.make("hello")
+String.setSymbol(h, mySymbol, 42)
+String.getSymbol(h, mySymbol) == Some(42)
+```
+*/
 @get_index external getSymbol: (string, Stdlib_Symbol.t) => option<'a> = ""
+
+/**
+`getSymbolUnsafe(str, symbol)` returns the value associated with the given symbol on the string. 
+
+This is _unsafe_, meaning it will return `undefined` if the symbol property doesn't exist.
+
+## Examples
+
+```rescript
+let mySymbol = Symbol.make("test")
+let h = String.make("hello")
+String.setSymbol(h, mySymbol, 43)
+String.getSymbolUnsafe(h, mySymbol) == 43
+```
+*/
 @get_index external getSymbolUnsafe: (string, Stdlib_Symbol.t) => 'a = ""
+
+/**
+`setSymbol(str, symbol, value)` sets the given symbol property on the string to the specified value.
+
+## Examples
+
+```rescript
+let mySymbol = Symbol.make("test")
+let h = String.make("hello")
+String.setSymbol(h, mySymbol, 42)
+String.getSymbol(h, mySymbol) == Some(42)
+```
+*/
 @set_index external setSymbol: (string, Stdlib_Symbol.t, 'a) => unit = ""
 
 /**


### PR DESCRIPTION
This one is a bit weird, I had to make the `@val` to `@new` change to make the examples work.
I noticed this in plain JavaScript as well, that not having the `new` keyword, doesn't make it work.

Happy to hear your thoughts here, not sure what is best.