### PR TITLE
Fix crash when `-bs-g` is used on untagged variants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Pass the rewatch exit code through in wrapper script. https://github.com/rescript-lang/rescript/pull/7565
 - Prop punning when types don't match results in I/O error: _none_: No such file or directory. https://github.com/rescript-lang/rescript/pull/7533
 - Pass location to children prop in jsx ppx. https://github.com/rescript-lang/rescript/pull/7540
+- Fix crash when `bs-g` is used with untagged variants. https://github.com/rescript-lang/rescript/pull/7575
 
 #### :nail_care: Polish
 

--- a/compiler/core/js_dump.ml
+++ b/compiler/core/js_dump.ml
@@ -949,7 +949,8 @@ and expression_desc cxt ~(level : int) f x : cxt =
               | false, 1 -> Js_op.Lit Literals.tl
               | _ -> Js_op.Lit ("_" ^ string_of_int i)),
               e ))
-          (if !Js_config.debug && not_is_cons then [(name_symbol, E.str p.name)]
+          (if !Js_config.debug && (not untagged) && not_is_cons then
+             [(name_symbol, E.str p.name)]
            else [])
       in
       if untagged || (not_is_cons = false && p.num_nonconst = 1) then tails


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript/issues/6496

While deprecation is being discussed, this prevents the compiler crashes.