### PR TITLE
Preserve jsx with custom module

### DIFF
--- a/tests/tests/src/jsx_preserve_custom_module.res
+++ b/tests/tests/src/jsx_preserve_custom_module.res
@@ -1,0 +1,16 @@
+@@config({
+  flags: ["-bs-jsx", "4", "-bs-jsx-preserve", "-bs-jsx-module", "Custom"],
+})
+
+module Custom = {
+  type component<'props> = Jsx.component<'props>
+  type element = Jsx.element
+
+  external jsx: (component<'props>, 'props) => element = "jsx"
+
+  type fragmentProps = {children?: element}
+
+  external jsxFragment: component<fragmentProps> = "Fragment"
+}
+
+let _fragment = <> {Jsx.string("Hello, world!")} </>


### PR DESCRIPTION
It was mentioned on the forum that `-bs-jsx-preserve` doesn't work in combination with `-bs-jsx-module`.


Sample to reproduce:
```shell
dune exec bsc -- ./tests/tests/src/jsx_preserve_custom_module.res       
```

@cristianoc PPX seems fine, and I believe the information gets lost before reaching `js_dump`.
Would you have any guess what is different for this code path?