### PR TITLE
Experimental command to format code blocks embedded in docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 12.0.0-beta.1 (Unreleased)
 
+#### :rocket: New Feature
+
+- Add experimental command to `rescript-tools` for formatting all ReScript code blocks in markdown. Either in a markdown file directly, or inside of docstrings in ReScript code. https://github.com/rescript-lang/rescript/pull/7598
+
 # 12.0.0-alpha.15
 
 #### :boom: Breaking Change

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -282,17 +282,13 @@ let format ~path =
         ~filename:path
     in
     if List.length diagnostics > 0 then ""
-    else
-      Res_printer.print_implementation
-        ~width:Res_multi_printer.default_print_width ~comments structure
+    else Res_printer.print_implementation ~comments structure
   else if Filename.check_suffix path ".resi" then
     let {Res_driver.parsetree = signature; comments; diagnostics} =
       Res_driver.parsing_engine.parse_interface ~for_printer:true ~filename:path
     in
     if List.length diagnostics > 0 then ""
-    else
-      Res_printer.print_interface ~width:Res_multi_printer.default_print_width
-        ~comments signature
+    else Res_printer.print_interface ~comments signature
   else ""
 
 let diagnosticSyntax ~path =

--- a/analysis/src/CreateInterface.ml
+++ b/analysis/src/CreateInterface.ml
@@ -102,7 +102,7 @@ let printSignature ~extractor ~signature =
   Printtyp.reset_names ();
   let sigItemToString (item : Outcometree.out_sig_item) =
     item |> Res_outcome_printer.print_out_sig_item_doc
-    |> Res_doc.to_string ~width:Res_multi_printer.default_print_width
+    |> Res_doc.to_string ~width:Res_printer.default_print_width
   in
 
   let genSigStrForInlineAttr lines attributes id vd =

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -855,7 +855,6 @@ let parseImplementation ~filename =
     let structure = [Ast_helper.Str.eval ~loc:expr.pexp_loc expr] in
     structure
     |> Res_printer.print_implementation
-         ~width:Res_multi_printer.default_print_width
          ~comments:(comments |> filterComments ~loc:expr.pexp_loc)
     |> Utils.indent range.start.character
   in
@@ -864,14 +863,12 @@ let parseImplementation ~filename =
     let structure = [item] in
     structure
     |> Res_printer.print_implementation
-         ~width:Res_multi_printer.default_print_width
          ~comments:(comments |> filterComments ~loc:item.pstr_loc)
     |> Utils.indent range.start.character
   in
   let printStandaloneStructure ~(loc : Location.t) structure =
     structure
     |> Res_printer.print_implementation
-         ~width:Res_multi_printer.default_print_width
          ~comments:(comments |> filterComments ~loc)
   in
   (structure, printExpr, printStructureItem, printStandaloneStructure)
@@ -891,7 +888,7 @@ let parseInterface ~filename =
       (item : Parsetree.signature_item) =
     let signature_item = [item] in
     signature_item
-    |> Res_printer.print_interface ~width:Res_multi_printer.default_print_width
+    |> Res_printer.print_interface
          ~comments:(comments |> filterComments ~loc:item.psig_loc)
     |> Utils.indent range.start.character
   in

--- a/compiler/ml/location.mli
+++ b/compiler/ml/location.mli
@@ -103,12 +103,28 @@ val register_error_of_exn : (exn -> error option) -> unit
     a location, a message, and optionally sub-messages (each of them
     being located as well). *)
 
-val report_error : ?src:string option -> formatter -> error -> unit
+val report_error :
+  ?custom_intro:string option ->
+  ?src:string option ->
+  formatter ->
+  error ->
+  unit
 
-val error_reporter : (?src:string option -> formatter -> error -> unit) ref
+val error_reporter :
+  (?custom_intro:string option ->
+  ?src:string option ->
+  formatter ->
+  error ->
+  unit)
+  ref
 (** Hook for intercepting error reports. *)
 
-val default_error_reporter : ?src:string option -> formatter -> error -> unit
+val default_error_reporter :
+  ?custom_intro:string option ->
+  ?src:string option ->
+  formatter ->
+  error ->
+  unit
 (** Original error reporter for use in hooks. *)
 
 val report_exception : formatter -> exn -> unit

--- a/compiler/syntax/src/res_diagnostics.ml
+++ b/compiler/syntax/src/res_diagnostics.ml
@@ -131,12 +131,13 @@ let explain t =
 
 let make ~start_pos ~end_pos category = {start_pos; end_pos; category}
 
-let print_report diagnostics src =
+let print_report ?(custom_intro = None) ?(formatter = Format.err_formatter)
+    diagnostics src =
   let rec print diagnostics src =
     match diagnostics with
     | [] -> ()
     | d :: rest ->
-      Location.report_error ~src:(Some src) Format.err_formatter
+      Location.report_error ~custom_intro ~src:(Some src) formatter
         Location.
           {
             loc =
@@ -147,12 +148,12 @@ let print_report diagnostics src =
           };
       (match rest with
       | [] -> ()
-      | _ -> Format.fprintf Format.err_formatter "@.");
+      | _ -> Format.fprintf formatter "@.");
       print rest src
   in
-  Format.fprintf Format.err_formatter "@[<v>";
+  Format.fprintf formatter "@[<v>";
   print (List.rev diagnostics) src;
-  Format.fprintf Format.err_formatter "@]@."
+  Format.fprintf formatter "@]@."
 
 let unexpected token context = Unexpected {token; context}
 

--- a/compiler/syntax/src/res_diagnostics.mli
+++ b/compiler/syntax/src/res_diagnostics.mli
@@ -22,4 +22,9 @@ val message : string -> category
 
 val make : start_pos:Lexing.position -> end_pos:Lexing.position -> category -> t
 
-val print_report : t list -> string -> unit
+val print_report :
+  ?custom_intro:string option ->
+  ?formatter:Format.formatter ->
+  t list ->
+  string ->
+  unit

--- a/compiler/syntax/src/res_multi_printer.ml
+++ b/compiler/syntax/src/res_multi_printer.ml
@@ -1,5 +1,3 @@
-let default_print_width = 100
-
 (* print res files to res syntax *)
 let print_res ~ignore_parse_errors ~is_interface ~filename =
   if is_interface then (
@@ -9,7 +7,7 @@ let print_res ~ignore_parse_errors ~is_interface ~filename =
     if parse_result.invalid then (
       Res_diagnostics.print_report parse_result.diagnostics parse_result.source;
       if not ignore_parse_errors then exit 1);
-    Res_printer.print_interface ~width:default_print_width
+    Res_printer.print_interface ~width:Res_printer.default_print_width
       ~comments:parse_result.comments parse_result.parsetree)
   else
     let parse_result =
@@ -18,7 +16,7 @@ let print_res ~ignore_parse_errors ~is_interface ~filename =
     if parse_result.invalid then (
       Res_diagnostics.print_report parse_result.diagnostics parse_result.source;
       if not ignore_parse_errors then exit 1);
-    Res_printer.print_implementation ~width:default_print_width
+    Res_printer.print_implementation ~width:Res_printer.default_print_width
       ~comments:parse_result.comments parse_result.parsetree
 [@@raises exit]
 

--- a/compiler/syntax/src/res_multi_printer.mli
+++ b/compiler/syntax/src/res_multi_printer.mli
@@ -1,5 +1,3 @@
-val default_print_width : int [@@live]
-
 (* Interface to print source code to res.
  * Takes a filename called "input" and returns the corresponding formatted res syntax *)
 val print : ?ignore_parse_errors:bool -> string -> string [@@dead "+print"]

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -5,6 +5,8 @@ module Token = Res_token
 module Parens = Res_parens
 module ParsetreeViewer = Res_parsetree_viewer
 
+let default_print_width = 100
+
 type callback_style =
   (* regular arrow function, example: `let f = x => x + 1` *)
   | NoCallback
@@ -6055,7 +6057,8 @@ let print_typ_expr t = print_typ_expr ~state:(State.init ()) t
 let print_expression e = print_expression ~state:(State.init ()) e
 let print_pattern p = print_pattern ~state:(State.init ()) p
 
-let print_implementation ~width (s : Parsetree.structure) ~comments =
+let print_implementation ?(width = default_print_width)
+    (s : Parsetree.structure) ~comments =
   let cmt_tbl = CommentTable.make () in
   CommentTable.walk_structure s cmt_tbl comments;
   (* CommentTable.log cmt_tbl; *)
@@ -6063,7 +6066,8 @@ let print_implementation ~width (s : Parsetree.structure) ~comments =
   (* Doc.debug doc; *)
   Doc.to_string ~width doc ^ "\n"
 
-let print_interface ~width (s : Parsetree.signature) ~comments =
+let print_interface ?(width = default_print_width) (s : Parsetree.signature)
+    ~comments =
   let cmt_tbl = CommentTable.make () in
   CommentTable.walk_signature s cmt_tbl comments;
   Doc.to_string ~width (print_signature ~state:(State.init ()) s cmt_tbl) ^ "\n"

--- a/compiler/syntax/src/res_printer.mli
+++ b/compiler/syntax/src/res_printer.mli
@@ -1,3 +1,5 @@
+val default_print_width : int
+
 val print_type_params :
   (Parsetree.core_type * Asttypes.variance) list ->
   Res_comments_table.t ->
@@ -18,9 +20,9 @@ val print_structure : Parsetree.structure -> Res_comments_table.t -> Res_doc.t
 [@@live]
 
 val print_implementation :
-  width:int -> Parsetree.structure -> comments:Res_comment.t list -> string
+  ?width:int -> Parsetree.structure -> comments:Res_comment.t list -> string
 val print_interface :
-  width:int -> Parsetree.signature -> comments:Res_comment.t list -> string
+  ?width:int -> Parsetree.signature -> comments:Res_comment.t list -> string
 
 val print_ident_like :
   ?allow_uident:bool -> ?allow_hyphen:bool -> string -> Res_doc.t

--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,8 @@
  (depends
   (ocaml
    (>= 4.14))
+  (cmarkit
+   (>= 0.3.0))
   (cppo
    (= 1.8.0))
   analysis

--- a/runtime/Stdlib_Result.resi
+++ b/runtime/Stdlib_Result.resi
@@ -83,10 +83,10 @@ let getOrThrow: result<'a, 'b> => 'a
 
 ```rescript
 let ok = Ok(42)
-Result.mapOr(ok, 0, (x) => x / 2) == 21
+Result.mapOr(ok, 0, x => x / 2) == 21
 
 let error = Error("Invalid data")
-Result.mapOr(error, 0, (x) => x / 2) == 0
+Result.mapOr(error, 0, x => x / 2) == 0
 ```
 */
 let mapOr: (result<'a, 'c>, 'b, 'a => 'b) => 'b
@@ -102,7 +102,7 @@ ordinary value.
 ## Examples
 
 ```rescript
-let f = (x) => sqrt(Int.toFloat(x))
+let f = x => sqrt(Int.toFloat(x))
 
 Result.map(Ok(64), f) == Ok(8.0)
 
@@ -119,8 +119,8 @@ unchanged. Function `f` takes a value of the same type as `n` and returns a
 ## Examples
 
 ```rescript
-let recip = (x) =>
-  if (x !== 0.0) {
+let recip = x =>
+  if x !== 0.0 {
     Ok(1.0 /. x)
   } else {
     Error("Divide by zero")
@@ -219,11 +219,11 @@ let mod10cmp = (a, b) => Int.compare(mod(a, 10), mod(b, 10))
 
 Result.compare(Ok(39), Ok(57), mod10cmp) == 1.
 
-Result.compare(Ok(57), Ok(39), mod10cmp) == (-1.)
+Result.compare(Ok(57), Ok(39), mod10cmp) == -1.
 
 Result.compare(Ok(39), Error("y"), mod10cmp) == 1.
 
-Result.compare(Error("x"), Ok(57), mod10cmp) == (-1.)
+Result.compare(Error("x"), Ok(57), mod10cmp) == -1.
 
 Result.compare(Error("x"), Error("y"), mod10cmp) == 0.
 ```

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
@@ -30,7 +30,7 @@ module Nested = {
     let getName = user=>user.name
   }
   ```  
-*/
+  */
   let testFunction2 = () => "test2"
 }
 

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
@@ -39,7 +39,8 @@ Third docstring with array and option types.
 
 ```rescript
 let processUsers=(users:array<user>)=>{
-users->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
+users
+->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
 }
 
 type status=|Loading|Success(string)|Error(option<string>)

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
@@ -1,0 +1,48 @@
+/**
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted=(x,y)=>{
+let result=x+y
+if result>0{Console.log("positive")}else{Console.log("negative")}
+result
+}
+```
+
+And another code block in the same docstring:
+
+```rescript
+type user={name:string,age:int,active:bool}
+let createUser=(name,age)=>{name:name,age:age,active:true}
+```
+*/
+let testFunction1 = () => "test1"
+
+module Nested = {
+  /**
+  This is a second docstring with different formatting issues.
+
+  But if I add another line here it should be fine.
+
+  ```rescript
+  module UserService={
+    let validate=user => user.age>=18 && user.name !== ""
+    let getName = user=>user.name
+  }
+  ```  
+*/
+  let testFunction2 = () => "test2"
+}
+
+/**
+Third docstring with array and option types.
+
+```rescript
+let processUsers=(users:array<user>)=>{
+users->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
+}
+
+type status=|Loading|Success(string)|Error(option<string>)
+```
+*/
+let testFunction3 = () => "test3"

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.res
@@ -1,7 +1,7 @@
 /**
 This is the first docstring with unformatted ReScript code.
 
-```rescript
+```res example
 let badly_formatted=(x,y)=>{
 let result=x+y
 if result>0{Console.log("positive")}else{Console.log("negative")}
@@ -24,7 +24,7 @@ module Nested = {
 
   But if I add another line here it should be fine.
 
-  ```rescript
+  ```res info
   module UserService={
     let validate=user => user.age>=18 && user.name !== ""
     let getName = user=>user.name

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.resi
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.resi
@@ -39,7 +39,8 @@ Third docstring with array and option types.
 
 ```rescript
 let processUsers=(users:array<user>)=>{
-users->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
+users
+->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
 }
 
 type status=|Loading|Success(string)|Error(option<string>)

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.resi
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest1.resi
@@ -1,0 +1,48 @@
+/**
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted=(x,y)=>{
+let result=x+y
+if result>0{Console.log("positive")}else{Console.log("negative")}
+result
+}
+```
+
+And another code block in the same docstring:
+
+```rescript
+type user={name:string,age:int,active:bool}
+let createUser=(name,age)=>{name:name,age:age,active:true}
+```
+*/
+let testFunction1: unit => string
+
+module Nested: {
+  /**
+  This is a second docstring with different formatting issues.
+
+  But if I add another line here it should be fine.
+
+  ```rescript
+  module UserService={
+    let validate=user => user.age>=18 && user.name !== ""
+    let getName = user=>user.name
+  }
+  ```  
+*/
+  let testFunction2: unit => string
+}
+
+/**
+Third docstring with array and option types.
+
+```rescript
+let processUsers=(users:array<user>)=>{
+users->Array.map(user=>{...user,active:false})->Array.filter(u=>u.age>21)
+}
+
+type status=|Loading|Success(string)|Error(option<string>)
+```
+*/
+let testFunction3: unit => string

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
@@ -1,0 +1,41 @@
+/**
+Testing JSX and more complex formatting scenarios.
+
+```rescript
+let component=()=>{
+<div className="container">
+<h1>{"Title"->React.string}</h1>
+<button onClick={_=>Console.log("clicked")}>{"Click me"->React.string}</button>
+</div>
+}
+```
+
+Testing pattern matching and switch expressions:
+
+```rescript
+let handleResult=(result:result<string,string>)=>{
+switch result {
+| Ok(value)=>Console.log(`Success: ${value}`)
+| Error(error)=>Console.error(`Error: ${error}`)
+}
+}
+```
+*/
+let testJsx = () => "jsx test"
+
+/**
+Testing function composition and piping.
+
+```rescript
+let processData=(data:array<int>)=>{
+data->Array.filter(x=>x>0)->Array.map(x=>x*2)->Array.reduce(0,(acc,x)=>acc+x)
+}
+
+let asyncExample=async()=>{
+let data=await fetchData()
+let processed=await processData(data)
+Console.log(processed)
+}
+```
+*/
+let testPipes = () => "pipes test"

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
@@ -28,7 +28,8 @@ Testing function composition and piping.
 
 ```rescript
 let processData=(data:array<int>)=>{
-data->Array.filter(x=>x>0)->Array.map(x=>x*2)->Array.reduce(0,(acc,x)=>acc+x)
+data
+->Array.filter(x=>x>0)->Array.map(x=>x*2)->Array.reduce(0,(acc,x)=>acc+x)
 }
 
 let asyncExample=async()=>{

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTest2.res
@@ -40,3 +40,17 @@ Console.log(processed)
 ```
 */
 let testPipes = () => "pipes test"
+
+/**
+Testing resi code blocks.
+
+```resi
+type x=int
+let x:int => 
+    string
+module M:{let ff: string => int
+}
+
+```
+ */
+let testResi = () => true

--- a/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res
+++ b/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res
@@ -1,0 +1,9 @@
+/**
+This docstring has an error.
+
+```rescript
+let name= 
+let x=12
+```
+*/
+let testJsx = () => "jsx test"

--- a/tests/tools_tests/src/docstrings-format/FormatRescriptBlocks.md
+++ b/tests/tools_tests/src/docstrings-format/FormatRescriptBlocks.md
@@ -1,0 +1,20 @@
+# Format ReScript code blocks
+
+This markdown file should be formatted.
+
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted=(x,y)=>{
+let result=x+y
+if result>0{Console.log("positive")}else{Console.log("negative")}
+result
+}
+```
+
+And another code block in the same docstring:
+
+```res
+type user={name:string,age:int,active:bool}
+let createUser=(name,age)=>{name:name,age:age,active:true}
+```

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
@@ -1,7 +1,7 @@
 /**
 This is the first docstring with unformatted ReScript code.
 
-```rescript
+```res example
 let badly_formatted = (x, y) => {
   let result = x + y
   if result > 0 {
@@ -28,7 +28,7 @@ module Nested = {
 
   But if I add another line here it should be fine.
 
-  ```rescript
+  ```res info
   module UserService = {
     let validate = user => user.age >= 18 && user.name !== ""
     let getName = user => user.name

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
@@ -34,7 +34,7 @@ module Nested = {
     let getName = user => user.name
   }
   ```
-*/
+  */
   let testFunction2 = () => "test2"
 }
 

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
@@ -1,0 +1,55 @@
+/**
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted = (x, y) => {
+  let result = x + y
+  if result > 0 {
+    Console.log("positive")
+  } else {
+    Console.log("negative")
+  }
+  result
+}
+```
+
+And another code block in the same docstring:
+
+```rescript
+type user = {name: string, age: int, active: bool}
+let createUser = (name, age) => {name, age, active: true}
+```
+*/
+let testFunction1 = () => "test1"
+
+module Nested = {
+  /**
+  This is a second docstring with different formatting issues.
+
+  But if I add another line here it should be fine.
+
+  ```rescript
+  module UserService = {
+    let validate = user => user.age >= 18 && user.name !== ""
+    let getName = user => user.name
+  }
+  ```  
+*/
+  let testFunction2 = () => "test2"
+}
+
+/**
+Third docstring with array and option types.
+
+```rescript
+let processUsers = (users: array<user>) => {
+  users
+  ->Array.map(user => {...user, active: false})
+  ->Array.filter(u => u.age > 21)
+}
+
+type status = Loading | Success(string) | Error(option<string>)
+```
+*/
+let testFunction3 = () => "test3"
+

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.res.expected
@@ -33,7 +33,7 @@ module Nested = {
     let validate = user => user.age >= 18 && user.name !== ""
     let getName = user => user.name
   }
-  ```  
+  ```
 */
   let testFunction2 = () => "test2"
 }

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.resi.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.resi.expected
@@ -1,0 +1,55 @@
+/**
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted = (x, y) => {
+  let result = x + y
+  if result > 0 {
+    Console.log("positive")
+  } else {
+    Console.log("negative")
+  }
+  result
+}
+```
+
+And another code block in the same docstring:
+
+```rescript
+type user = {name: string, age: int, active: bool}
+let createUser = (name, age) => {name, age, active: true}
+```
+*/
+let testFunction1: unit => string
+
+module Nested: {
+  /**
+  This is a second docstring with different formatting issues.
+
+  But if I add another line here it should be fine.
+
+  ```rescript
+  module UserService = {
+    let validate = user => user.age >= 18 && user.name !== ""
+    let getName = user => user.name
+  }
+  ```  
+*/
+  let testFunction2: unit => string
+}
+
+/**
+Third docstring with array and option types.
+
+```rescript
+let processUsers = (users: array<user>) => {
+  users
+  ->Array.map(user => {...user, active: false})
+  ->Array.filter(u => u.age > 21)
+}
+
+type status = Loading | Success(string) | Error(option<string>)
+```
+*/
+let testFunction3: unit => string
+

--- a/tests/tools_tests/src/expected/FormatDocstringsTest1.resi.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest1.resi.expected
@@ -33,7 +33,7 @@ module Nested: {
     let validate = user => user.age >= 18 && user.name !== ""
     let getName = user => user.name
   }
-  ```  
+  ```
 */
   let testFunction2: unit => string
 }

--- a/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
@@ -43,3 +43,16 @@ let asyncExample = async () => {
 */
 let testPipes = () => "pipes test"
 
+/**
+Testing resi code blocks.
+
+```resi
+type x = int
+let x: int => string
+module M: {
+  let ff: string => int
+}
+```
+ */
+let testResi = () => true
+

--- a/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
@@ -5,9 +5,7 @@ Testing JSX and more complex formatting scenarios.
 let component = () => {
   <div className="container">
     <h1> {"Title"->React.string} </h1>
-    <button onClick={_ => Console.log("clicked")}>
-      {"Click me"->React.string}
-    </button>
+    <button onClick={_ => Console.log("clicked")}> {"Click me"->React.string} </button>
   </div>
 }
 ```

--- a/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTest2.res.expected
@@ -1,0 +1,47 @@
+/**
+Testing JSX and more complex formatting scenarios.
+
+```rescript
+let component = () => {
+  <div className="container">
+    <h1> {"Title"->React.string} </h1>
+    <button onClick={_ => Console.log("clicked")}>
+      {"Click me"->React.string}
+    </button>
+  </div>
+}
+```
+
+Testing pattern matching and switch expressions:
+
+```rescript
+let handleResult = (result: result<string, string>) => {
+  switch result {
+  | Ok(value) => Console.log(`Success: ${value}`)
+  | Error(error) => Console.error(`Error: ${error}`)
+  }
+}
+```
+*/
+let testJsx = () => "jsx test"
+
+/**
+Testing function composition and piping.
+
+```rescript
+let processData = (data: array<int>) => {
+  data
+  ->Array.filter(x => x > 0)
+  ->Array.map(x => x * 2)
+  ->Array.reduce(0, (acc, x) => acc + x)
+}
+
+let asyncExample = async () => {
+  let data = await fetchData()
+  let processed = await processData(data)
+  Console.log(processed)
+}
+```
+*/
+let testPipes = () => "pipes test"
+

--- a/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
@@ -2,10 +2,10 @@
   Syntax error in code block in docstring
   FormatDocstringsTestError.res:5:10-6:3
 
-  3 [2m│[0m 
-  4 [2m│[0m 
-  [1;31m5[0m [2m│[0m let name=[1;31m [0m
-  [1;31m6[0m [2m│[0m [1;31mlet[0m x=12
+  3 │ 
+  4 │ 
+  5 │ let name= 
+  6 │ let x=12
 
   This let-binding misses an expression
 

--- a/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
@@ -1,10 +1,11 @@
 
   Syntax error in code block in docstring
-  /Users/zth/OSS/rescript-compiler/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res:2:10-3:3
+  /Users/zth/OSS/rescript-compiler/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res:5:10-6:3
 
-  1 [2m│[0m 
-  [1;31m2[0m [2m│[0m let name=[1;31m [0m
-  [1;31m3[0m [2m│[0m [1;31mlet[0m x=12
+  3 [2m│[0m 
+  4 [2m│[0m 
+  [1;31m5[0m [2m│[0m let name=[1;31m [0m
+  [1;31m6[0m [2m│[0m [1;31mlet[0m x=12
 
   This let-binding misses an expression
 

--- a/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
@@ -1,0 +1,11 @@
+
+  Syntax error in code block in docstring
+  /Users/zth/OSS/rescript-compiler/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res:2:10-3:3
+
+  1 [2m│[0m 
+  [1;31m2[0m [2m│[0m let name=[1;31m [0m
+  [1;31m3[0m [2m│[0m [1;31mlet[0m x=12
+
+  This let-binding misses an expression
+
+

--- a/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
+++ b/tests/tools_tests/src/expected/FormatDocstringsTestError.res.expected
@@ -1,6 +1,6 @@
 
   Syntax error in code block in docstring
-  /Users/zth/OSS/rescript-compiler/tests/tools_tests/src/docstrings-format/FormatDocstringsTestError.res:5:10-6:3
+  FormatDocstringsTestError.res:5:10-6:3
 
   3 [2m│[0m 
   4 [2m│[0m 

--- a/tests/tools_tests/src/expected/FormatRescriptBlocks.md.expected
+++ b/tests/tools_tests/src/expected/FormatRescriptBlocks.md.expected
@@ -1,0 +1,25 @@
+# Format ReScript code blocks
+
+This markdown file should be formatted.
+
+This is the first docstring with unformatted ReScript code.
+
+```rescript
+let badly_formatted = (x, y) => {
+  let result = x + y
+  if result > 0 {
+    Console.log("positive")
+  } else {
+    Console.log("negative")
+  }
+  result
+}
+```
+
+And another code block in the same docstring:
+
+```res
+type user = {name: string, age: int, active: bool}
+let createUser = (name, age) => {name, age, active: true}
+```
+

--- a/tests/tools_tests/test.sh
+++ b/tests/tools_tests/test.sh
@@ -16,6 +16,16 @@ for file in ppx/*.res; do
   fi
 done
 
+# Test format-docstrings command
+for file in src/docstrings-format/*.{res,resi}; do
+  output="src/expected/$(basename $file).expected"
+  ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
+  # # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
+  if [ "$RUNNER_OS" == "Windows" ]; then
+    perl -pi -e 's/\r\n/\n/g' -- $output
+  fi
+done
+
 warningYellow='\033[0;33m'
 successGreen='\033[0;32m'
 reset='\033[0m'

--- a/tests/tools_tests/test.sh
+++ b/tests/tools_tests/test.sh
@@ -19,7 +19,7 @@ done
 # Test format-docstrings command
 for file in src/docstrings-format/*.{res,resi}; do
   output="src/expected/$(basename $file).expected"
-  ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
+  DISABLE_COLOR=true ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
   # # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
   if [ "$RUNNER_OS" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output

--- a/tests/tools_tests/test.sh
+++ b/tests/tools_tests/test.sh
@@ -19,7 +19,7 @@ done
 # Test format-docstrings command
 for file in src/docstrings-format/*.{res,resi}; do
   output="src/expected/$(basename $file).expected"
-  DISABLE_COLOR=true ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
+  ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
   # # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
   if [ "$RUNNER_OS" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output

--- a/tests/tools_tests/test.sh
+++ b/tests/tools_tests/test.sh
@@ -17,9 +17,9 @@ for file in ppx/*.res; do
 done
 
 # Test format-docstrings command
-for file in src/docstrings-format/*.{res,resi}; do
+for file in src/docstrings-format/*.{res,resi,md}; do
   output="src/expected/$(basename $file).expected"
-  ../../_build/install/default/bin/rescript-tools format-docstrings "$file" --stdout > $output
+  ../../_build/install/default/bin/rescript-tools format-codeblocks "$file" --stdout > $output
   # # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
   if [ "$RUNNER_OS" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output

--- a/tools.opam
+++ b/tools.opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
   "ocaml" {>= "4.14"}
+  "cmarkit" {>= "0.3.0"}
   "cppo" {= "1.8.0"}
   "analysis"
   "dune" {>= "3.17"}

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -58,11 +58,12 @@ let main () =
     | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
     | path :: args -> (
       let isStdout = List.mem "--stdout" args in
+      let transformAssertEqual = List.mem "--transform-assert-equal" args in
       let outputMode = if isStdout then `Stdout else `File in
       Clflags.color := Some Misc.Color.Never;
       match
         ( Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode
-            ~entryPointFile:path,
+            ~transformAssertEqual ~entryPointFile:path,
           outputMode )
       with
       | Ok content, `Stdout -> print_endline content

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -56,18 +56,18 @@ let main () =
   | "format-codeblocks" :: rest -> (
     match rest with
     | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
-    | [path; "--stdout"] -> (
+    | path :: args -> (
+      let isStdout = List.mem "--stdout" args in
+      let outputMode = if isStdout then `Stdout else `File in
       Clflags.color := Some Misc.Color.Never;
       match
-        Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode:`Stdout
-          ~entryPointFile:path
+        ( Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode
+            ~entryPointFile:path,
+          outputMode )
       with
-      | Ok content -> print_endline content
-      | Error e -> logAndExit (Error e))
-    | [path] ->
-      Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode:`File
-        ~entryPointFile:path
-      |> logAndExit
+      | Ok content, `Stdout -> print_endline content
+      | result, `File -> logAndExit result
+      | Error e, _ -> logAndExit (Error e))
     | _ -> logAndExit (Error formatDocstringsHelp))
   | "reanalyze" :: _ ->
     let len = Array.length Sys.argv in

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -24,7 +24,9 @@ Usage: rescript-tools [command]
 Commands:
 
 doc <file>                              Generate documentation
-format-codeblocks <file> [--stdout]     Format ReScript code blocks
+format-codeblocks <file>                Format ReScript code blocks
+  [--stdout]                              Output to stdout
+  [--transform-assert-equal]              Transform `assertEqual` to `==`
 reanalyze                               Reanalyze
 -v, --version                           Print version
 -h, --help                              Print help|}

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -54,14 +54,10 @@ let main () =
       logAndExit (Tools.extractDocs ~entryPointFile:path ~debug:false)
     | _ -> logAndExit (Error docHelp))
   | "format-docstrings" :: rest -> (
-    (try
-       match Sys.getenv "DISABLE_COLOR" with
-       | "true" -> Clflags.color := Some Misc.Color.Never
-       | _ -> ()
-     with Not_found -> ());
     match rest with
     | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
     | [path; "--stdout"] -> (
+      Clflags.color := Some Misc.Color.Never;
       match
         Tools.FormatDocstrings.formatDocstrings ~outputMode:`Stdout
           ~entryPointFile:path

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -12,7 +12,7 @@ let formatDocstringsHelp =
 
 Format ReScript code blocks in docstrings
 
-Usage: rescript-tools format-docstrings <FILE> [--stdout]
+Usage: rescript-tools format-docstrings <FILE> [--stdout] [--transform-assert-equal]
 
 Example: rescript-tools format-docstrings ./path/to/MyModule.res|}
 

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -7,6 +7,15 @@ Usage: rescript-tools doc <FILE>
 
 Example: rescript-tools doc ./path/to/EntryPointLib.res|}
 
+let formatDocstringsHelp =
+  {|ReScript Tools
+
+Format ReScript code blocks in docstrings
+
+Usage: rescript-tools format-docstrings <FILE> [--stdout]
+
+Example: rescript-tools format-docstrings ./path/to/MyModule.res|}
+
 let help =
   {|ReScript Tools
 
@@ -14,10 +23,11 @@ Usage: rescript-tools [command]
 
 Commands:
 
-doc <file>            Generate documentation
-reanalyze             Reanalyze
--v, --version         Print version
--h, --help            Print help|}
+doc <file>                              Generate documentation
+format-docstrings <file> [--stdout]     Format ReScript code blocks in docstrings
+reanalyze                               Reanalyze
+-v, --version                           Print version
+-h, --help                              Print help|}
 
 let logAndExit = function
   | Ok log ->
@@ -43,6 +53,21 @@ let main () =
       in
       logAndExit (Tools.extractDocs ~entryPointFile:path ~debug:false)
     | _ -> logAndExit (Error docHelp))
+  | "format-docstrings" :: rest -> (
+    match rest with
+    | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
+    | [path; "--stdout"] -> (
+      match
+        Tools.FormatDocstrings.formatDocstrings ~outputMode:`Stdout
+          ~entryPointFile:path
+      with
+      | Ok content -> print_endline content
+      | Error e -> logAndExit (Error e))
+    | [path] ->
+      Tools.FormatDocstrings.formatDocstrings ~outputMode:`File
+        ~entryPointFile:path
+      |> logAndExit
+    | _ -> logAndExit (Error formatDocstringsHelp))
   | "reanalyze" :: _ ->
     let len = Array.length Sys.argv in
     for i = 1 to len - 2 do

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -54,6 +54,11 @@ let main () =
       logAndExit (Tools.extractDocs ~entryPointFile:path ~debug:false)
     | _ -> logAndExit (Error docHelp))
   | "format-docstrings" :: rest -> (
+    (try
+       match Sys.getenv "DISABLE_COLOR" with
+       | "true" -> Clflags.color := Some Misc.Color.Never
+       | _ -> ()
+     with Not_found -> ());
     match rest with
     | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
     | [path; "--stdout"] -> (

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -24,7 +24,7 @@ Usage: rescript-tools [command]
 Commands:
 
 doc <file>                              Generate documentation
-format-docstrings <file> [--stdout]     Format ReScript code blocks in docstrings
+format-codeblocks <file> [--stdout]     Format ReScript code blocks
 reanalyze                               Reanalyze
 -v, --version                           Print version
 -h, --help                              Print help|}
@@ -53,19 +53,19 @@ let main () =
       in
       logAndExit (Tools.extractDocs ~entryPointFile:path ~debug:false)
     | _ -> logAndExit (Error docHelp))
-  | "format-docstrings" :: rest -> (
+  | "format-codeblocks" :: rest -> (
     match rest with
     | ["-h"] | ["--help"] -> logAndExit (Ok formatDocstringsHelp)
     | [path; "--stdout"] -> (
       Clflags.color := Some Misc.Color.Never;
       match
-        Tools.FormatDocstrings.formatDocstrings ~outputMode:`Stdout
+        Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode:`Stdout
           ~entryPointFile:path
       with
       | Ok content -> print_endline content
       | Error e -> logAndExit (Error e))
     | [path] ->
-      Tools.FormatDocstrings.formatDocstrings ~outputMode:`File
+      Tools.FormatCodeblocks.formatCodeBlocksInFile ~outputMode:`File
         ~entryPointFile:path
       |> logAndExit
     | _ -> logAndExit (Error formatDocstringsHelp))

--- a/tools/src/dune
+++ b/tools/src/dune
@@ -2,4 +2,4 @@
  (name tools)
  (flags
   (-w "+6+26+27+32+33+39"))
- (libraries analysis))
+ (libraries analysis cmarkit))

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -843,7 +843,7 @@ module FormatDocstrings = struct
           source )
     in
     let errors = !errors in
-    if not (List.is_empty errors) then (
+    if List.length errors > 0 then (
       errors |> String.concat "\n" |> print_endline;
       Error (Printf.sprintf "Error formatting docstrings."))
     else if formatted_content <> source then (

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -823,7 +823,7 @@ module FormatDocstrings = struct
         let {Res_driver.parsetree = structure; comments; source; filename} =
           parser ~filename:path
         in
-
+        let filename = Filename.basename filename in
         let mapper = makeMapper ~displayFilename:filename in
         let astMapped = mapper.structure mapper structure in
         ( Res_printer.print_implementation

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -726,6 +726,16 @@ module FormatCodeblocks = struct
         in
         mapper.structure mapper ast
   end
+
+  let isResLang lang =
+    match String.lowercase_ascii lang with
+    | "res" | "rescript" | "resi" -> true
+    | lang ->
+      (* Cover ```res example, and similar *)
+      String.starts_with ~prefix:"res " lang
+      || String.starts_with ~prefix:"rescript " lang
+      || String.starts_with ~prefix:"resi " lang
+
   let formatRescriptCodeBlocks content ~transformAssertEqual ~displayFilename
       ~addError ~markdownBlockStartLine =
     (* Detect ReScript code blocks. *)
@@ -733,7 +743,7 @@ module FormatCodeblocks = struct
     let block _m = function
       | Cmarkit.Block.Code_block (codeBlock, meta) -> (
         match Cmarkit.Block.Code_block.info_string codeBlock with
-        | Some ((("rescript" | "res"), _) as info_string) ->
+        | Some ((lang, _) as info_string) when isResLang lang ->
           hadCodeBlocks := true;
 
           let currentLine =

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -752,12 +752,12 @@ module FormatDocstrings = struct
       mapRescriptCodeBlocks
         ~colIndent:(payloadLoc.loc_start.pos_cnum - payloadLoc.loc_start.pos_bol)
         ~mapper:(fun code currentLine ->
-          (* TODO: Figure out the line offsets here so the error messages line up as intended. *)
+          let codeLines = String.split_on_char '\n' code in
+          let n = List.length codeLines in
           let newlinesNeeded =
-            payloadLoc.loc_start.pos_lnum + currentLine - 5
+            max 0 (payloadLoc.loc_start.pos_lnum + currentLine - n)
           in
-          let codeOffset = String.make newlinesNeeded '\n' in
-          let codeWithOffset = codeOffset ^ code in
+          let codeWithOffset = String.make newlinesNeeded '\n' ^ code in
           let formatted_code =
             let {Res_driver.parsetree; comments; invalid; diagnostics} =
               Res_driver.parse_implementation_from_source ~for_printer:true

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -764,7 +764,7 @@ module FormatDocstrings = struct
                 ~display_filename:displayFilename ~source:codeWithOffset
             in
             if invalid then (
-              let buf = Buffer.create 32 in
+              let buf = Buffer.create 1000 in
               let formatter = Format.formatter_of_buffer buf in
               Res_diagnostics.print_report ~formatter
                 ~custom_intro:(Some "Syntax error in code block in docstring")

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -772,8 +772,7 @@ module FormatCodeblocks = struct
                     parsetree
                 else parsetree
               in
-              Res_printer.print_implementation
-                ~width:Res_multi_printer.default_print_width parsetree ~comments
+              Res_printer.print_implementation parsetree ~comments
               |> String.trim |> Block_line.list_of_string
           in
 
@@ -856,10 +855,7 @@ module FormatCodeblocks = struct
           makeMapper ~transformAssertEqual ~displayFilename:filename
         in
         let astMapped = mapper.structure mapper structure in
-        Ok
-          ( Res_printer.print_implementation
-              ~width:Res_multi_printer.default_print_width astMapped ~comments,
-            source )
+        Ok (Res_printer.print_implementation astMapped ~comments, source)
       else if Filename.check_suffix path ".resi" then
         let parser =
           Res_driver.parsing_engine.parse_interface ~for_printer:true
@@ -871,10 +867,7 @@ module FormatCodeblocks = struct
           makeMapper ~transformAssertEqual ~displayFilename:filename
         in
         let astMapped = mapper.signature mapper signature in
-        Ok
-          ( Res_printer.print_interface
-              ~width:Res_multi_printer.default_print_width astMapped ~comments,
-            source )
+        Ok (Res_printer.print_interface astMapped ~comments, source)
       else
         Error
           (Printf.sprintf


### PR DESCRIPTION
Adds an experimental command to `tools` for formatting ReScript code blocks in docstrings.

I put it under `tools` just because that was the easiest place to put it. Feedback gladly accepted on where to put it.
I ran formatting on `Stdlib_Result.resi` so you can see an example of the results easily.