### PR TITLE
Rust implementation of "rescript format"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 12.0.0-beta.2 (Unreleased)
 
+#### :boom: Breaking Change
+
+- Rust implementation of the `rescript format` command. Command line options changed from `-all`, `-check` and `-stdin` to `--all`, `--check` and `--stdin` compared to the legacy implementation. https://github.com/rescript-lang/rescript/pull/7603
+
 #### :nail_care: Polish
 
 - Add missing backtick and spaces to `Belt.Map.map` doc comment. https://github.com/rescript-lang/rescript/pull/7632

--- a/rewatch/Cargo.lock
+++ b/rewatch/Cargo.lock
@@ -304,6 +304,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -763,12 +795,27 @@ dependencies = [
  "log",
  "notify",
  "notify-debouncer-mini",
+ "num_cpus",
  "rayon",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
  "sysinfo",
+ "tempfile",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -860,6 +907,19 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rewatch/Cargo.toml
+++ b/rewatch/Cargo.toml
@@ -20,11 +20,13 @@ log = { version = "0.4.17" }
 notify = { version = "5.1.0", features = ["serde"] }
 notify-debouncer-mini = { version = "0.2.0" }
 rayon = "1.6.1"
+num_cpus = "1.17.0"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_derive = "1.0.152"
 serde_json = { version = "1.0.93" }
 sysinfo = "0.29.10"
+tempfile = "3.10.1"
 
 
 [profile.release]

--- a/rewatch/src/cli.rs
+++ b/rewatch/src/cli.rs
@@ -8,6 +8,16 @@ fn parse_regex(s: &str) -> Result<Regex, regex::Error> {
     Regex::new(s)
 }
 
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum FileExtension {
+    #[value(name = ".res")]
+    Res,
+    #[value(name = ".resi")]
+    Resi,
+}
+
 /// ReScript - Fast, Simple, Fully Typed JavaScript from the Future
 #[derive(Parser, Debug)]
 #[command(version)]
@@ -169,11 +179,29 @@ pub enum Command {
         #[command(flatten)]
         dev: DevArg,
     },
-    /// Alias to `legacy format`.
-    #[command(disable_help_flag = true)]
+    /// Formats ReScript files.
     Format {
-        #[arg(allow_hyphen_values = true, num_args = 0..)]
-        format_args: Vec<OsString>,
+        /// Format the whole project.
+        #[arg(short, long, group = "format_input_mode")]
+        all: bool,
+
+        /// Check formatting status without applying changes.
+        #[arg(short, long)]
+        check: bool,
+
+        /// Read the code from stdin and print the formatted code to stdout.
+        #[arg(
+            short,
+            long,
+            group = "format_input_mode",
+            value_enum,
+            conflicts_with = "check"
+        )]
+        stdin: Option<FileExtension>,
+
+        /// Files to format.
+        #[arg(group = "format_input_mode")]
+        files: Vec<String>,
     },
     /// Alias to `legacy dump`.
     #[command(disable_help_flag = true)]

--- a/rewatch/src/cli.rs
+++ b/rewatch/src/cli.rs
@@ -200,7 +200,7 @@ pub enum Command {
         stdin: Option<FileExtension>,
 
         /// Files to format.
-        #[arg(group = "format_input_mode")]
+        #[arg(group = "format_input_mode", required_unless_present_any = ["format_input_mode"])]
         files: Vec<String>,
     },
     /// Alias to `legacy dump`.

--- a/rewatch/src/format.rs
+++ b/rewatch/src/format.rs
@@ -1,0 +1,127 @@
+use crate::helpers;
+use anyhow::{Result, bail};
+use num_cpus;
+use rayon::prelude::*;
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::build::packages;
+use crate::cli::FileExtension;
+use clap::ValueEnum;
+
+pub fn format(
+    stdin_extension: Option<FileExtension>,
+    all: bool,
+    check: bool,
+    files: Vec<String>,
+) -> Result<()> {
+    let bsc_path = helpers::get_bsc();
+
+    match stdin_extension {
+        Some(extension) => {
+            format_stdin(&bsc_path, extension)?;
+        }
+        None => {
+            let files = if all { get_all_files()? } else { files };
+            format_files(&bsc_path, files, check)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn get_all_files() -> Result<Vec<String>> {
+    let current_dir = std::env::current_dir()?;
+    let project_root = helpers::get_abs_path(&current_dir);
+    let workspace_root_option = helpers::get_workspace_root(&project_root);
+
+    let build_state = packages::make(&None, &project_root, &workspace_root_option, false, false)?;
+    let mut files: Vec<String> = Vec::new();
+
+    for (_package_name, package) in build_state {
+        if let Some(source_files) = package.source_files {
+            for (path, _metadata) in source_files {
+                if let Some(extension) = path.extension() {
+                    if extension == "res" || extension == "resi" {
+                        files.push(package.path.join(path).to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn format_stdin(bsc_exe: &Path, extension: FileExtension) -> Result<()> {
+    let extension_value = extension
+        .to_possible_value()
+        .ok_or(anyhow::anyhow!("Could not get extension arg value"))?;
+
+    let mut temp_file = tempfile::Builder::new()
+        .suffix(extension_value.get_name())
+        .tempfile()?;
+    io::copy(&mut io::stdin(), &mut temp_file)?;
+    let temp_path = temp_file.path();
+
+    let mut cmd = Command::new(bsc_exe);
+    cmd.arg("-format").arg(temp_path);
+
+    let output = cmd.output()?;
+
+    if output.status.success() {
+        io::stdout().write_all(&output.stdout)?;
+    } else {
+        let stderr_str = String::from_utf8_lossy(&output.stderr);
+        bail!("Error formatting stdin: {}", stderr_str);
+    }
+
+    Ok(())
+}
+
+fn format_files(bsc_exe: &Path, files: Vec<String>, check: bool) -> Result<()> {
+    let batch_size = 4 * num_cpus::get();
+    let incorrectly_formatted_files = AtomicUsize::new(0);
+
+    files.par_chunks(batch_size).try_for_each(|batch| {
+        batch.iter().try_for_each(|file| {
+            let mut cmd = Command::new(bsc_exe);
+            if check {
+                cmd.arg("-format").arg(file);
+            } else {
+                cmd.arg("-o").arg(file).arg("-format").arg(file);
+            }
+
+            let output = cmd.output()?;
+
+            if output.status.success() {
+                if check {
+                    let original_content = fs::read_to_string(file)?;
+                    let formatted_content = String::from_utf8_lossy(&output.stdout);
+                    if original_content != formatted_content {
+                        eprintln!("[format check] {}", file);
+                        incorrectly_formatted_files.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            } else {
+                let stderr_str = String::from_utf8_lossy(&output.stderr);
+                bail!("Error formatting {}: {}", file, stderr_str);
+            }
+            Ok(())
+        })
+    })?;
+
+    let count = incorrectly_formatted_files.load(Ordering::SeqCst);
+    if count > 0 {
+        if count == 1 {
+            eprintln!("The file listed above needs formatting");
+        } else {
+            eprintln!("The {} files listed above need formatting", count);
+        }
+        bail!("Formatting check failed");
+    }
+
+    Ok(())
+}

--- a/rewatch/src/lib.rs
+++ b/rewatch/src/lib.rs
@@ -2,6 +2,7 @@ pub mod build;
 pub mod cli;
 pub mod cmd;
 pub mod config;
+pub mod format;
 pub mod helpers;
 pub mod lock;
 pub mod queue;

--- a/rewatch/src/main.rs
+++ b/rewatch/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use log::LevelFilter;
 use std::{io::Write, path::Path};
 
-use rewatch::{build, cli, cmd, lock, watcher};
+use rewatch::{build, cli, cmd, format, lock, watcher};
 
 fn main() -> Result<()> {
     let args = cli::Cli::parse();
@@ -91,11 +91,12 @@ fn main() -> Result<()> {
             let code = build::pass_through_legacy(legacy_args);
             std::process::exit(code);
         }
-        cli::Command::Format { mut format_args } => {
-            format_args.insert(0, "format".into());
-            let code = build::pass_through_legacy(format_args);
-            std::process::exit(code);
-        }
+        cli::Command::Format {
+            stdin,
+            all,
+            check,
+            files,
+        } => format::format(stdin, all, check, files),
         cli::Command::Dump { mut dump_args } => {
             dump_args.insert(0, "dump".into());
             let code = build::pass_through_legacy(dump_args);

--- a/rewatch/tests/format.sh
+++ b/rewatch/tests/format.sh
@@ -1,0 +1,43 @@
+source "./utils.sh"
+cd ../testrepo
+
+bold "Test: It should format all files"
+
+git diff --name-only ./
+error_output=$("$REWATCH_EXECUTABLE" format --all)
+git_diff_file_count=$(git diff --name-only ./ | wc -l | xargs)
+if [ $? -eq 0 ] && [ $git_diff_file_count -eq 4 ];
+then
+    success "Test package formatted. Got $git_diff_file_count changed files."
+    git restore .
+else
+    error "Error formatting test package"
+    echo $error_output
+    exit 1
+fi
+
+bold "Test: It should format a single file"
+
+error_output=$("$REWATCH_EXECUTABLE" format packages/dep01/src/Dep01.res)
+git_diff_file_count=$(git diff --name-only ./ | wc -l | xargs)
+if [ $? -eq 0 ] && [ $git_diff_file_count -eq 1 ];
+then
+    success "Single file formatted successfully"
+    git restore .
+else
+    error "Error formatting single file"
+    echo $error_output
+    exit 1
+fi
+
+bold "Test: It should format from stdin"
+
+error_output=$(echo "let x = 1" | "$REWATCH_EXECUTABLE" format --stdin .res)
+if [ $? -eq 0 ];
+then
+    success "Stdin formatted successfully"
+else
+    error "Error formatting from stdin"
+    echo $error_output
+    exit 1
+fi

--- a/rewatch/tests/suite-ci.sh
+++ b/rewatch/tests/suite-ci.sh
@@ -40,4 +40,4 @@ else
   exit 1
 fi
 
-./compile.sh && ./watch.sh && ./lock.sh && ./suffix.sh && ./legacy.sh
+./compile.sh && ./watch.sh && ./lock.sh && ./suffix.sh && ./legacy.sh && ./format.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,7 +7,7 @@ dune build @fmt --auto-promote
 
 echo Formatting ReScript code...
 files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*" ! -name "generated_mocha_test.res" ! -path "tests/syntax_tests*" ! -path "tests/analysis_tests/tests*" ! -path "*/node_modules/*")
-./cli/rescript-legacy.js format $files
+./cli/rescript.js format $files
 
 echo Formatting JS code...
 yarn format

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -18,7 +18,7 @@ case "$(uname -s)" in
 
     echo "Checking ReScript code formatting..."
     files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*" ! -name "generated_mocha_test.res" ! -path "tests/syntax_tests*" ! -path "tests/analysis_tests/tests*" ! -path "*/node_modules/*")
-    if ./cli/rescript-legacy.js format -check $files; then
+    if ./cli/rescript.js format --check $files; then
       printf "${successGreen}✅ ReScript code formatting ok.${reset}\n"
     else
       printf "${warningYellow}⚠️ ReScript code formatting issues found. Run 'make format' to fix.${reset}\n"


### PR DESCRIPTION
Do not forward the `rescript format` command to the legacy JS cli anymore, instead implement the functionality natively in Rust.