### PR TITLE
fix: ignore warning config for non local deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Pass location to children prop in jsx ppx. https://github.com/rescript-lang/rescript/pull/7540
 - Fix crash when `bs-g` is used with untagged variants. https://github.com/rescript-lang/rescript/pull/7575
 - Fix issue with preserve mode where `jsx` is declared as an external without a `@module` attribute. https://github.com/rescript-lang/rescript/pull/7591
+- Fix rewatch considering warning configs of non-local dependencies. https://github.com/rescript-lang/rescript/pull/7614
 
 #### :nail_care: Polish
 

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -114,6 +114,7 @@ pub fn get_compiler_args(
         &workspace_root,
         &None,
         build_dev_deps,
+        true,
     );
 
     let result = serde_json::to_string_pretty(&CompilerArgs {

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -287,7 +287,7 @@ pub fn read_dependency(
 /// Given a config, recursively finds all dependencies.
 /// 1. It starts with registering dependencies and
 ///    prevents the operation for the ones which are already
-///    registerd for the parent packages. Especially relevant for peerDependencies.
+///    registered for the parent packages. Especially relevant for peerDependencies.
 /// 2. In parallel performs IO to read the dependencies config and
 ///    recursively continues operation for their dependencies as well.
 fn read_dependencies(
@@ -329,7 +329,7 @@ fn read_dependencies(
 
                         let parent_path_str = parent_path.to_string_lossy();
                         log::error!(
-                            "We could not build package tree reading depencency '{package_name}', at path '{parent_path_str}'. Error: {error}",
+                            "We could not build package tree reading dependency '{package_name}', at path '{parent_path_str}'. Error: {error}",
                         );
 
                         std::process::exit(2)

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -470,6 +470,37 @@ impl Config {
         }
     }
 
+    pub fn get_warning_args(&self, is_local_dep: bool) -> Vec<String> {
+        // Ignore warning config for non local dependencies (node_module dependencies)
+        if !is_local_dep {
+            return vec![];
+        }
+
+        match self.warnings {
+            None => vec![],
+            Some(ref warnings) => {
+                let warn_number = match warnings.number {
+                    None => vec![],
+                    Some(ref warnings) => {
+                        vec!["-w".to_string(), warnings.to_string()]
+                    }
+                };
+
+                let warn_error = match warnings.error {
+                    Some(Error::Catchall(true)) => {
+                        vec!["-warn-error".to_string(), "A".to_string()]
+                    }
+                    Some(Error::Qualified(ref errors)) => {
+                        vec!["-warn-error".to_string(), errors.to_string()]
+                    }
+                    _ => vec![],
+                };
+
+                [warn_number, warn_error].concat()
+            }
+        }
+    }
+
     pub fn get_package_specs(&self) -> Vec<PackageSpec> {
         match self.package_specs.clone() {
             None => vec![PackageSpec {


### PR DESCRIPTION
This fixes: #7564 
The warning configuration for non-local dependencies is ignored.