### PR TITLE
Refactor parse tree for function arguments.

### DIFF
--- a/analysis/reanalyze/src/DeadOptionalArgs.ml
+++ b/analysis/reanalyze/src/DeadOptionalArgs.ml
@@ -31,8 +31,8 @@ let addFunctionReference ~(locFrom : Location.t) ~(locTo : Location.t) =
 let rec hasOptionalArgs (texpr : Types.type_expr) =
   match texpr.desc with
   | _ when not (active ()) -> false
-  | Tarrow (Optional _, _tFrom, _tTo, _, _) -> true
-  | Tarrow (_, _tFrom, tTo, _, _) -> hasOptionalArgs tTo
+  | Tarrow ({lbl = Optional _}, _tTo, _, _) -> true
+  | Tarrow (_, tTo, _, _) -> hasOptionalArgs tTo
   | Tlink t -> hasOptionalArgs t
   | Tsubst t -> hasOptionalArgs t
   | _ -> false
@@ -40,8 +40,8 @@ let rec hasOptionalArgs (texpr : Types.type_expr) =
 let rec fromTypeExpr (texpr : Types.type_expr) =
   match texpr.desc with
   | _ when not (active ()) -> []
-  | Tarrow (Optional s, _tFrom, tTo, _, _) -> s :: fromTypeExpr tTo
-  | Tarrow (_, _tFrom, tTo, _, _) -> fromTypeExpr tTo
+  | Tarrow ({lbl = Optional s}, tTo, _, _) -> s :: fromTypeExpr tTo
+  | Tarrow (_, tTo, _, _) -> fromTypeExpr tTo
   | Tlink t -> fromTypeExpr t
   | Tsubst t -> fromTypeExpr t
   | _ -> []

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -978,7 +978,10 @@ and getCompletionsForContextPath ~debug ~full ~opens ~rawOpens ~pos ~env ~exact
         | [] -> tRet
         | (label, tArg) :: rest ->
           let restType = reconstructFunctionType rest tRet in
-          {typ with desc = Tarrow (label, tArg, restType, Cok, None)}
+          {
+            typ with
+            desc = Tarrow ({lbl = label; typ = tArg}, restType, Cok, None);
+          }
       in
       let rec processApply args labels =
         match (args, labels) with

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -247,7 +247,8 @@ let getJsxLabels ~componentPath ~findTypeOfValue ~package =
         match propsType |> getPropsType with
         | Some (path, typeArgs) -> getFields ~path ~typeArgs
         | None -> [])
-      | Tarrow (Nolabel, {desc = Tconstr (path, typeArgs, _)}, _, _, _)
+      | Tarrow
+          ({lbl = Nolabel; typ = {desc = Tconstr (path, typeArgs, _)}}, _, _, _)
         when Path.last path = "props" ->
         getFields ~path ~typeArgs
       | Tconstr (clPath, [{desc = Tconstr (path, typeArgs, _)}; _], _)
@@ -255,7 +256,7 @@ let getJsxLabels ~componentPath ~findTypeOfValue ~package =
              && Path.last path = "props" ->
         (* JSX V4 external or interface *)
         getFields ~path ~typeArgs
-      | Tarrow (Nolabel, typ, _, _, _) -> (
+      | Tarrow ({lbl = Nolabel; typ}, _, _, _) -> (
         (* Component without the JSX PPX, like a make fn taking a hand-written
            type props. *)
         let rec digToConstr typ =

--- a/analysis/src/CreateInterface.ml
+++ b/analysis/src/CreateInterface.ml
@@ -124,7 +124,10 @@ let printSignature ~extractor ~signature =
     in
     match typ.desc with
     | Tarrow
-        (_, {desc = Tconstr (Path.Pident propsId, typeArgs, _)}, retType, _, _)
+        ( {typ = {desc = Tconstr (Path.Pident propsId, typeArgs, _)}},
+          retType,
+          _,
+          _ )
       when Ident.name propsId = "props" ->
       Some (typeArgs, retType)
     | Tconstr
@@ -175,7 +178,7 @@ let printSignature ~extractor ~signature =
             in
             {
               retType with
-              desc = Tarrow (lbl, propType, mkFunType rest, Cok, None);
+              desc = Tarrow ({lbl; typ = propType}, mkFunType rest, Cok, None);
             }
         in
         let funType =
@@ -183,7 +186,10 @@ let printSignature ~extractor ~signature =
             let tUnit =
               Ctype.newconstr (Path.Pident (Ident.create "unit")) []
             in
-            {retType with desc = Tarrow (Nolabel, tUnit, retType, Cok, None)}
+            {
+              retType with
+              desc = Tarrow ({lbl = Nolabel; typ = tUnit}, retType, Cok, None);
+            }
           else mkFunType labelDecls
         in
         sigItemToString

--- a/analysis/src/Shared.ml
+++ b/analysis/src/Shared.ml
@@ -48,9 +48,9 @@ let findTypeConstructors (tel : Types.type_expr list) =
     | Tconstr (path, args, _) ->
       addPath path;
       args |> List.iter loop
-    | Tarrow (_, te1, te2, _, _) ->
-      loop te1;
-      loop te2
+    | Tarrow (arg, ret, _, _) ->
+      loop arg.typ;
+      loop ret
     | Ttuple tel -> tel |> List.iter loop
     | Tnil | Tvar _ | Tobject _ | Tfield _ | Tvariant _ | Tunivar _ | Tpackage _
       ->

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -112,9 +112,7 @@ let extractParameters ~signature ~typeStrForParser ~labelPrefixLen =
       match expr with
       | {
        (* Gotcha: functions with multiple arugments are modelled as a series of single argument functions. *)
-       Parsetree.ptyp_desc =
-         Ptyp_arrow
-           {lbl = argumentLabel; arg = argumentTypeExpr; ret = nextFunctionExpr};
+       Parsetree.ptyp_desc = Ptyp_arrow {arg; ret = nextFunctionExpr};
        ptyp_loc;
       } ->
         let startOffset =
@@ -123,20 +121,20 @@ let extractParameters ~signature ~typeStrForParser ~labelPrefixLen =
           |> Option.get
         in
         let endOffset =
-          argumentTypeExpr.ptyp_loc |> Loc.end_
+          arg.typ.ptyp_loc |> Loc.end_
           |> Pos.positionToOffset typeStrForParser
           |> Option.get
         in
         (* The AST locations does not account for "=?" of optional arguments, so add that to the offset here if needed. *)
         let endOffset =
-          match argumentLabel with
+          match arg.lbl with
           | Asttypes.Optional _ -> endOffset + 2
           | _ -> endOffset
         in
         extractParams nextFunctionExpr
           (params
           @ [
-              ( argumentLabel,
+              ( arg.lbl,
                 (* Remove the label prefix offset here, since we're not showing
                    that to the end user. *)
                 startOffset - labelPrefixLen,

--- a/compiler/frontend/ast_compatible.ml
+++ b/compiler/frontend/ast_compatible.ml
@@ -30,8 +30,8 @@ open Parsetree
 
 let default_loc = Location.none
 
-let arrow ?loc ?attrs ~arity a b =
-  Ast_helper.Typ.arrow ?loc ?attrs ~arity Nolabel a b
+let arrow ?loc ?attrs ~arity typ ret =
+  Ast_helper.Typ.arrow ?loc ?attrs ~arity {lbl = Nolabel; typ} ret
 
 let apply_simple ?(loc = default_loc) ?(attrs = []) (fn : expression)
     (args : expression list) : expression =
@@ -138,22 +138,30 @@ let apply_labels ?(loc = default_loc) ?(attrs = []) fn
         };
   }
 
-let label_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt arg ret :
+let label_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt typ ret :
     core_type =
   {
     ptyp_desc =
       Ptyp_arrow
-        {lbl = Asttypes.Labelled {txt; loc = default_loc}; arg; ret; arity};
+        {
+          arg = {lbl = Asttypes.Labelled {txt; loc = default_loc}; typ};
+          ret;
+          arity;
+        };
     ptyp_loc = loc;
     ptyp_attributes = attrs;
   }
 
-let opt_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt arg ret : core_type
+let opt_arrow ?(loc = default_loc) ?(attrs = []) ~arity txt typ ret : core_type
     =
   {
     ptyp_desc =
       Ptyp_arrow
-        {lbl = Asttypes.Optional {txt; loc = default_loc}; arg; ret; arity};
+        {
+          arg = {lbl = Asttypes.Optional {txt; loc = default_loc}; typ};
+          ret;
+          arity;
+        };
     ptyp_loc = loc;
     ptyp_attributes = attrs;
   }

--- a/compiler/frontend/ast_core_type.ml
+++ b/compiler/frontend/ast_core_type.ml
@@ -142,7 +142,8 @@ let mk_fn_type (new_arg_types_ty : param_type list) (result : t) : t =
     Ext_list.fold_right new_arg_types_ty result
       (fun {label; ty; attr; loc} acc ->
         {
-          ptyp_desc = Ptyp_arrow {lbl = label; arg = ty; ret = acc; arity = None};
+          ptyp_desc =
+            Ptyp_arrow {arg = {lbl = label; typ = ty}; ret = acc; arity = None};
           ptyp_loc = loc;
           ptyp_attributes = attr;
         })
@@ -156,9 +157,14 @@ let mk_fn_type (new_arg_types_ty : param_type list) (result : t) : t =
 let list_of_arrow (ty : t) : t * param_type list =
   let rec aux (ty : t) acc =
     match ty.ptyp_desc with
-    | Ptyp_arrow {lbl = label; arg; ret; arity} when arity = None || acc = [] ->
+    | Ptyp_arrow {arg; ret; arity} when arity = None || acc = [] ->
       aux ret
-        (({label; ty = arg; attr = ty.ptyp_attributes; loc = ty.ptyp_loc}
+        (({
+            label = arg.lbl;
+            ty = arg.typ;
+            attr = ty.ptyp_attributes;
+            loc = ty.ptyp_loc;
+          }
            : param_type)
         :: acc)
     | Ptyp_poly (_, ty) ->

--- a/compiler/frontend/ast_core_type_class_type.ml
+++ b/compiler/frontend/ast_core_type_class_type.ml
@@ -67,17 +67,17 @@ let default_typ_mapper = Bs_ast_mapper.default_mapper.typ
 let typ_mapper (self : Bs_ast_mapper.mapper) (ty : Parsetree.core_type) =
   let loc = ty.ptyp_loc in
   match ty.ptyp_desc with
-  | Ptyp_arrow {lbl = label; arg = args; ret = body}
+  | Ptyp_arrow {arg; ret = body}
   (* let it go without regard label names,
      it will report error later when the label is not empty
   *)
     -> (
     match fst (Ast_attributes.process_attributes_rev ty.ptyp_attributes) with
     | Meth_callback _ ->
-      Ast_typ_uncurry.to_method_callback_type loc self label args body
+      Ast_typ_uncurry.to_method_callback_type loc self arg.lbl arg.typ body
     | Method _ ->
       (* Treat @meth as making the type uncurried, for backwards compatibility *)
-      Ast_typ_uncurry.to_uncurry_type loc self label args body
+      Ast_typ_uncurry.to_uncurry_type loc self arg.lbl arg.typ body
     | Nothing -> Bs_ast_mapper.default_mapper.typ self ty)
   | Ptyp_object (methods, closed_flag) ->
     let ( +> ) attr (typ : Parsetree.core_type) =

--- a/compiler/frontend/ast_exp_handle_external.ml
+++ b/compiler/frontend/ast_exp_handle_external.ml
@@ -44,7 +44,9 @@ let handle_external loc (x : string) : Parsetree.expression =
       pexp_desc =
         Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
           ~pval_type:
-            (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+            (Typ.arrow ~arity:(Some 1)
+               {lbl = Nolabel; typ = Typ.any ()}
+               (Typ.any ()))
           [str_exp];
     }
   in
@@ -70,7 +72,8 @@ let handle_debugger loc (payload : Ast_payload.t) =
   | PStr [] ->
     Ast_external_mk.local_external_apply loc ~pval_prim:["%debugger"]
       ~pval_type:
-        (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ())
+        (Typ.arrow ~arity:(Some 1)
+           {lbl = Nolabel; typ = Typ.any ()}
            (Ast_literal.type_unit ()))
       [Ast_literal.val_unit ~loc ()]
   | _ ->
@@ -96,7 +99,9 @@ let handle_raw ~kind loc payload =
       pexp_desc =
         Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
           ~pval_type:
-            (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+            (Typ.arrow ~arity:(Some 1)
+               {lbl = Nolabel; typ = Typ.any ()}
+               (Typ.any ()))
           [exp];
       pexp_attributes =
         (match !is_function with
@@ -123,11 +128,12 @@ let handle_ffi ~loc ~payload =
       let any = Ast_helper.Typ.any ~loc:e.pexp_loc () in
       let unit = Ast_literal.type_unit ~loc () in
       let rec arrow ~arity =
-        if arity = 0 then Ast_helper.Typ.arrow ~arity:None ~loc Nolabel unit any
+        if arity = 0 then
+          Ast_helper.Typ.arrow ~arity:None ~loc {lbl = Nolabel; typ = unit} any
         else if arity = 1 then
-          Ast_helper.Typ.arrow ~arity:None ~loc Nolabel any any
+          Ast_helper.Typ.arrow ~arity:None ~loc {lbl = Nolabel; typ = any} any
         else
-          Ast_helper.Typ.arrow ~loc ~arity:None Nolabel any
+          Ast_helper.Typ.arrow ~loc ~arity:None {lbl = Nolabel; typ = any}
             (arrow ~arity:(arity - 1))
       in
       match !is_function with
@@ -146,7 +152,9 @@ let handle_ffi ~loc ~payload =
         pexp_desc =
           Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_expr"]
             ~pval_type:
-              (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+              (Typ.arrow ~arity:(Some 1)
+                 {lbl = Nolabel; typ = Typ.any ()}
+                 (Typ.any ()))
             [exp];
         pexp_attributes =
           (match !is_function with
@@ -163,7 +171,9 @@ let handle_raw_structure loc payload =
         pexp_desc =
           Ast_external_mk.local_external_apply loc ~pval_prim:["#raw_stmt"]
             ~pval_type:
-              (Typ.arrow ~arity:(Some 1) Nolabel (Typ.any ()) (Typ.any ()))
+              (Typ.arrow ~arity:(Some 1)
+                 {lbl = Nolabel; typ = Typ.any ()}
+                 (Typ.any ()))
             [exp];
       }
   | None ->

--- a/compiler/frontend/ast_typ_uncurry.ml
+++ b/compiler/frontend/ast_typ_uncurry.ml
@@ -33,7 +33,9 @@ let to_method_callback_type loc (mapper : Bs_ast_mapper.mapper)
     (typ : Parsetree.core_type) =
   let first_arg = mapper.typ mapper first_arg in
   let typ = mapper.typ mapper typ in
-  let meth_type = Typ.arrow ~loc ~arity:None label first_arg typ in
+  let meth_type =
+    Typ.arrow ~loc ~arity:None {lbl = label; typ = first_arg} typ
+  in
   let arity = Ast_core_type.get_uncurry_arity meth_type in
   match arity with
   | Some n ->
@@ -57,7 +59,7 @@ let to_uncurry_type loc (mapper : Bs_ast_mapper.mapper)
   let first_arg = mapper.typ mapper first_arg in
   let typ = mapper.typ mapper typ in
 
-  let fn_type = Typ.arrow ~loc ~arity:None label first_arg typ in
+  let fn_type = Typ.arrow ~loc ~arity:None {lbl = label; typ = first_arg} typ in
   let arity = Ast_core_type.get_uncurry_arity fn_type in
   let fn_type =
     match fn_type.ptyp_desc with

--- a/compiler/frontend/bs_ast_mapper.ml
+++ b/compiler/frontend/bs_ast_mapper.ml
@@ -100,8 +100,10 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow {lbl; arg; ret; arity} ->
-      arrow ~loc ~attrs ~arity lbl (sub.typ sub arg) (sub.typ sub ret)
+    | Ptyp_arrow {arg; ret; arity} ->
+      arrow ~loc ~attrs ~arity
+        {arg with typ = sub.typ sub arg.typ}
+        (sub.typ sub ret)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) ->
       constr ~loc ~attrs (map_loc sub lid) (List.map (sub.typ sub) tl)
@@ -151,7 +153,7 @@ module T = struct
     | Ptype_record l -> Ptype_record (List.map (sub.label_declaration sub) l)
     | Ptype_open -> Ptype_open
 
-  let map_constructor_arguments sub = function
+  let map_constructor_arguments (sub : mapper) = function
     | Pcstr_tuple l -> Pcstr_tuple (List.map (sub.typ sub) l)
     | Pcstr_record l -> Pcstr_record (List.map (sub.label_declaration sub) l)
 

--- a/compiler/gentype/TranslateCoreType.ml
+++ b/compiler/gentype/TranslateCoreType.ml
@@ -52,7 +52,7 @@ let rec translate_arrow_type ~config ~type_vars_gen
     ~no_function_return_dependencies ~type_env ~rev_arg_deps ~rev_args
     (core_type : Typedtree.core_type) =
   match core_type.ctyp_desc with
-  | Ttyp_arrow (Nolabel, core_type1, core_type2, arity)
+  | Ttyp_arrow ({lbl = Nolabel; typ = core_type1}, core_type2, arity)
     when arity = None || rev_args = [] ->
     let {dependencies; type_} =
       core_type1 |> fun __x ->
@@ -64,7 +64,9 @@ let rec translate_arrow_type ~config ~type_vars_gen
          ~no_function_return_dependencies ~type_env ~rev_arg_deps:next_rev_deps
          ~rev_args:((Nolabel, type_) :: rev_args)
   | Ttyp_arrow
-      (((Labelled lbl | Optional lbl) as label), core_type1, core_type2, arity)
+      ( {lbl = (Labelled lbl | Optional lbl) as label; typ = core_type1},
+        core_type2,
+        arity )
     when arity = None || rev_args = [] -> (
     let as_label =
       match core_type.ctyp_attributes |> Annotation.get_gentype_as_renaming with

--- a/compiler/gentype/TranslateTypeExprFromTypes.ml
+++ b/compiler/gentype/TranslateTypeExprFromTypes.ml
@@ -290,7 +290,7 @@ let rec translate_arrow_type ~config ~type_vars_gen ~type_env ~rev_arg_deps
   | Tlink t ->
     translate_arrow_type ~config ~type_vars_gen ~type_env ~rev_arg_deps
       ~rev_args t
-  | Tarrow (Nolabel, type_expr1, type_expr2, _, arity)
+  | Tarrow ({lbl = Nolabel; typ = type_expr1}, type_expr2, _, arity)
     when arity = None || rev_args = [] ->
     let {dependencies; type_} =
       type_expr1 |> fun __x ->
@@ -302,8 +302,7 @@ let rec translate_arrow_type ~config ~type_vars_gen ~type_env ~rev_arg_deps
          ~rev_arg_deps:next_rev_deps
          ~rev_args:((Nolabel, type_) :: rev_args)
   | Tarrow
-      ( ((Labelled lbl | Optional lbl) as label),
-        type_expr1,
+      ( {lbl = (Labelled lbl | Optional lbl) as label; typ = type_expr1},
         type_expr2,
         _,
         arity )

--- a/compiler/ml/ast_helper.ml
+++ b/compiler/ml/ast_helper.ml
@@ -54,8 +54,8 @@ module Typ = struct
 
   let any ?loc ?attrs () = mk ?loc ?attrs Ptyp_any
   let var ?loc ?attrs a = mk ?loc ?attrs (Ptyp_var a)
-  let arrow ?loc ?attrs ~arity lbl arg ret =
-    mk ?loc ?attrs (Ptyp_arrow {lbl; arg; ret; arity})
+  let arrow ?loc ?attrs ~arity arg ret =
+    mk ?loc ?attrs (Ptyp_arrow {arg; ret; arity})
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ptyp_tuple a)
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_constr (a, b))
   let object_ ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_object (a, b))
@@ -83,7 +83,8 @@ module Typ = struct
           check_variable var_names t.ptyp_loc x;
           Ptyp_var x
         | Ptyp_arrow ({arg; ret} as arr) ->
-          Ptyp_arrow {arr with arg = loop arg; ret = loop ret}
+          Ptyp_arrow
+            {arr with arg = {arr.arg with typ = loop arg.typ}; ret = loop ret}
         | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
         | Ptyp_constr ({txt = Longident.Lident s}, []) when List.mem s var_names
           ->

--- a/compiler/ml/ast_helper.mli
+++ b/compiler/ml/ast_helper.mli
@@ -55,13 +55,7 @@ module Typ : sig
   val any : ?loc:loc -> ?attrs:attrs -> unit -> core_type
   val var : ?loc:loc -> ?attrs:attrs -> string -> core_type
   val arrow :
-    ?loc:loc ->
-    ?attrs:attrs ->
-    arity:arity ->
-    arg_label ->
-    core_type ->
-    core_type ->
-    core_type
+    ?loc:loc -> ?attrs:attrs -> arity:arity -> arg -> core_type -> core_type
   val tuple : ?loc:loc -> ?attrs:attrs -> core_type list -> core_type
   val constr : ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> core_type
   val object_ :

--- a/compiler/ml/ast_iterator.ml
+++ b/compiler/ml/ast_iterator.ml
@@ -97,7 +97,7 @@ module T = struct
     match desc with
     | Ptyp_any | Ptyp_var _ -> ()
     | Ptyp_arrow {arg; ret} ->
-      sub.typ sub arg;
+      sub.typ sub arg.typ;
       sub.typ sub ret
     | Ptyp_tuple tyl -> List.iter (sub.typ sub) tyl
     | Ptyp_constr (lid, tl) ->

--- a/compiler/ml/ast_mapper.ml
+++ b/compiler/ml/ast_mapper.ml
@@ -92,8 +92,10 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow {lbl; arg; ret; arity} ->
-      arrow ~loc ~attrs ~arity lbl (sub.typ sub arg) (sub.typ sub ret)
+    | Ptyp_arrow {arg; ret; arity} ->
+      arrow ~loc ~attrs ~arity
+        {arg with typ = sub.typ sub arg.typ}
+        (sub.typ sub ret)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) ->
       constr ~loc ~attrs (map_loc sub lid) (List.map (sub.typ sub) tl)

--- a/compiler/ml/ast_mapper_from0.ml
+++ b/compiler/ml/ast_mapper_from0.ml
@@ -98,9 +98,9 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow (lab, t1, t2) ->
-      let lab = Asttypes.to_arg_label lab in
-      arrow ~loc ~attrs ~arity:None lab (sub.typ sub t1) (sub.typ sub t2)
+    | Ptyp_arrow (lbl, t1, t2) ->
+      let lbl = Asttypes.to_arg_label lbl in
+      arrow ~loc ~attrs ~arity:None {lbl; typ = sub.typ sub t1} (sub.typ sub t2)
     | Ptyp_tuple tyl -> tuple ~loc ~attrs (List.map (sub.typ sub) tyl)
     | Ptyp_constr (lid, tl) -> (
       let typ0 =

--- a/compiler/ml/ast_mapper_to0.ml
+++ b/compiler/ml/ast_mapper_to0.ml
@@ -98,9 +98,11 @@ module T = struct
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
-    | Ptyp_arrow {lbl; arg; ret; arity} -> (
-      let lbl = Asttypes.to_noloc lbl in
-      let typ0 = arrow ~loc ~attrs lbl (sub.typ sub arg) (sub.typ sub ret) in
+    | Ptyp_arrow {arg; ret; arity} -> (
+      let lbl = Asttypes.to_noloc arg.lbl in
+      let typ0 =
+        arrow ~loc ~attrs lbl (sub.typ sub arg.typ) (sub.typ sub ret)
+      in
       match arity with
       | None -> typ0
       | Some arity ->

--- a/compiler/ml/btype.ml
+++ b/compiler/ml/btype.ml
@@ -260,7 +260,7 @@ let rec iter_row f row =
 let iter_type_expr f ty =
   match ty.desc with
   | Tvar _ -> ()
-  | Tarrow (_, ty1, ty2, _, _) ->
+  | Tarrow ({typ = ty1}, ty2, _, _) ->
     f ty1;
     f ty2
   | Ttuple l -> List.iter f l
@@ -428,8 +428,8 @@ let rec norm_univar ty =
 
 let rec copy_type_desc ?(keep_names = false) f = function
   | Tvar _ as ty -> if keep_names then ty else Tvar None
-  | Tarrow (p, ty1, ty2, c, arity) ->
-    Tarrow (p, f ty1, f ty2, copy_commu c, arity)
+  | Tarrow (arg, ret, c, arity) ->
+    Tarrow ({arg with typ = f arg.typ}, f ret, copy_commu c, arity)
   | Ttuple l -> Ttuple (List.map f l)
   | Tconstr (p, l, _) -> Tconstr (p, List.map f l, ref Mnil)
   | Tobject (ty, {contents = Some (p, tl)}) ->

--- a/compiler/ml/depend.ml
+++ b/compiler/ml/depend.ml
@@ -106,7 +106,7 @@ let rec add_type bv ty =
   | Ptyp_any -> ()
   | Ptyp_var _ -> ()
   | Ptyp_arrow {arg; ret} ->
-    add_type bv arg;
+    add_type bv arg.typ;
     add_type bv ret
   | Ptyp_tuple tl -> List.iter (add_type bv) tl
   | Ptyp_constr (c, tl) ->

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -73,10 +73,12 @@ and core_type = {
   ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
 }
 
+and arg = {lbl: arg_label; typ: core_type}
+
 and core_type_desc =
   | Ptyp_any (*  _ *)
   | Ptyp_var of string (* 'a *)
-  | Ptyp_arrow of {lbl: arg_label; arg: core_type; ret: core_type; arity: arity}
+  | Ptyp_arrow of {arg: arg; ret: core_type; arity: arity}
     (* T1 -> T2       Simple
        ~l:T1 -> T2    Labelled
        ?l:T1 -> T2    Optional

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -298,9 +298,9 @@ and core_type ctxt f x =
       (attributes ctxt) x.ptyp_attributes
   else
     match x.ptyp_desc with
-    | Ptyp_arrow {lbl = l; arg; ret; arity} ->
+    | Ptyp_arrow {arg; ret; arity} ->
       pp f "@[<2>%a@;->@;%a%s@]" (* FIXME remove parens later *)
-        (type_with_label ctxt) (l, arg) (core_type ctxt) ret
+        (type_with_label ctxt) (arg.lbl, arg.typ) (core_type ctxt) ret
         (match arity with
         | None -> ""
         | Some n -> " (a:" ^ string_of_int n ^ ")")

--- a/compiler/ml/printast.ml
+++ b/compiler/ml/printast.ml
@@ -123,15 +123,15 @@ let rec core_type i ppf x =
   match x.ptyp_desc with
   | Ptyp_any -> line i ppf "Ptyp_any\n"
   | Ptyp_var s -> line i ppf "Ptyp_var %s\n" s
-  | Ptyp_arrow {lbl; arg; ret; arity} ->
+  | Ptyp_arrow {arg; ret; arity} ->
     line i ppf "Ptyp_arrow\n";
     let () =
       match arity with
       | None -> ()
       | Some n -> line i ppf "arity = %d\n" n
     in
-    arg_label_loc i ppf lbl;
-    core_type i ppf arg;
+    arg_label_loc i ppf arg.lbl;
+    core_type i ppf arg.typ;
     core_type i ppf ret
   | Ptyp_tuple l ->
     line i ppf "Ptyp_tuple\n";

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -149,11 +149,11 @@ let rec core_type i ppf x =
   match x.ctyp_desc with
   | Ttyp_any -> line i ppf "Ttyp_any\n"
   | Ttyp_var s -> line i ppf "Ttyp_var %s\n" s
-  | Ttyp_arrow (l, ct1, ct2, _) ->
+  | Ttyp_arrow (arg, ret, _) ->
     line i ppf "Ttyp_arrow\n";
-    arg_label i ppf l;
-    core_type i ppf ct1;
-    core_type i ppf ct2
+    arg_label i ppf arg.lbl;
+    core_type i ppf arg.typ;
+    core_type i ppf ret
   | Ttyp_tuple l ->
     line i ppf "Ttyp_tuple\n";
     list i core_type ppf l

--- a/compiler/ml/record_type_spread.ml
+++ b/compiler/ml/record_type_spread.ml
@@ -22,8 +22,11 @@ let substitute_types ~type_map (t : Types.type_expr) =
       | Tsubst t -> {t with desc = Tsubst (loop t)}
       | Tvariant rd -> {t with desc = Tvariant (row_desc rd)}
       | Tnil -> t
-      | Tarrow (lbl, t1, t2, c, arity) ->
-        {t with desc = Tarrow (lbl, loop t1, loop t2, c, arity)}
+      | Tarrow (arg, ret, c, arity) ->
+        {
+          t with
+          desc = Tarrow ({arg with typ = loop arg.typ}, loop ret, c, arity);
+        }
       | Ttuple tl -> {t with desc = Ttuple (tl |> List.map loop)}
       | Tobject (t, r) -> {t with desc = Tobject (loop t, r)}
       | Tfield (n, k, t1, t2) -> {t with desc = Tfield (n, k, loop t1, loop t2)}

--- a/compiler/ml/tast_iterator.ml
+++ b/compiler/ml/tast_iterator.ml
@@ -284,9 +284,9 @@ let typ sub {ctyp_desc; ctyp_env; _} =
   match ctyp_desc with
   | Ttyp_any -> ()
   | Ttyp_var _ -> ()
-  | Ttyp_arrow (_, ct1, ct2, _) ->
-    sub.typ sub ct1;
-    sub.typ sub ct2
+  | Ttyp_arrow (arg, ret, _) ->
+    sub.typ sub arg.typ;
+    sub.typ sub ret
   | Ttyp_tuple list -> List.iter (sub.typ sub) list
   | Ttyp_constr (_, _, list) -> List.iter (sub.typ sub) list
   | Ttyp_object (list, _) -> List.iter (sub.object_field sub) list

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -359,8 +359,8 @@ let typ sub x =
   let ctyp_desc =
     match x.ctyp_desc with
     | (Ttyp_any | Ttyp_var _) as d -> d
-    | Ttyp_arrow (label, ct1, ct2, arity) ->
-      Ttyp_arrow (label, sub.typ sub ct1, sub.typ sub ct2, arity)
+    | Ttyp_arrow (arg, ret, arity) ->
+      Ttyp_arrow ({arg with typ = sub.typ sub arg.typ}, sub.typ sub ret, arity)
     | Ttyp_tuple list -> Ttyp_tuple (List.map (sub.typ sub) list)
     | Ttyp_constr (path, lid, list) ->
       Ttyp_constr (path, lid, List.map (sub.typ sub) list)

--- a/compiler/ml/translcore.ml
+++ b/compiler/ml/translcore.ml
@@ -691,8 +691,8 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
       let prim =
         let expanded = Ctype.expand_head e.exp_env e.exp_type in
         match (Btype.repr expanded).desc with
-        | Tarrow (Nolabel, t, _, _, _) -> (
-          match (Ctype.expand_head e.exp_env t).desc with
+        | Tarrow ({lbl = Nolabel; typ}, _, _, _) -> (
+          match (Ctype.expand_head e.exp_env typ).desc with
           | Tconstr (Pident {name = "unit"}, [], _) -> Pjs_fn_make_unit
           | _ -> Pjs_fn_make arity)
         | _ -> Pjs_fn_make arity

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -1871,7 +1871,7 @@ and is_nonexpansive_opt = function
 
 let rec approx_type env sty =
   match sty.ptyp_desc with
-  | Ptyp_arrow {lbl = p; ret = sty; arity} ->
+  | Ptyp_arrow {arg = {lbl = p}; ret = sty; arity} ->
     let p = Asttypes.to_noloc p in
     let ty1 = if is_optional p then type_option (newvar ()) else newvar () in
     newty (Tarrow (p, ty1, approx_type env sty, Cok, arity))

--- a/compiler/ml/typedecl.ml
+++ b/compiler/ml/typedecl.ml
@@ -1036,14 +1036,14 @@ let compute_variance env visited vari ty =
       visited := TypeMap.add ty vari !visited;
       let compute_same = compute_variance_rec vari in
       match ty.desc with
-      | Tarrow (_, ty1, ty2, _, _) ->
+      | Tarrow (arg, ret, _, _) ->
         let open Variance in
         let v = conjugate vari in
         let v1 =
           if mem May_pos v || mem May_neg v then set May_weak true v else v
         in
-        compute_variance_rec v1 ty1;
-        compute_same ty2
+        compute_variance_rec v1 arg.typ;
+        compute_same ret
       | Ttuple tl -> List.iter compute_same tl
       | Tconstr (path, tl, _) -> (
         let open Variance in
@@ -1842,8 +1842,8 @@ let transl_exception env sext =
 
 let rec arity_from_arrow_type env core_type ty =
   match (core_type.ptyp_desc, (Ctype.repr ty).desc) with
-  | Ptyp_arrow {ret = ct2}, Tarrow (_, _, t2, _, _) ->
-    1 + arity_from_arrow_type env ct2 t2
+  | Ptyp_arrow {ret = ct2}, Tarrow (_, ret, _, _) ->
+    1 + arity_from_arrow_type env ct2 ret
   | Ptyp_arrow _, _ | _, Tarrow _ -> assert false
   | _ -> 0
 

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -303,10 +303,12 @@ and core_type = {
   ctyp_attributes: attribute list;
 }
 
+and arg = {lbl: Noloc.arg_label; typ: core_type}
+
 and core_type_desc =
   | Ttyp_any
   | Ttyp_var of string
-  | Ttyp_arrow of Noloc.arg_label * core_type * core_type * arity
+  | Ttyp_arrow of arg * core_type * arity
   | Ttyp_tuple of core_type list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
   | Ttyp_object of object_field list * closed_flag

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -409,10 +409,12 @@ and core_type = {
   ctyp_attributes: attributes;
 }
 
+and arg = {lbl: Noloc.arg_label; typ: core_type}
+
 and core_type_desc =
   | Ttyp_any
   | Ttyp_var of string
-  | Ttyp_arrow of Noloc.arg_label * core_type * core_type * arity
+  | Ttyp_arrow of arg * core_type * arity
   | Ttyp_tuple of core_type list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
   | Ttyp_object of object_field list * closed_flag

--- a/compiler/ml/typedtreeIter.ml
+++ b/compiler/ml/typedtreeIter.ml
@@ -375,9 +375,9 @@ end = struct
     (match ct.ctyp_desc with
     | Ttyp_any -> ()
     | Ttyp_var _ -> ()
-    | Ttyp_arrow (_label, ct1, ct2, _) ->
-      iter_core_type ct1;
-      iter_core_type ct2
+    | Ttyp_arrow (arg, ret, _) ->
+      iter_core_type arg.typ;
+      iter_core_type ret
     | Ttyp_tuple list -> List.iter iter_core_type list
     | Ttyp_constr (_path, _, list) -> List.iter iter_core_type list
     | Ttyp_object (list, _o) -> List.iter iter_object_field list

--- a/compiler/ml/typeopt.ml
+++ b/compiler/ml/typeopt.ml
@@ -93,7 +93,7 @@ let rec type_cannot_contain_undefined (typ : Types.type_expr) (env : Env.t) =
 
 let is_function_type env ty =
   match scrape env ty with
-  | Tarrow (_, lhs, rhs, _, _) -> Some (lhs, rhs)
+  | Tarrow (arg, rhs, _, _) -> Some (arg.typ, rhs)
   | _ -> None
 
 let is_base_type env ty base_ty_path =

--- a/compiler/ml/types.ml
+++ b/compiler/ml/types.ml
@@ -21,9 +21,11 @@ open Asttypes
 
 type type_expr = {mutable desc: type_desc; mutable level: int; id: int}
 
+and arg = {lbl: Noloc.arg_label; typ: type_expr}
+
 and type_desc =
   | Tvar of string option
-  | Tarrow of Noloc.arg_label * type_expr * type_expr * commutable * arity
+  | Tarrow of arg * type_expr * commutable * arity
   | Ttuple of type_expr list
   | Tconstr of Path.t * type_expr list * abbrev_memo ref
   | Tobject of type_expr * (Path.t * type_expr list) option ref

--- a/compiler/ml/types.mli
+++ b/compiler/ml/types.mli
@@ -57,11 +57,13 @@ type type_expr = {mutable desc: type_desc; mutable level: int; id: int}
     Note on mutability: TBD.
  *)
 
+and arg = {lbl: Noloc.arg_label; typ: type_expr}
+
 and type_desc =
   | Tvar of string option
       (** [Tvar (Some "a")] ==> ['a] or ['_a]
       [Tvar None]       ==> [_] *)
-  | Tarrow of Noloc.arg_label * type_expr * type_expr * commutable * arity
+  | Tarrow of arg * type_expr * commutable * arity
       (** [Tarrow (Nolabel,      e1, e2, c)] ==> [e1    -> e2]
       [Tarrow (Labelled "l", e1, e2, c)] ==> [l:e1  -> e2]
       [Tarrow (Optional "l", e1, e2, c)] ==> [?l:e1 -> e2]

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -318,10 +318,10 @@ and transl_type_aux env policy styp =
           v)
     in
     ctyp (Ttyp_var name) ty
-  | Ptyp_arrow {lbl; arg = st1; ret = st2; arity} ->
-    let lbl = Asttypes.to_noloc lbl in
-    let cty1 = transl_type env policy st1 in
-    let cty2 = transl_type env policy st2 in
+  | Ptyp_arrow {arg; ret; arity} ->
+    let lbl = Asttypes.to_noloc arg.lbl in
+    let cty1 = transl_type env policy arg.typ in
+    let cty2 = transl_type env policy ret in
     let ty1 = cty1.ctyp_type in
     let ty1 =
       if Btype.is_optional lbl then

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -329,7 +329,7 @@ and transl_type_aux env policy styp =
       else ty1
     in
     let ty = newty (Tarrow (lbl, ty1, cty2.ctyp_type, Cok, arity)) in
-    ctyp (Ttyp_arrow (lbl, cty1, cty2, arity)) ty
+    ctyp (Ttyp_arrow ({lbl; typ = cty1}, cty2, arity)) ty
   | Ptyp_tuple stl ->
     assert (List.length stl >= 2);
     let ctys = List.map (transl_type env policy) stl in

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -328,7 +328,7 @@ and transl_type_aux env policy styp =
         newty (Tconstr (Predef.path_option, [ty1], ref Mnil))
       else ty1
     in
-    let ty = newty (Tarrow (lbl, ty1, cty2.ctyp_type, Cok, arity)) in
+    let ty = newty (Tarrow ({lbl; typ = ty1}, cty2.ctyp_type, Cok, arity)) in
     ctyp (Ttyp_arrow ({lbl; typ = cty1}, cty2, arity)) ty
   | Ptyp_tuple stl ->
     assert (List.length stl >= 2);

--- a/compiler/syntax/src/res_ast_debugger.ml
+++ b/compiler/syntax/src/res_ast_debugger.ml
@@ -875,12 +875,12 @@ module SexpAst = struct
       match typexpr.ptyp_desc with
       | Ptyp_any -> Sexp.atom "Ptyp_any"
       | Ptyp_var var -> Sexp.list [Sexp.atom "Ptyp_var"; string var]
-      | Ptyp_arrow {lbl; arg; ret} ->
+      | Ptyp_arrow {arg; ret} ->
         Sexp.list
           [
             Sexp.atom "Ptyp_arrow";
-            arg_label_loc lbl;
-            core_type arg;
+            arg_label_loc arg.lbl;
+            core_type arg.typ;
             core_type ret;
           ]
       | Ptyp_tuple types ->

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -319,27 +319,28 @@ let arrow_type ct =
   let rec process attrs_before acc typ =
     match typ with
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel as lbl; arg; ret};
+     ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel} as arg; ret};
      ptyp_attributes = [];
     } ->
-      let arg = ([], lbl, arg) in
+      let arg = ([], arg.lbl, arg.typ) in
       process attrs_before (arg :: acc) ret
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel as lbl; arg; ret};
+     ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel} as arg; ret};
      ptyp_attributes = [({txt = "bs"}, _)] as attrs;
     } ->
-      let arg = (attrs, lbl, arg) in
+      let arg = (attrs, arg.lbl, arg.typ) in
       process attrs_before (arg :: acc) ret
-    | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}} as return_type ->
+    | {ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel}}} as return_type ->
       let args = List.rev acc in
       (attrs_before, args, return_type)
-    | {ptyp_desc = Ptyp_arrow {lbl; arg; ret}; ptyp_attributes = attrs} ->
-      let arg = (attrs, lbl, arg) in
+    | {ptyp_desc = Ptyp_arrow {arg; ret}; ptyp_attributes = attrs} ->
+      let arg = (attrs, arg.lbl, arg.typ) in
       process attrs_before (arg :: acc) ret
     | typ -> (attrs_before, List.rev acc, typ)
   in
   match ct with
-  | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = attrs} as typ ->
+  | {ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel}}; ptyp_attributes = attrs} as
+    typ ->
     process attrs [] {typ with ptyp_attributes = []}
   | typ -> process [] [] typ
 

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -4039,7 +4039,8 @@ and parse_poly_type_expr ?current_type_name_path ?inline_types_context p =
         let typ = Ast_helper.Typ.var ~loc:var.loc var.txt in
         let return_type = parse_typ_expr ~alias:false p in
         let loc = mk_loc typ.Parsetree.ptyp_loc.loc_start p.prev_end_pos in
-        Ast_helper.Typ.arrow ~loc ~arity:(Some 1) Nolabel typ return_type
+        Ast_helper.Typ.arrow ~loc ~arity:(Some 1) {lbl = Nolabel; typ}
+          return_type
       | _ -> Ast_helper.Typ.var ~loc:var.loc var.txt)
     | _ -> assert false)
   | _ -> parse_typ_expr ?current_type_name_path ?inline_types_context p
@@ -4388,7 +4389,7 @@ and parse_es6_arrow_type ~attrs p =
     let name, label_loc = parse_lident p in
     Parser.expect ~grammar:Grammar.TypeExpression Colon p;
     let typ = parse_typ_expr ~alias:false ~es6_arrow:false p in
-    let arg =
+    let lbl =
       match p.Parser.token with
       | Equal ->
         Parser.next p;
@@ -4399,7 +4400,7 @@ and parse_es6_arrow_type ~attrs p =
     Parser.expect EqualGreater p;
     let return_type = parse_typ_expr ~alias:false p in
     let loc = mk_loc start_pos p.prev_end_pos in
-    Ast_helper.Typ.arrow ~loc ~attrs ~arity:None arg typ return_type
+    Ast_helper.Typ.arrow ~loc ~attrs ~arity:None {lbl; typ} return_type
   | DocComment _ -> assert false
   | _ ->
     let parameters = parse_type_parameters p in
@@ -4428,7 +4429,7 @@ and parse_es6_arrow_type ~attrs p =
             | _ -> arity
           in
           let t_arg =
-            Ast_helper.Typ.arrow ~loc ~attrs ~arity:None arg_lbl typ t
+            Ast_helper.Typ.arrow ~loc ~attrs ~arity:None {lbl = arg_lbl; typ} t
           in
           if param_num = 1 then
             (param_num - 1, Ast_uncurried.uncurried_type ~arity t_arg, 1)
@@ -4492,7 +4493,7 @@ and parse_arrow_type_rest ~es6_arrow ~start_pos typ p =
     Parser.next p;
     let return_type = parse_typ_expr ~alias:false p in
     let loc = mk_loc start_pos p.prev_end_pos in
-    Ast_helper.Typ.arrow ~loc ~arity:(Some 1) Nolabel typ return_type
+    Ast_helper.Typ.arrow ~loc ~arity:(Some 1) {lbl = Nolabel; typ} return_type
   | _ -> typ
 
 and parse_typ_expr_region p =
@@ -5150,7 +5151,8 @@ and parse_type_equation_or_constr_decl p =
         let return_type = parse_typ_expr ~alias:false p in
         let loc = mk_loc uident_start_pos p.prev_end_pos in
         let arrow_type =
-          Ast_helper.Typ.arrow ~loc ~arity:(Some 1) Nolabel typ return_type
+          Ast_helper.Typ.arrow ~loc ~arity:(Some 1) {lbl = Nolabel; typ}
+            return_type
         in
         let typ = parse_type_alias p arrow_type in
         (Some typ, Asttypes.Public, Parsetree.Ptype_abstract)

--- a/compiler/syntax/src/res_parsetree_viewer.ml
+++ b/compiler/syntax/src/res_parsetree_viewer.ml
@@ -11,24 +11,24 @@ let arrow_type ?(max_arity = max_int) ct =
       when acc <> [] ->
       (attrs_before, List.rev acc, typ)
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel as lbl; arg; ret};
+     ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel} as arg; ret};
      ptyp_attributes = [];
     } ->
-      let arg = ([], lbl, arg) in
+      let arg = ([], arg.lbl, arg.typ) in
       process attrs_before (arg :: acc) ret (arity - 1)
     | {
-     ptyp_desc = Ptyp_arrow {lbl = Nolabel};
+     ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel}};
      ptyp_attributes = [({txt = "bs"}, _)];
     } ->
       (* stop here, the uncurried attribute always indicates the beginning of an arrow function
        * e.g. `(. int) => (. int)` instead of `(. int, . int)` *)
       (attrs_before, List.rev acc, typ)
-    | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = _attrs} as
-      return_type ->
+    | {ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel}}; ptyp_attributes = _attrs}
+      as return_type ->
       let args = List.rev acc in
       (attrs_before, args, return_type)
     | {
-     ptyp_desc = Ptyp_arrow {lbl = (Labelled _ | Optional _) as lbl; arg; ret};
+     ptyp_desc = Ptyp_arrow {arg = {lbl = Labelled _ | Optional _} as arg; ret};
      ptyp_attributes = attrs;
     } ->
       (* Res_core.parse_es6_arrow_type has a workaround that removed an extra arity for the function if the
@@ -37,18 +37,19 @@ let arrow_type ?(max_arity = max_int) ct =
          When this case is encountered we add that missing arity so the arrow is printed properly.
       *)
       let arity =
-        match arg with
+        match arg.typ with
         | {ptyp_desc = Ptyp_any; ptyp_attributes = attrs1}
           when has_as_attr attrs1 ->
           arity
         | _ -> arity - 1
       in
-      let arg = (attrs, lbl, arg) in
+      let arg = (attrs, arg.lbl, arg.typ) in
       process attrs_before (arg :: acc) ret arity
     | typ -> (attrs_before, List.rev acc, typ)
   in
   match ct with
-  | {ptyp_desc = Ptyp_arrow {lbl = Nolabel}; ptyp_attributes = attrs1} as typ ->
+  | {ptyp_desc = Ptyp_arrow {arg = {lbl = Nolabel}}; ptyp_attributes = attrs1}
+    as typ ->
     process attrs1 [] {typ with ptyp_attributes = []} max_arity
   | typ -> process [] [] typ max_arity
 

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -395,8 +395,8 @@ let valueDetail (typ : Types.type_expr) =
                  collectSignatureTypes t)
         in
         [{path = p; genericParameters = ts}])
-    | Tarrow (_, t1, t2, _, _) ->
-      collectSignatureTypes t1 @ collectSignatureTypes t2
+    | Tarrow (arg, ret, _, _) ->
+      collectSignatureTypes arg.typ @ collectSignatureTypes ret
     | Tvar None -> [{path = "_"; genericParameters = []}]
     | _ -> []
   in


### PR DESCRIPTION
Put the label and type together, so in future it will be possible to represent a function of several arguments with a list.