### PR TITLE
Prevent trying to read non-existing file when extracting extra info for error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Rewatch: Add --dev flag to clean command. https://github.com/rescript-lang/rescript/pull/7622
 - Rewatch: Use root package suffix in clean log messages. https://github.com/rescript-lang/rescript/pull/7648
 - Fix inside comment printing for empty dict. https://github.com/rescript-lang/rescript/pull/7654
+- Fix I/O error message when trying to extract extra info from non-existing file. https://github.com/rescript-lang/rescript/pull/7656
 
 # 12.0.0-beta.1
 

--- a/compiler/ml/error_message_utils.ml
+++ b/compiler/ml/error_message_utils.ml
@@ -41,9 +41,13 @@ end = struct
     String.sub src start_offset (end_offset - start_offset)
 
   let extract_text_at_loc loc =
-    (* TODO: Maybe cache later on *)
-    let src = Ext_io.load_file loc.Location.loc_start.pos_fname in
-    extract_location_string ~src loc
+    if loc.Location.loc_start.pos_fname = "_none_" then ""
+    else
+      try
+        (* TODO: Maybe cache later on *)
+        let src = Ext_io.load_file loc.Location.loc_start.pos_fname in
+        extract_location_string ~src loc
+      with _ -> ""
 
   let parse_expr_at_loc loc =
     let sub_src = extract_text_at_loc loc in

--- a/tests/build_tests/super_errors/expected/extract_from_none_file.res.expected
+++ b/tests/build_tests/super_errors/expected/extract_from_none_file.res.expected
@@ -1,0 +1,6 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/extract_from_none_file.res[0m
+
+  This has type: [1;31mRegExp.t[0m
+  But a [1;33mwhile[0m loop condition must always be of type: [1;33mbool[0m

--- a/tests/build_tests/super_errors/fixtures/extract_from_none_file.res
+++ b/tests/build_tests/super_errors/fixtures/extract_from_none_file.res
@@ -1,0 +1,5 @@
+// This will try and extract the text from a non-existing file.
+// Test is intended to check that this does not crash.
+while /foo/ {
+  ()
+}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7610