### PR TITLE
Remove legacy clean

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,9 +3,9 @@
   "name": "playground",
   "type": "commonjs",
   "scripts": {
-    "clean": "rescript legacy clean",
+    "clean": "rescript clean",
     "test": "node ./playground_test.cjs",
-    "build": "rescript legacy clean && rescript legacy build && node scripts/generate_cmijs.mjs && rollup -c",
+    "build": "rescript clean && rescript legacy build && node scripts/generate_cmijs.mjs && rollup -c",
     "upload-bundle": "node scripts/upload_bundle.mjs"
   },
   "dependencies": {

--- a/packages/playground/scripts/generate_cmijs.mjs
+++ b/packages/playground/scripts/generate_cmijs.mjs
@@ -23,7 +23,7 @@ import {
   playgroundPackagesDir,
 } from "./common.mjs";
 
-exec("yarn rescript legacy clean");
+exec("yarn rescript clean");
 exec("yarn rescript legacy");
 
 // We need to build the compiler's builtin modules as a separate cmij.

--- a/rescript.json
+++ b/rescript.json
@@ -1,0 +1,6 @@
+{
+    "name": "rescript",
+    "bs-dependencies": [
+        "@tests/gentype-react-example"
+    ]
+}

--- a/rewatch/testrepo/package.json
+++ b/rewatch/testrepo/package.json
@@ -22,6 +22,6 @@
     "watch": "../target/release/rewatch watch .",
     "watch:rescript": "rescript legacy watch",
     "clean": "../target/release/rewatch clean .",
-    "clean:rescript": "rescript legacy clean"
+    "clean:rescript": "rescript clean"
   }
 }

--- a/scripts/res/package.json
+++ b/scripts/res/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean",
+    "clean": "rescript clean",
     "dev": "rescript legacy -w",
     "apidocs:generate": "yarn build && node GenApiDocs.res.js"
   },

--- a/tests/analysis_tests/tests-generic-jsx-transform/package.json
+++ b/tests/analysis_tests/tests-generic-jsx-transform/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean"
+    "clean": "rescript clean"
   },
   "dependencies": {
     "rescript": "workspace:^"

--- a/tests/analysis_tests/tests-incremental-typechecking/package.json
+++ b/tests/analysis_tests/tests-incremental-typechecking/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean"
+    "clean": "rescript clean"
   },
   "dependencies": {
     "rescript": "workspace:^"

--- a/tests/analysis_tests/tests-reanalyze/deadcode/package.json
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean"
+    "clean": "rescript clean"
   },
   "dependencies": {
     "@rescript/react": "link:../../../dependencies/rescript-react",

--- a/tests/analysis_tests/tests-reanalyze/termination/package.json
+++ b/tests/analysis_tests/tests-reanalyze/termination/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean"
+    "clean": "rescript clean"
   },
   "dependencies": {
     "rescript": "workspace:^"

--- a/tests/analysis_tests/tests/package.json
+++ b/tests/analysis_tests/tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean"
+    "clean": "rescript clean"
   },
   "dependencies": {
     "@rescript/react": "link:../../dependencies/rescript-react",

--- a/tests/docstring_tests/package.json
+++ b/tests/docstring_tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean",
+    "clean": "rescript clean",
     "dev": "rescript -w"
   },
   "dependencies": {

--- a/tests/gentype_tests/typescript-react-example/package.json
+++ b/tests/gentype_tests/typescript-react-example/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "rescript legacy build -w",
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean",
+    "clean": "rescript clean",
     "typecheck": "tsc",
     "check": "biome check --changed --no-errors-on-unmatched ."
   },

--- a/tests/gentype_tests/typescript-react-example/rescript.json
+++ b/tests/gentype_tests/typescript-react-example/rescript.json
@@ -15,7 +15,7 @@
     },
     "exportInterfaces": false
   },
-  "name": "sample-typescript-app",
+  "name": "@tests/gentype-react-example",
   "bsc-flags": [],
   "jsx": { "version": 4 },
   "bs-dependencies": ["@rescript/react"],

--- a/tests/tools_tests/package.json
+++ b/tests/tools_tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rescript legacy build",
-    "clean": "rescript legacy clean",
+    "clean": "rescript clean",
     "dev": "rescript -w"
   },
   "dependencies": {


### PR DESCRIPTION
The `"@tests/gentype-react-example"` project is using the root `node_modules` and without a top level `rescript.json`, rewatch doesn't know where to find the right files to clean.
This makes sense to me, let me know if it does for you.