### PR TITLE
Fix fatal error when JSX not configured in rescript.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Rewatch: Use root package suffix in clean log messages. https://github.com/rescript-lang/rescript/pull/7648
 - Fix inside comment printing for empty dict. https://github.com/rescript-lang/rescript/pull/7654
 - Fix I/O error message when trying to extract extra info from non-existing file. https://github.com/rescript-lang/rescript/pull/7656
+- Fix fatal error when JSX expression used without configuring JSX in rescript.json. https://github.com/rescript-lang/rescript/pull/7656
 
 # 12.0.0-beta.1
 

--- a/compiler/ml/typecore.mli
+++ b/compiler/ml/typecore.mli
@@ -116,6 +116,8 @@ type error =
   | Field_not_optional of string * type_expr
   | Type_params_not_supported of Longident.t
   | Field_access_on_dict_type
+  | Jsx_not_enabled
+
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 


### PR DESCRIPTION
Fixes #7468.

(I accidentally pushed the commit with the fix to the master already, this PR is for documentation.)

<img width="899" height="180" alt="Bildschirmfoto 2025-07-17 um 19 33 38" src="https://github.com/user-attachments/assets/5e711d23-2d69-4ca5-ac00-ed9092a0a4ec" />