### PR TITLE
Generate sourcedirs.json

### DIFF
--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -14,6 +14,7 @@ use crate::build::compile::{mark_modules_with_deleted_deps_dirty, mark_modules_w
 use crate::helpers::emojis::*;
 use crate::helpers::{self, get_workspace_root};
 use crate::sourcedirs;
+use ahash::AHashSet;
 use anyhow::{Result, anyhow};
 use build_types::*;
 use console::style;
@@ -21,12 +22,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::log_enabled;
 use serde::Serialize;
 use std::ffi::OsString;
-use std::fmt;
 use std::fs::File;
 use std::io::{Write, stdout};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
+use std::{fmt, fs};
 
 fn is_dirty(module: &Module) -> bool {
     match module.source_type {
@@ -469,6 +470,50 @@ pub fn write_build_ninja(build_state: &BuildState) {
     }
 }
 
+#[derive(Serialize, Debug)]
+pub struct SourceDirsMeta {
+    pub dirs: Vec<String>,
+    pub pkgs: Vec<(String, String)>,
+    pub generated: Vec<String>,
+}
+
+fn generate_sourcedirs_meta(build_state: &BuildState) {
+    let mut dir_set: AHashSet<String> = AHashSet::new();
+    let mut pkgs: Vec<(String, String)> = vec![];
+    for package in build_state.packages.values() {
+        if package.is_local_dep {
+            if let Some(source_files) = &package.source_files {
+                for source_file in source_files.keys() {
+                    if let Some(parent) = source_file.parent() {
+                        dir_set.insert(parent.to_string_lossy().into_owned());
+                    }
+                }
+            }
+        } else {
+            pkgs.push((package.name.clone(), package.path.to_string_lossy().into_owned()));
+        }
+    }
+
+    let meta = SourceDirsMeta {
+        dirs: dir_set.into_iter().collect(),
+        pkgs,
+        generated: vec![],
+    };
+
+    let json = serde_json::to_string(&meta);
+    match json {
+        Err(err) => {
+            println!("Error serializing .sourcedirs.json: {}", err);
+        }
+        Ok(json) => {
+            let output_path = build_state.project_root.join("lib/bs/.sourcedirs.json");
+            if let Err(e) = fs::write(output_path, json) {
+                println!("Error writing sourcedirs.json: {}", e);
+            }
+        }
+    }
+}
+
 pub fn build(
     filter: &Option<regex::Regex>,
     path: &Path,
@@ -493,6 +538,8 @@ pub fn build(
         snapshot_output,
     )
     .map_err(|e| anyhow!("Could not initialize build. Error: {e}"))?;
+
+    generate_sourcedirs_meta(&build_state);
 
     match incremental_build(
         &mut build_state,

--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -535,7 +535,9 @@ fn get_dependency_paths(
                     .as_ref()
                     .map(|package| package.path.clone())
             } else {
-                packages::read_dependency(package_name, project_root, project_root, workspace_root).ok()
+                packages::read_dependency(package_name, project_root, project_root, workspace_root)
+                    .map(|(p, _)| p)
+                    .ok()
             }
             .map(|canonicalized_path| {
                 vec![

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -1,6 +1,7 @@
 use super::build_types::*;
 use super::namespaces;
 use super::packages;
+use crate::build::packages::DependencySymLink::{NoSymlink, Symlink};
 use crate::config;
 use crate::helpers;
 use crate::helpers::StrippedVerbatimPath;
@@ -40,12 +41,21 @@ impl Namespace {
 }
 
 #[derive(Debug, Clone)]
+pub enum DependencySymLink {
+    NoSymlink,
+    Symlink(PathBuf),
+}
+
+#[derive(Debug, Clone)]
 struct Dependency {
     name: String,
     config: config::Config,
     path: PathBuf,
     is_pinned: bool,
     dependencies: Vec<Dependency>,
+    // Track if the original dependency path actually a symbolic link.
+    // We need to know this to later assert if a package is local or not.
+    sym_link: DependencySymLink,
 }
 
 #[derive(Debug, Clone)]
@@ -254,7 +264,7 @@ pub fn read_dependency(
     parent_path: &Path,
     project_root: &Path,
     workspace_root: &Option<PathBuf>,
-) -> Result<PathBuf, String> {
+) -> Result<(PathBuf, DependencySymLink), String> {
     let path_from_parent = PathBuf::from(helpers::package_path(parent_path, package_name));
     let path_from_project_root = PathBuf::from(helpers::package_path(project_root, package_name));
     let maybe_path_from_workspace_root = workspace_root
@@ -277,6 +287,17 @@ pub fn read_dependency(
         )),
     }?;
 
+    // There could be a symbolic link because the package.json has:
+    //   "dependencies": {
+    //     "my-package": "link:my-package",
+    //   }
+    // In this case, there will be a link from node_modules/my-package to a local path.
+    let symlink = match fs::symlink_metadata(&path).map(|m| m.file_type().is_symlink()) {
+        Err(_) => NoSymlink,
+        Ok(false) => NoSymlink,
+        Ok(true) => Symlink(path.clone()),
+    };
+
     let canonical_path = match path
         .canonicalize()
         .map(StrippedVerbatimPath::to_stripped_verbatim_path)
@@ -290,7 +311,7 @@ pub fn read_dependency(
         )),
     }?;
 
-    Ok(canonical_path)
+    Ok((canonical_path, symlink))
 }
 
 /// # Make Package
@@ -331,7 +352,7 @@ fn read_dependencies(
         // Read all config files in parallel instead of blocking
         .par_iter()
         .map(|package_name| {
-            let (config, canonical_path) =
+            let (config, canonical_path, sym_link) =
                 match read_dependency(package_name, parent_path, project_root, &workspace_root) {
                     Err(error) => {
                     if show_progress {
@@ -350,9 +371,9 @@ fn read_dependencies(
 
                         std::process::exit(2)
                     }
-                    Ok(canonical_path) => {
+                    Ok((canonical_path, sym_link)) => {
                         match read_config(&canonical_path) {
-                            Ok(config) => (config, canonical_path),
+                            Ok(config) => (config, canonical_path, sym_link),
                             Err(error) => {
                                 let parent_path_str = parent_path.to_string_lossy();
                                 log::error!(
@@ -386,6 +407,7 @@ fn read_dependencies(
                 path: canonical_path,
                 is_pinned,
                 dependencies,
+                sym_link
             }
         })
         .collect()
@@ -416,7 +438,13 @@ pub fn read_package_name(package_dir: &Path) -> Result<String> {
         .ok_or_else(|| anyhow!("No name field found in package.json"))
 }
 
-fn make_package(config: config::Config, package_path: &Path, is_pinned_dep: bool, is_root: bool) -> Package {
+fn make_package(
+    config: config::Config,
+    package_path: &Path,
+    is_pinned_dep: bool,
+    is_root: bool,
+    is_local_dep: bool,
+) -> Package {
     let source_folders = match config.sources.to_owned() {
         Some(config::OneOrMore::Single(source)) => get_source_dirs(source, None),
         Some(config::OneOrMore::Multiple(sources)) => {
@@ -469,7 +497,7 @@ This inconsistency will cause issues with package resolution.\n",
             .expect("Could not canonicalize"),
         dirs: None,
         is_pinned_dep,
-        is_local_dep: !package_path.components().any(|c| c.as_os_str() == "node_modules"),
+        is_local_dep,
         is_root,
     }
 }
@@ -484,7 +512,7 @@ fn read_packages(
 
     // Store all packages and completely deduplicate them
     let mut map: AHashMap<String, Package> = AHashMap::new();
-    let root_package = make_package(root_config.to_owned(), project_root, false, true);
+    let root_package = make_package(root_config.to_owned(), project_root, false, true, true);
     map.insert(root_package.name.to_string(), root_package);
 
     let mut registered_dependencies_set: AHashSet<String> = AHashSet::new();
@@ -499,7 +527,13 @@ fn read_packages(
     ));
     dependencies.iter().for_each(|d| {
         if !map.contains_key(&d.name) {
-            let package = make_package(d.config.to_owned(), &d.path, d.is_pinned, false);
+            let is_local_dep = match &d.sym_link {
+                NoSymlink => !d.path.components().any(|c| c.as_os_str() == "node_modules"),
+                Symlink(original_path) => !original_path
+                    .components()
+                    .any(|c| c.as_os_str() == "node_modules"),
+            };
+            let package = make_package(d.config.to_owned(), &d.path, d.is_pinned, false, is_local_dep);
             map.insert(d.name.to_string(), package);
         }
     });


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7670

While testing this locally, I did notice I needed to add a bit more logic to ensure a symbolic linked package in the node_modules is still considered as non local package.

Could already use some eyes on this!