### PR TITLE
Adjust to bs-* deprecations

### DIFF
--- a/analysis/src/FindFiles.ml
+++ b/analysis/src/FindFiles.ml
@@ -213,16 +213,21 @@ let findProjectFiles ~public ~namespace ~path ~sourceDirectories ~libBs =
 
 let findDependencyFiles base config =
   let deps =
-    config |> Json.get "bs-dependencies" |> bind Json.array
-    |> Option.value ~default:[]
-    |> List.filter_map Json.string
+    match
+      ( config |> Json.get "dependencies" |> bind Json.array,
+        config |> Json.get "bs-dependencies" |> bind Json.array )
+    with
+    | None, None -> []
+    | Some deps, None | _, Some deps -> deps |> List.filter_map Json.string
   in
   let devDeps =
-    config
-    |> Json.get "bs-dev-dependencies"
-    |> bind Json.array
-    |> Option.map (List.filter_map Json.string)
-    |> Option.value ~default:[]
+    match
+      ( config |> Json.get "dev-dependencies" |> bind Json.array,
+        config |> Json.get "bs-dev-dependencies" |> bind Json.array )
+    with
+    | None, None -> []
+    | Some devDeps, None | _, Some devDeps ->
+      devDeps |> List.filter_map Json.string
   in
   let deps = deps @ devDeps in
   Log.log ("Dependencies: " ^ String.concat " " deps);

--- a/compiler/gentype/GenTypeConfig.ml
+++ b/compiler/gentype/GenTypeConfig.ml
@@ -203,8 +203,10 @@ let read_config ~get_config_file ~namespace =
       | _ -> default.suffix
     in
     let bs_dependencies =
-      match bsconf |> get_opt "bs-dependencies" with
-      | Some (Arr {content}) ->
+      match
+        (bsconf |> get_opt "dependencies", bsconf |> get_opt "bs-dependencies")
+      with
+      | Some (Arr {content}), None | None, Some (Arr {content}) ->
         let strings = ref [] in
         content
         |> Array.iter (fun x ->

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -888,8 +888,8 @@ let report_error env ppf = function
       Format.fprintf ppf
         "@[<v>@{<info>The module or file %a can't be found.@}@,\
          @[<v 2>- If it's a third-party dependency:@,\
-         - Did you add it to the \"bs-dependencies\" or \
-         \"bs-dev-dependencies\" in rescript.json?@]@,\
+         - Did you add it to the \"dependencies\" or \"dev-dependencies\" in \
+         rescript.json?@]@,\
          - Did you include the file's directory to the \"sources\" in \
          rescript.json?@,"
         Printtyp.longident lid);

--- a/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
@@ -20,7 +20,7 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file WebAPI can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 

--- a/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
@@ -20,10 +20,9 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file WebAPI can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
+    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K
-  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
@@ -20,9 +20,10 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file WebAPI can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K
+  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -22,7 +22,7 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Dep02 can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -22,9 +22,10 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Dep02 can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K
+  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -22,10 +22,9 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Dep02 can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
+    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K
-  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -20,7 +20,7 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Other_module can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
   

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -20,12 +20,11 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Other_module can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
+    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
   
   [1;33mHint: Did you mean Other_module2?[0m
 
 
-Incremental build failed. Error: [2K
-  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -20,11 +20,12 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file Other_module can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
   
   [1;33mHint: Did you mean Other_module2?[0m
 
 
-Incremental build failed. Error: [2K  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K
+  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -22,9 +22,10 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file InternalDep can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K
+  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -22,10 +22,9 @@ Use 'compiler-flags' instead.
 
   [1;33mThe module or file InternalDep can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
+    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?
   
 
 
-Incremental build failed. Error: [2K
-  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K  Failed to Compile. See Errors Above

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -27,5 +27,4 @@ Use 'compiler-flags' instead.
   
 
 
-Incremental build failed. Error: [2K
-  Failed to Compile. See Errors Above
+Incremental build failed. Error: [2K  Failed to Compile. See Errors Above

--- a/tests/build_tests/super_errors/expected/modules1.res.expected
+++ b/tests/build_tests/super_errors/expected/modules1.res.expected
@@ -7,5 +7,5 @@
 
   [1;33mThe module or file Foo can't be found.[0m
   - If it's a third-party dependency:
-    - Did you add it to the "bs-dependencies" or "bs-dev-dependencies" in rescript.json?
+    - Did you add it to the "dependencies" or "dev-dependencies" in rescript.json?
   - Did you include the file's directory to the "sources" in rescript.json?


### PR DESCRIPTION
This adjusts more stuff to the `bs-*` deprecations.

I pretty much simply trust that the build system will error if both are defined, so I don't care too much about that type of logic for this.

I couldn't add proper tests for this in the analysis, because this requires rewatch and I can't get the analysis tests to build with rewatch right now.

I don't think this needs a changelog since https://github.com/rescript-lang/rescript/pull/7658 already has one.