### PR TITLE
Hint in error for string constants matching expected variant

### DIFF
--- a/tests/build_tests/super_errors/expected/string_constant_to_polyvariant.res.expected
+++ b/tests/build_tests/super_errors/expected/string_constant_to_polyvariant.res.expected
@@ -1,0 +1,15 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/string_constant_to_polyvariant.res[0m:[2m8:20-24[0m
+
+  6 [2m│[0m }
+  7 [2m│[0m 
+  [1;31m8[0m [2m│[0m let x = doStuff(1, [1;31m"ONE"[0m)
+  9 [2m│[0m 
+
+  This has type: [1;31mstring[0m
+  But this function argument is expecting: [1;33m[#ONE | #TWO][0m
+
+  Possible solutions:
+  - The constant passed matches one of the expected polymorphic variant constructors. Did you mean to pass this as a polymorphic variant? If so, rewrite [1;33m"ONE"[0m to [1;33m#ONE
+[0m

--- a/tests/build_tests/super_errors/expected/string_constant_to_variant.res.expected
+++ b/tests/build_tests/super_errors/expected/string_constant_to_variant.res.expected
@@ -1,0 +1,15 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/string_constant_to_variant.res[0m:[2m11:28-35[0m
+
+   9 [2m│[0m }
+  10 [2m│[0m 
+  [1;31m11[0m [2m│[0m let result = processStatus([1;31m"Active"[0m)
+  12 [2m│[0m 
+
+  This has type: [1;31mstring[0m
+  But this function argument is expecting: [1;33mstatus[0m
+
+  Possible solutions:
+  - The constant passed matches the runtime representation of one of the expected variant constructors. Did you mean to pass this as a variant constructor? If so, rewrite [1;33m"Active"[0m to [1;33mActive
+[0m

--- a/tests/build_tests/super_errors/fixtures/string_constant_to_polyvariant.res
+++ b/tests/build_tests/super_errors/fixtures/string_constant_to_polyvariant.res
@@ -1,0 +1,8 @@
+let doStuff = (a: int, b: [#ONE | #TWO]) => {
+  switch b {
+  | #ONE => a + 1
+  | #TWO => a + 2
+  }
+}
+
+let x = doStuff(1, "ONE")

--- a/tests/build_tests/super_errors/fixtures/string_constant_to_variant.res
+++ b/tests/build_tests/super_errors/fixtures/string_constant_to_variant.res
@@ -1,0 +1,11 @@
+type status = Active | Inactive | Pending
+
+let processStatus = (s: status) => {
+  switch s {
+  | Active => "active"
+  | Inactive => "inactive"
+  | Pending => "pending"
+  }
+}
+
+let result = processStatus("Active")


### PR DESCRIPTION
This error is helpful when going from a string to something more typed (variant/polyvariant).