### PR TITLE
Fix formatter removed parens from functor type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 #### :bug: Bug fix
 
 - Fix error message that falsely suggested using coercion when it wouldn't work. https://github.com/rescript-lang/rescript/pull/7721
+- Fix formatter removes () from functor type. https://github.com/rescript-lang/rescript/pull/7735
 
 # 12.0.0-beta.3
 

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -807,6 +807,10 @@ and print_mod_type ~state mod_type cmt_tbl =
             Doc.concat [attrs; print_mod_type ~state mod_type cmt_tbl]
           in
           print_comments doc cmt_tbl cmt_loc
+        | [(attrs, {Location.txt = "*"; loc}, None)] ->
+          let attrs = print_attributes ~state attrs cmt_tbl in
+          let doc = Doc.concat [attrs; Doc.text "()"] in
+          print_comments doc cmt_tbl loc
         | params ->
           Doc.group
             (Doc.concat

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -834,8 +834,10 @@ and print_mod_type ~state mod_type cmt_tbl =
                                  print_attributes ~state attrs cmt_tbl
                                in
                                let lbl_doc =
-                                 if lbl.Location.txt = "_" || lbl.txt = "*" then
-                                   Doc.nil
+                                 if lbl.Location.txt = "_" then Doc.nil
+                                 else if lbl.txt = "*" then
+                                   let doc = Doc.text "()" in
+                                   print_comments doc cmt_tbl lbl.loc
                                  else
                                    let doc = Doc.text lbl.txt in
                                    print_comments doc cmt_tbl lbl.loc

--- a/tests/syntax_tests/data/printer/structure/expected/moduleBinding.res.txt
+++ b/tests/syntax_tests/data/printer/structure/expected/moduleBinding.res.txt
@@ -3,3 +3,6 @@ module React = {
 
   let render = () => Js.log("foo")
 }
+
+module Make: () => S = (_: Config, ()) => {}
+module rec Make: (Config, ()) => S = (Config: Config, ()): S => {}

--- a/tests/syntax_tests/data/printer/structure/moduleBinding.res
+++ b/tests/syntax_tests/data/printer/structure/moduleBinding.res
@@ -3,3 +3,6 @@ module React = {
 
   let render = () => Js.log("foo")
 }
+
+module Make: () => S = (Config, ()) => {}
+module rec Make: (Config, ()) => S = (Config: Config, ()): S => {}


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript/issues/7720