### PR TITLE
Move is_local_dep to Dependency struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 #### :bug: Bug fix
 
 - Fix error message that falsely suggested using coercion when it wouldn't work. https://github.com/rescript-lang/rescript/pull/7721
+- Rewatch: don't compile dev-dependencies of non local dependencies with `--dev`. https://github.com/rescript-lang/rescript/pull/7736
 
 # 12.0.0-beta.3
 

--- a/rewatch/testrepo/packages/with-dev-deps/package.json
+++ b/rewatch/testrepo/packages/with-dev-deps/package.json
@@ -8,5 +8,8 @@
   "license": "MIT",
   "devDependencies": {
     "@rescript/webapi": "0.1.0-experimental-73e6a0d"
+  },
+  "dependencies": {
+    "rescript-nodejs": "16.1.0"
   }
 }

--- a/rewatch/testrepo/packages/with-dev-deps/rescript.json
+++ b/rewatch/testrepo/packages/with-dev-deps/rescript.json
@@ -9,6 +9,7 @@
       "type": "dev"
     }
   ],
+  "dependencies": ["rescript-nodejs"],
   "dev-dependencies": ["@rescript/webapi"],
   "package-specs": {
     "module": "es6",

--- a/rewatch/testrepo/yarn.lock
+++ b/rewatch/testrepo/yarn.lock
@@ -107,8 +107,16 @@ __metadata:
   resolution: "@testrepo/with-dev-deps@workspace:packages/with-dev-deps"
   dependencies:
     "@rescript/webapi": "npm:0.1.0-experimental-73e6a0d"
+    rescript-nodejs: "npm:16.1.0"
   languageName: unknown
   linkType: soft
+
+"rescript-nodejs@npm:16.1.0":
+  version: 16.1.0
+  resolution: "rescript-nodejs@npm:16.1.0"
+  checksum: 10c0/2ea271dbddebdceec79bf5ee6089c15474f2c014cb22c1cc39d43ef27fd363fcb1cd8e1244d0cb998cd6b426d7474e3055e41277951fb01ee1eeecf68bbe01ab
+  languageName: node
+  linkType: hard
 
 "rescript@npm:12.0.0-beta.1, rescript@npm:^12.0.0-alpha.13":
   version: 12.0.0-beta.1

--- a/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/bs-dev-dependency-used-by-non-dev-source.txt
@@ -1,4 +1,4 @@
-Cleaned 0/16
+Cleaned 0/56
 Parsed 2 source files
 Compiled 2 modules
 

--- a/rewatch/tests/snapshots/dependency-cycle.txt
+++ b/rewatch/tests/snapshots/dependency-cycle.txt
@@ -1,4 +1,4 @@
-Cleaned 0/16
+Cleaned 0/56
 Parsed 1 source files
 Compiled 0 modules
 

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -1,4 +1,4 @@
-Cleaned 1/16
+Cleaned 1/56
 Parsed 0 source files
 Compiled 1 modules
 

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -1,4 +1,4 @@
-Cleaned 2/16
+Cleaned 2/56
 Parsed 2 source files
 Compiled 3 modules
 

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -1,4 +1,4 @@
-Cleaned 2/16
+Cleaned 2/56
 Parsed 2 source files
 Compiled 2 modules
 

--- a/rewatch/tests/snapshots/rename-file-with-interface.txt
+++ b/rewatch/tests/snapshots/rename-file-with-interface.txt
@@ -1,5 +1,5 @@
 [2K No implementation file found for interface file (skipping): src/ModuleWithInterface.resi
-Cleaned 2/16
+Cleaned 2/56
 Parsed 1 source files
 Compiled 2 modules
 

--- a/rewatch/tests/snapshots/rename-file.txt
+++ b/rewatch/tests/snapshots/rename-file.txt
@@ -1,4 +1,4 @@
-Cleaned 1/16
+Cleaned 1/56
 Parsed 1 source files
 Compiled 1 modules
 

--- a/rewatch/tests/snapshots/rename-interface-file.txt
+++ b/rewatch/tests/snapshots/rename-interface-file.txt
@@ -1,5 +1,5 @@
 [2K No implementation file found for interface file (skipping): src/ModuleWithInterface2.resi
-Cleaned 1/16
+Cleaned 1/56
 Parsed 1 source files
 Compiled 2 modules
 


### PR DESCRIPTION
I'm in a very confused state writing this, but this PR might hold an answer to https://github.com/rescript-lang/rewatch/issues/124#issuecomment-3131420682

I could be wrong, but I don't think it makes sense to compile the `devDependencies` of your own non-local dependencies.

In the sample of https://github.com/greenfinity/rescript-sample-v12, a local package has:
`"bs-dependencies": ["rescript-nodejs"],`.
If I were to build that package with `--dev`, I don't think we want to build any `devDependencies` of `rescript-nodejs`. Like, why would we? For all we know, the sources are missing as in the `node_modules` anyway.

@jfrolich, @Bushuo, @cknitt any thoughts?