### PR TITLE
Try and read package name from rescript.json if package.json is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 #### :nail_care: Polish
 
+- Read package name from rescript.json if package.json is absent. https://github.com/rescript-lang/rescript/pull/7746
+
 #### :house: Internal
 
 - Add token viewer to `res_parser`. https://github.com/rescript-lang/rescript/pull/7751

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -399,8 +399,12 @@ fn flatten_dependencies(dependencies: Vec<Dependency>) -> Vec<Dependency> {
 pub fn read_package_name(package_dir: &Path) -> Result<String> {
     let package_json_path = package_dir.join("package.json");
 
-    let package_json_contents =
-        fs::read_to_string(&package_json_path).map_err(|e| anyhow!("Could not read package.json: {}", e))?;
+    let package_json_contents = if Path::exists(&package_json_path) {
+        fs::read_to_string(&package_json_path).map_err(|e| anyhow!("Could not read package.json: {}", e))?
+    } else {
+        let rescript_json_path = package_dir.join("rescript.json");
+        fs::read_to_string(&rescript_json_path).map_err(|e| anyhow!("Could not read rescript.json: {}", e))?
+    };
 
     let package_json: serde_json::Value = serde_json::from_str(&package_json_contents)
         .map_err(|e| anyhow!("Could not parse package.json: {}", e))?;

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -397,17 +397,27 @@ fn flatten_dependencies(dependencies: Vec<Dependency>) -> Vec<Dependency> {
 }
 
 pub fn read_package_name(package_dir: &Path) -> Result<String> {
-    let package_json_path = package_dir.join("package.json");
+    let mut file_name = "package.json";
+    let package_json_path = package_dir.join(file_name);
 
     let package_json_contents = if Path::exists(&package_json_path) {
         fs::read_to_string(&package_json_path).map_err(|e| anyhow!("Could not read package.json: {}", e))?
     } else {
         let rescript_json_path = package_dir.join("rescript.json");
-        fs::read_to_string(&rescript_json_path).map_err(|e| anyhow!("Could not read rescript.json: {}", e))?
+        if Path::exists(&rescript_json_path) {
+            file_name = "rescript.json";
+            fs::read_to_string(&rescript_json_path)
+                .map_err(|e| anyhow!("Could not read rescript.json: {}", e))?
+        } else {
+            return Err(anyhow!(
+                "There is no package.json or rescript.json file in {}",
+                package_dir.to_string_lossy()
+            ));
+        }
     };
 
     let package_json: serde_json::Value = serde_json::from_str(&package_json_contents)
-        .map_err(|e| anyhow!("Could not parse package.json: {}", e))?;
+        .map_err(|e| anyhow!("Could not parse {}: {}", file_name, e))?;
 
     package_json["name"]
         .as_str()


### PR DESCRIPTION
Use-case which @jderochervlk has with Deno.

@jfrolich setup is the following:

```
some-project
  - rescript.json
  - deno.json
```

User has no `package.json`, so we fallback to rescript.json for the name.
Do you see any problems with this?