### PR TITLE
Be more aware of the workspace during clean

### DIFF
--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -611,7 +611,15 @@ pub fn make(
     show_progress: bool,
     build_dev_deps: bool,
 ) -> Result<AHashMap<String, Package>> {
-    let map = read_packages(root_folder, workspace_root, show_progress, build_dev_deps)?;
+    let map = match &workspace_root {
+        Some(wr) => {
+            let root_folder_str = root_folder.to_string_lossy();
+            let workspace_root_str = wr.to_string_lossy();
+            log::debug!("Building workspace: {workspace_root_str} for {root_folder_str}",);
+            read_packages(wr, workspace_root, show_progress, build_dev_deps)?
+        }
+        None => read_packages(root_folder, workspace_root, show_progress, build_dev_deps)?,
+    };
 
     /* Once we have the deduplicated packages, we can add the source files for each - to minimize
      * the IO */


### PR DESCRIPTION
This is an attempt to drive the conversation at https://github.com/rescript-lang/rescript/issues/7707

In case of clean, we already do an upward traversal to find a root rescript json.
I'm adding some logic to check if the parent rescript json contains the current rescript json in "dependencies" (or "dev-dependencies").

If we did find a link, we would only remove the files from the current project and not everything.

Consider https://github.com/nojaf/rescript-kaplay/blob/main/packages/rescript-kaplay/rescript.json

We already find https://github.com/nojaf/rescript-kaplay/blob/d38649fcd409c174c39b31488f790e036f3b0a20/rescript.json#L8

If that name matches `root_package` (in the code, a bit confusing name) is `"@nojaf/rescript-kaplay"`, so we only need to remove those files.

Files from https://github.com/nojaf/rescript-kaplay/blob/main/packages/samples/rescript.json are unaffected.

If we were to clean from the repo root, `root_config` would be the well the root package and everything gets cleaned.