### PR TITLE
Reuse package resolution for ppx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix ppx resolution with package inside monorepo. https://github.com/rescript-lang/rescript/pull/7776
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -80,7 +80,7 @@ pub fn get_compiler_args(rescript_file_path: &Path) -> Result<String> {
         &project_context.current_config,
         relative_filename,
         &contents,
-    );
+    )?;
     let is_interface = filename.to_string_lossy().ends_with('i');
     let has_interface = if is_interface {
         true


### PR DESCRIPTION
This is another attempt to solve ppx resolution in monorepos.

<img width="1395" height="653" alt="image" src="https://github.com/user-attachments/assets/7798728e-d6f7-4e56-a820-517efe0ea62a" />

The gist is that some workspaces can have `node_modules` on the root and the package level.
We take this into account for finding dependencies but didn't for ppx.
In this PR, I've refactored the same resolution code and reused it when looking for ppx.

I didn't add a test as it is very difficult to reproduce this in a yarn workspace.
It is my understanding that yarn will only show this behaviour when it fails to resolve a single version for the entire workspace.

@tsnobip could you give this one a go?