### PR TITLE
Allow skipping leading pipe in definitions of variants with attribute on leading constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 #### :nail_care: Polish
 
+- Allow skipping the leading pipe in variant definition with a leading constructor with an attribute. https://github.com/rescript-lang/rescript/pull/7782
+
 #### :house: Internal
 
 # 12.0.0-beta.6

--- a/tests/syntax_tests/data/parsing/grammar/typedefinition/expected/missingPipeBeforeConstructorAttribute.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/typedefinition/expected/missingPipeBeforeConstructorAttribute.res.txt
@@ -1,0 +1,2 @@
+type nonrec t =
+  | One [@as {js|one|js}]

--- a/tests/syntax_tests/data/parsing/grammar/typedefinition/missingPipeBeforeConstructorAttribute.res
+++ b/tests/syntax_tests/data/parsing/grammar/typedefinition/missingPipeBeforeConstructorAttribute.res
@@ -1,0 +1,2 @@
+type t = @as("one") One
+

--- a/tests/syntax_tests/data/printer/typeDef/expected/missingPipeBeforeConstructorAttribute.res.txt
+++ b/tests/syntax_tests/data/printer/typeDef/expected/missingPipeBeforeConstructorAttribute.res.txt
@@ -1,0 +1,1 @@
+type t = | @as("one") One

--- a/tests/syntax_tests/data/printer/typeDef/missingPipeBeforeConstructorAttribute.res
+++ b/tests/syntax_tests/data/printer/typeDef/missingPipeBeforeConstructorAttribute.res
@@ -1,0 +1,2 @@
+type t = @as("one") One
+


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7578 by simply allowing it instead.

@shulhi GPT5 figured most of this out, but to me it looks reasonable and good. WDYT?