### PR TITLE
Error for braced single identifier to record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - Make parser less strict around leading attributes. https://github.com/rescript-lang/rescript/pull/7787
 - Dedicated error message for ternary type mismatch. https://github.com/rescript-lang/rescript/pull/7804
+- Dedicated error message for passing a braced ident to something expected to be a record. https://github.com/rescript-lang/rescript/pull/7806
 
 #### :house: Internal
 

--- a/compiler/ml/error_message_utils.ml
+++ b/compiler/ml/error_message_utils.ml
@@ -105,6 +105,7 @@ type type_clash_context =
       is_constant: string option;
     }
   | FunctionArgument of {optional: bool; name: string option}
+  | BracedIdent
   | Statement of type_clash_statement
   | ForLoopCondition
   | Await
@@ -128,6 +129,7 @@ let context_to_string = function
   | Some IfReturn -> "IfReturn"
   | Some TernaryReturn -> "TernaryReturn"
   | Some Await -> "Await"
+  | Some BracedIdent -> "BracedIdent"
   | None -> "None"
 
 let fprintf = Format.fprintf
@@ -198,7 +200,7 @@ let error_expected_type_text ppf type_clash_context =
     fprintf ppf
       "But you're using @{<info>await@} on this expression, so it is expected \
        to be of type:"
-  | Some MaybeUnwrapOption | None ->
+  | Some MaybeUnwrapOption | Some BracedIdent | None ->
     fprintf ppf "But it's expected to have type:"
 
 let is_record_type ~(extract_concrete_typedecl : extract_concrete_typedecl) ~env
@@ -546,6 +548,35 @@ let print_extra_type_clash_help ~extract_concrete_typedecl ~env loc ppf
        with @{<info>?@} to show you want to pass the option, like: \
        @{<info>?%s@}"
       (Parser.extract_text_at_loc loc)
+  | Some BracedIdent, Some (_, ({desc = Tconstr (_, _, _)} as t))
+    when is_record_type ~extract_concrete_typedecl ~env t ->
+    fprintf ppf
+      "@,\
+       @,\
+       You might have meant to pass this as a record, but wrote it as a block.@,\
+       Braces with a single identifier counts as a block, not a record with a \
+       single (punned) field.@,\
+       @,\
+       Possible solutions: @,\
+       - Return the expected record from the block@,\
+       - Write out the full record with field and value, like: @{<info>%s@}"
+      (match
+         Parser.reprint_expr_at_loc
+           ~mapper:(fun e ->
+             match e.pexp_desc with
+             | Pexp_ident {txt} ->
+               Some
+                 {
+                   e with
+                   pexp_desc =
+                     Pexp_record
+                       ([{lid = Location.mknoloc txt; opt = false; x = e}], None);
+                 }
+             | _ -> None)
+           loc
+       with
+      | None -> ""
+      | Some s -> s)
   | _, Some ({Types.desc = Tconstr (p1, _, _)}, {desc = Tvariant row_desc})
     when Path.same Predef.path_string p1 -> (
     (* Check if we have a string constant that could be a polymorphic variant constructor *)

--- a/compiler/ml/error_message_utils.ml
+++ b/compiler/ml/error_message_utils.ml
@@ -63,7 +63,8 @@ end = struct
     match parse_expr_at_loc loc with
     | Some (exp, comments) -> (
       match mapper exp with
-      | Some exp -> Some (!reprint_source (wrap_in_structure exp) comments)
+      | Some exp ->
+        Some (!reprint_source (wrap_in_structure exp) comments |> String.trim)
       | None -> None)
     | None -> None
 end
@@ -558,8 +559,8 @@ let print_extra_type_clash_help ~extract_concrete_typedecl ~env loc ppf
        single (punned) field.@,\
        @,\
        Possible solutions: @,\
-       - Return the expected record from the block@,\
-       - Write out the full record with field and value, like: @{<info>%s@}"
+       - Write out the full record with field and value, like: @{<info>%s@}@,\
+       - Return the expected record from the block"
       (match
          Parser.reprint_expr_at_loc
            ~mapper:(fun e ->

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -2256,6 +2256,18 @@ let rec type_exp ~context ?recarg env sexp =
 *)
 
 and type_expect ~context ?in_function ?recarg env sexp ty_expected =
+  (* Special errors for braced identifiers passed to records *)
+  let context =
+    match sexp.pexp_desc with
+    | Pexp_ident _ ->
+      if
+        sexp.pexp_attributes
+        |> List.exists (fun (attr, _) -> attr.txt = "res.braces")
+        && is_record_type ~extract_concrete_typedecl ~env ty_expected
+      then Some Error_message_utils.BracedIdent
+      else context
+    | _ -> context
+  in
   let previous_saved_types = Cmt_format.get_saved_types () in
   let exp =
     Builtin_attributes.warning_scope sexp.pexp_attributes (fun () ->
@@ -3394,7 +3406,9 @@ and type_label_exp ~call_context create env loc ty_expected
   (lid, label, {arg with exp_type = instance env arg.exp_type}, opt)
 
 and type_argument ~context ?recarg env sarg ty_expected' ty_expected =
+  print_endline "hey1";
   let texp = type_expect ~context ?recarg env sarg ty_expected' in
+  print_endline "hey";
   unify_exp ~context env texp ty_expected;
   texp
 

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -2263,7 +2263,6 @@ and type_expect ~context ?in_function ?recarg env sexp ty_expected =
       if
         sexp.pexp_attributes
         |> List.exists (fun (attr, _) -> attr.txt = "res.braces")
-        && is_record_type ~extract_concrete_typedecl ~env ty_expected
       then Some Error_message_utils.BracedIdent
       else context
     | _ -> context

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -3406,9 +3406,7 @@ and type_label_exp ~call_context create env loc ty_expected
   (lid, label, {arg with exp_type = instance env arg.exp_type}, opt)
 
 and type_argument ~context ?recarg env sarg ty_expected' ty_expected =
-  print_endline "hey1";
   let texp = type_expect ~context ?recarg env sarg ty_expected' in
-  print_endline "hey";
   unify_exp ~context env texp ty_expected;
   texp
 

--- a/tests/build_tests/super_errors/expected/array_literal_passed_to_tuple.res.expected
+++ b/tests/build_tests/super_errors/expected/array_literal_passed_to_tuple.res.expected
@@ -10,5 +10,4 @@
   This has type: [1;31marray<'a>[0m
   But it's expected to have type: [1;33m(string, string)[0m
 
-  - Fix this by passing a tuple instead of an array, like: [1;33m("hello", "world")
-[0m
+  - Fix this by passing a tuple instead of an array, like: [1;33m("hello", "world")[0m

--- a/tests/build_tests/super_errors/expected/object_literal_passed_when_record_expected.res.expected
+++ b/tests/build_tests/super_errors/expected/object_literal_passed_when_record_expected.res.expected
@@ -13,5 +13,4 @@
   You're passing a [1;31mReScript object[0m where a [1;33mrecord[0m is expected. Objects are written with quoted keys, and records with unquoted keys.
   
   Possible solutions: 
-  - Rewrite the object to a record, like: [1;33m{one: true}
-[0m
+  - Rewrite the object to a record, like: [1;33m{one: true}[0m

--- a/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record.res.expected
+++ b/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record.res.expected
@@ -14,6 +14,5 @@
   Braces with a single identifier counts as a block, not a record with a single (punned) field.
   
   Possible solutions: 
+  - Write out the full record with field and value, like: [1;33m{householdId: householdId}[0m
   - Return the expected record from the block
-  - Write out the full record with field and value, like: [1;33m{householdId: householdId}
-[0m

--- a/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record.res.expected
+++ b/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record.res.expected
@@ -1,0 +1,19 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/pass_braced_identifier_to_record.res[0m:[2m8:15-25[0m
+
+  6 [2m│[0m 
+  7 [2m│[0m let householdId = "12"
+  [1;31m8[0m [2m│[0m let ff = doX({[1;31mhouseholdId[0m})
+  9 [2m│[0m 
+
+  This has type: [1;31mstring[0m
+  But it's expected to have type: [1;33mxx[0m
+  
+  You might have meant to pass this as a record, but wrote it as a block.
+  Braces with a single identifier counts as a block, not a record with a single (punned) field.
+  
+  Possible solutions: 
+  - Return the expected record from the block
+  - Write out the full record with field and value, like: [1;33m{householdId: householdId}
+[0m

--- a/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record_fn_argument.res.expected
+++ b/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record_fn_argument.res.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
-  [36m/.../fixtures/pass_braced_identifier_to_record.res[0m:[2m4:15-25[0m
+  [36m/.../fixtures/pass_braced_identifier_to_record_fn_argument.res[0m:[2m8:15-25[0m
 
-  2 [2m│[0m let householdId = "12"
-  3 [2m│[0m 
-  [1;31m4[0m [2m│[0m let ff: xx = {[1;31mhouseholdId[0m}
-  5 [2m│[0m 
+  6 [2m│[0m 
+  7 [2m│[0m let householdId = "12"
+  [1;31m8[0m [2m│[0m let ff = doX({[1;31mhouseholdId[0m})
+  9 [2m│[0m 
 
   This has type: [1;31mstring[0m
   But it's expected to have type: [1;33mxx[0m

--- a/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record_fn_argument.res.expected
+++ b/tests/build_tests/super_errors/expected/pass_braced_identifier_to_record_fn_argument.res.expected
@@ -14,6 +14,5 @@
   Braces with a single identifier counts as a block, not a record with a single (punned) field.
   
   Possible solutions: 
+  - Write out the full record with field and value, like: [1;33m{householdId: householdId}[0m
   - Return the expected record from the block
-  - Write out the full record with field and value, like: [1;33m{householdId: householdId}
-[0m

--- a/tests/build_tests/super_errors/expected/string_constant_to_polyvariant.res.expected
+++ b/tests/build_tests/super_errors/expected/string_constant_to_polyvariant.res.expected
@@ -11,5 +11,4 @@
   But this function argument is expecting: [1;33m[#ONE | #TWO][0m
 
   Possible solutions:
-  - The constant passed matches one of the expected polymorphic variant constructors. Did you mean to pass this as a polymorphic variant? If so, rewrite [1;33m"ONE"[0m to [1;33m#ONE
-[0m
+  - The constant passed matches one of the expected polymorphic variant constructors. Did you mean to pass this as a polymorphic variant? If so, rewrite [1;33m"ONE"[0m to [1;33m#ONE[0m

--- a/tests/build_tests/super_errors/expected/string_constant_to_variant.res.expected
+++ b/tests/build_tests/super_errors/expected/string_constant_to_variant.res.expected
@@ -11,5 +11,4 @@
   But this function argument is expecting: [1;33mstatus[0m
 
   Possible solutions:
-  - The constant passed matches the runtime representation of one of the expected variant constructors. Did you mean to pass this as a variant constructor? If so, rewrite [1;33m"Active"[0m to [1;33mActive
-[0m
+  - The constant passed matches the runtime representation of one of the expected variant constructors. Did you mean to pass this as a variant constructor? If so, rewrite [1;33m"Active"[0m to [1;33mActive[0m

--- a/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record.res
+++ b/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record.res
@@ -1,0 +1,8 @@
+type xx = {householdId: string}
+
+let doX = ({householdId}) => {
+  householdId
+}
+
+let householdId = "12"
+let ff = doX({householdId})

--- a/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record.res
+++ b/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record.res
@@ -1,8 +1,4 @@
 type xx = {householdId: string}
-
-let doX = ({householdId}) => {
-  householdId
-}
-
 let householdId = "12"
-let ff = doX({householdId})
+
+let ff: xx = {householdId}

--- a/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record_fn_argument.res
+++ b/tests/build_tests/super_errors/fixtures/pass_braced_identifier_to_record_fn_argument.res
@@ -1,0 +1,8 @@
+type xx = {householdId: string}
+
+let doX = ({householdId}) => {
+  householdId
+}
+
+let householdId = "12"
+let ff = doX({householdId})


### PR DESCRIPTION
This is a pretty common gotcha - `{ident}` is counted as a block with an ident, not a record expr with a single field.