### PR TITLE
Try to improve error message about inline record escaping scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - More autocomplete improvements involving modules and module types. https://github.com/rescript-lang/rescript/pull/7795
 - Autocomplete `@react.componentWithProps` attribute. https://github.com/rescript-lang/rescript/pull/7812
 - Add some missing iframe attributes to `domProps`. https://github.com/rescript-lang/rescript/pull/7813
+- Polish error message for inline record escaping scope. https://github.com/rescript-lang/rescript/pull/7808
 
 #### :house: Internal
 

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4598,8 +4598,14 @@ let report_error env loc ppf error =
       "@[Exception patterns must be at the top level of a match case.@]"
   | Inlined_record_escape ->
     fprintf ppf
-      "@[This form is not allowed as the type of the inlined record could \
-       escape.@]"
+      "@[This use of an inlined record is not allowed: its anonymous type \
+       would escape its constructor scope.@,\
+       @,\
+       Possible solutions: @,\
+       - Destructure the fields you're interested in from the inline record@,\
+       - Change the underlying type to use a defined record as payload instead \
+       of an inline record. That will let you use the payload without \
+       destructuring it first"
   | Inlined_record_expected ->
     fprintf ppf "@[This constructor expects an inlined record argument.@]"
   | Invalid_extension_constructor_payload ->

--- a/tests/build_tests/super_errors/expected/inline_record_escape.res.expected
+++ b/tests/build_tests/super_errors/expected/inline_record_escape.res.expected
@@ -1,0 +1,14 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/inline_record_escape.res[0m:[2m5:15[0m
+
+  3 [2m│[0m let g = (v: x) =>
+  4 [2m│[0m   switch v {
+  [1;31m5[0m [2m│[0m   | One(r) => [1;31mr[0m
+  6 [2m│[0m   }
+  7 [2m│[0m 
+
+  This use of an inlined record is not allowed: its anonymous type would escape its constructor scope.
+  Possible solutions: 
+  - Destructure the fields you're interested in from the inline record
+  - Change the underlying type to use a defined record as payload instead of an inline record. That will let you use the payload without destructuring it first

--- a/tests/build_tests/super_errors/fixtures/inline_record_escape.res
+++ b/tests/build_tests/super_errors/fixtures/inline_record_escape.res
@@ -1,0 +1,6 @@
+type x = One({test: bool})
+
+let g = (v: x) =>
+  switch v {
+  | One(r) => r
+  }


### PR DESCRIPTION
An attempt to improve the (IMO quite cryptic) error message for inline records possibly escaping its scope. What do you think?