### PR TITLE
Do not include .ast/.iast files in lib-ocaml.zip artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lib-ocaml
-          path: packages/@rescript/runtime/lib/ocaml
+          path: |
+            packages/@rescript/runtime/lib/ocaml
+            !packages/@rescript/runtime/lib/ocaml/*.ast
+            !packages/@rescript/runtime/lib/ocaml/*.iast
 
       - name: Generate API Docs
         if: ${{ matrix.generate_api_docs }}


### PR DESCRIPTION
(No effect on the npm package, they are already excluded there.)