### PR TITLE
CI: windows-latest -> windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             upload_binaries: true
             node-target: darwin-arm64
             rust-target: aarch64-apple-darwin
-          - os: windows-latest
+          - os: windows-2022
             ocaml_compiler: 5.3.0
             upload_binaries: true
             node-target: win32-x64
@@ -539,7 +539,7 @@ jobs:
           - os: macos-14
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
-          - os: windows-latest
+          - os: windows-2022
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: "1"
@@ -590,7 +590,7 @@ jobs:
           - os: macos-14
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
-          - os: windows-latest
+          - os: windows-2022
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: "1"
@@ -645,7 +645,7 @@ jobs:
           - os: macos-14
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
-          - os: windows-latest
+          - os: windows-2022
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: "1"


### PR DESCRIPTION
The default will change to `windows-2025` on Sep 2.

However, moving to `windows-2025` will require updating setup-ocaml and adapting our caching logic to the changed paths, see https://github.com/ocaml/setup-ocaml/pull/991.