### PR TITLE
Fix generation of interfaces for module types containing multiple type constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix generation of interfaces for module types containing multiple type constraints. https://github.com/rescript-lang/rescript/pull/7825
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/compiler/syntax/src/res_outcome_printer.ml
+++ b/compiler/syntax/src/res_outcome_printer.ml
@@ -217,14 +217,18 @@ let rec print_out_type_doc (out_type : Outcometree.out_type) =
           Doc.join ~sep:Doc.line
             ((List.map2 [@doesNotRaise])
                (fun lbl typ ->
-                 Doc.concat
-                   [
-                     Doc.text
-                       (if i.contents > 0 then "and type " else "with type ");
-                     Doc.text lbl;
-                     Doc.text " = ";
-                     print_out_type_doc typ;
-                   ])
+                 let result =
+                   Doc.concat
+                     [
+                       Doc.text
+                         (if i.contents > 0 then "and type " else "with type ");
+                       Doc.text lbl;
+                       Doc.text " = ";
+                       print_out_type_doc typ;
+                     ]
+                 in
+                 incr i;
+                 result)
                labels types)
         in
         Doc.indent (Doc.concat [Doc.line; package])

--- a/tests/analysis_tests/tests/src/CreateInterface.res
+++ b/tests/analysis_tests/tests/src/CreateInterface.res
@@ -171,3 +171,24 @@ module ComponentWithPolyProp = {
     <div className />
   }
 }
+
+module OrderedSet = {
+  type t<'a, 'identity> = {
+    cmp: ('a, 'a) => int,
+    set: Belt.Set.t<'a, 'identity>,
+    array: array<'a>,
+  }
+
+  let make = (
+    type value identity,
+    ~id: module(Belt.Id.Comparable with type t = value and type identity = identity),
+  ): t<value, identity> => {
+    let module(M) = id
+
+    {
+      cmp: M.cmp->Belt.Id.getCmpInternal,
+      set: Belt.Set.make(~id),
+      array: [],
+    }
+  }
+}

--- a/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
@@ -124,4 +124,12 @@ module ComponentWithPolyProp: {
   @react.component
   let make: (~size: [< #large | #small]=?) => Jsx.element
 }
+module OrderedSet: {
+  type t<'a, 'identity> = {
+    cmp: ('a, 'a) => int,
+    set: Belt.Set.t<'a, 'identity>,
+    array: array<'a>,
+  }
+  let make: (~id: module(Belt.Id.Comparable with type identity = 'a with type t = 'b)) => t<'b, 'a>
+}
 

--- a/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
@@ -130,6 +130,6 @@ module OrderedSet: {
     set: Belt.Set.t<'a, 'identity>,
     array: array<'a>,
   }
-  let make: (~id: module(Belt.Id.Comparable with type identity = 'a with type t = 'b)) => t<'b, 'a>
+  let make: (~id: module(Belt.Id.Comparable with type identity = 'a and type t = 'b)) => t<'b, 'a>
 }
 


### PR DESCRIPTION
When creating an interface file with `rescript-editor-analysis createInterface SomeFile.res`, invalid syntax was being generated for module types containing multiple type constraints.

For example:

```rescript
let make = (
  type value identity,
  ~id: module(Belt.Id.Comparable with type t = value and type identity = identity),
): t<value, identity> => {
  // ...
}
```

was being converted to interface:

```rescript
let make: (~id: module(Belt.Id.Comparable with type identity = 'a with type t = 'b)) => t<'b, 'a>
```

but `with type identity = 'a with type t = 'b` is invalid syntax and should have been `with type identity = 'a and type t = 'b` (notice the second `with` becomes `and`).

`res_outcome_printer` did have existing logic to emit `and` instead of `with`, but it relied on a ref counter that was not being incremented.