### PR TITLE
Add `Stdlib.TypedArray` completions to stdlib typed array types

### DIFF
--- a/packages/@rescript/runtime/Stdlib_BigInt64Array.res
+++ b/packages/@rescript/runtime/Stdlib_BigInt64Array.res
@@ -1,5 +1,6 @@
 /** The `BigInt64Array` typed array represents an array of 64-bit signed integers in platform byte order. See [BigInt64Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<bigint>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_BigUint64Array.res
+++ b/packages/@rescript/runtime/Stdlib_BigUint64Array.res
@@ -1,5 +1,6 @@
 /** The `BigUint64Array` typed array represents an array of 64-bit unsigned integers in platform byte order. See [BigUint64Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<bigint>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Float32Array.res
+++ b/packages/@rescript/runtime/Stdlib_Float32Array.res
@@ -1,5 +1,6 @@
 /** The `Float32Array` typed array represents an array of 32-bit floating point numbers in platform byte order. See [Float32Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<float>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Float64Array.res
+++ b/packages/@rescript/runtime/Stdlib_Float64Array.res
@@ -1,5 +1,6 @@
 /** The `Float64Array` typed array represents an array of 64-bit floating point numbers in platform byte order. See [Float64Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<float>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Int16Array.res
+++ b/packages/@rescript/runtime/Stdlib_Int16Array.res
@@ -1,5 +1,6 @@
 /** The `Int16Array` typed array represents an array of twos-complement 16-bit signed integers in platform byte order. See [Int16Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Int32Array.res
+++ b/packages/@rescript/runtime/Stdlib_Int32Array.res
@@ -1,5 +1,6 @@
 /** The `Int32Array` typed array represents an array of twos-complemenet 32-bit signed integers in platform byte order. See [Int32Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Int8Array.res
+++ b/packages/@rescript/runtime/Stdlib_Int8Array.res
@@ -1,5 +1,6 @@
 /** The `Int8Array` typed array represents an array of twos-complement 8-bit signed integers. See [Int8Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Uint16Array.res
+++ b/packages/@rescript/runtime/Stdlib_Uint16Array.res
@@ -1,5 +1,6 @@
 /** The `Uint16Array` typed array represents an array of 16-bit unsigned integers in platform byte order. See [Uint16Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Uint32Array.res
+++ b/packages/@rescript/runtime/Stdlib_Uint32Array.res
@@ -1,5 +1,6 @@
 /** The `Uint32Array` typed array represents an array of 32-bit unsigned integers in platform byte order. See [Uint32Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Uint8Array.res
+++ b/packages/@rescript/runtime/Stdlib_Uint8Array.res
@@ -1,5 +1,6 @@
 /** The `Uint8Array` typed array represents an array of 8-bit unsigned integers. See [Uint8Array on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/packages/@rescript/runtime/Stdlib_Uint8ClampedArray.res
+++ b/packages/@rescript/runtime/Stdlib_Uint8ClampedArray.res
@@ -1,5 +1,6 @@
 /** The `Uint8ClampedArray` typed array represents an array of 8-bit unsigned integers clamped to 0-255. See [Uint8ClampedArray on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray)
 */
+@editor.completeFrom(Stdlib.TypedArray)
 type t = Stdlib_TypedArray.t<int>
 
 module Constants = {

--- a/tests/analysis_tests/tests/src/CompletionTypedArrays.res
+++ b/tests/analysis_tests/tests/src/CompletionTypedArrays.res
@@ -1,0 +1,43 @@
+let bigInt64Array = BigInt64Array.fromLength(0)
+// bigInt64Array.
+//               ^com
+
+let bigUint64Array = BigUint64Array.fromLength(0)
+// bigUint64Array.
+//                ^com
+
+let float32Array = Float32Array.fromLength(0)
+// float32Array.
+//              ^com
+
+let float64Array = Float64Array.fromLength(0)
+// float64Array.
+//              ^com
+
+let int16Array = Int16Array.fromLength(0)
+// int16Array.
+//            ^com
+
+let int32Array = Int32Array.fromLength(0)
+// int32Array.
+//            ^com
+
+let int8Array = Int8Array.fromLength(0)
+// int8Array.
+//           ^com
+
+let uint16Array = Uint16Array.fromLength(0)
+// uint16Array.
+//             ^com
+
+let uint32Array = Uint32Array.fromLength(0)
+// uint32Array.
+//             ^com
+
+let uint8Array = Uint8Array.fromLength(0)
+// uint8Array.
+//            ^com
+
+let uint8ClampedArray = Uint8ClampedArray.fromLength(0)
+// uint8ClampedArray.
+//                   ^com

--- a/tests/analysis_tests/tests/src/expected/CompletionTypedArrays.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionTypedArrays.res.txt
@@ -1,0 +1,980 @@
+Complete src/CompletionTypedArrays.res 1:17
+posCursor:[1:17] posNoWhite:[1:16] Found expr:[1:3->1:17]
+Pexp_field [1:3->1:16] _:[4:0->1:17]
+Completable: Cpath Value[bigInt64Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[bigInt64Array].""
+ContextPath Value[bigInt64Array]
+Path bigInt64Array
+ContextPath Value[bigInt64Array]->
+ContextPath Value[bigInt64Array]
+Path bigInt64Array
+CPPipe pathFromEnv:Stdlib.BigInt64Array found:false
+Path Stdlib.BigInt64Array.
+Path 
+[{
+    "label": "->BigInt64Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(bigIntArray)` ignores the provided bigIntArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->BigInt64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 5:18
+posCursor:[5:18] posNoWhite:[5:17] Found expr:[5:3->5:18]
+Pexp_field [5:3->5:17] _:[8:0->5:18]
+Completable: Cpath Value[bigUint64Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[bigUint64Array].""
+ContextPath Value[bigUint64Array]
+Path bigUint64Array
+ContextPath Value[bigUint64Array]->
+ContextPath Value[bigUint64Array]
+Path bigUint64Array
+CPPipe pathFromEnv:Stdlib.BigUint64Array found:false
+Path Stdlib.BigUint64Array.
+Path 
+[{
+    "label": "->BigUint64Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(bigUintArray)` ignores the provided bigUintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->BigUint64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 9:16
+posCursor:[9:16] posNoWhite:[9:15] Found expr:[9:3->9:16]
+Pexp_field [9:3->9:15] _:[12:0->9:16]
+Completable: Cpath Value[float32Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[float32Array].""
+ContextPath Value[float32Array]
+Path float32Array
+ContextPath Value[float32Array]->
+ContextPath Value[float32Array]
+Path float32Array
+CPPipe pathFromEnv:Stdlib.Float32Array found:false
+Path Stdlib.Float32Array.
+Path 
+[{
+    "label": "->Float32Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(floatArray)` ignores the provided floatArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Float32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 13:16
+posCursor:[13:16] posNoWhite:[13:15] Found expr:[13:3->13:16]
+Pexp_field [13:3->13:15] _:[16:0->13:16]
+Completable: Cpath Value[float64Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[float64Array].""
+ContextPath Value[float64Array]
+Path float64Array
+ContextPath Value[float64Array]->
+ContextPath Value[float64Array]
+Path float64Array
+CPPipe pathFromEnv:Stdlib.Float64Array found:false
+Path Stdlib.Float64Array.
+Path 
+[{
+    "label": "->Float64Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(floatArray)` ignores the provided floatArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Float64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 17:14
+posCursor:[17:14] posNoWhite:[17:13] Found expr:[17:3->17:14]
+Pexp_field [17:3->17:13] _:[20:0->17:14]
+Completable: Cpath Value[int16Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[int16Array].""
+ContextPath Value[int16Array]
+Path int16Array
+ContextPath Value[int16Array]->
+ContextPath Value[int16Array]
+Path int16Array
+CPPipe pathFromEnv:Stdlib.Int16Array found:false
+Path Stdlib.Int16Array.
+Path 
+[{
+    "label": "->Int16Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(intArray)` ignores the provided intArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Int16Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 21:14
+posCursor:[21:14] posNoWhite:[21:13] Found expr:[21:3->21:14]
+Pexp_field [21:3->21:13] _:[24:0->21:14]
+Completable: Cpath Value[int32Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[int32Array].""
+ContextPath Value[int32Array]
+Path int32Array
+ContextPath Value[int32Array]->
+ContextPath Value[int32Array]
+Path int32Array
+CPPipe pathFromEnv:Stdlib.Int32Array found:false
+Path Stdlib.Int32Array.
+Path 
+[{
+    "label": "->Int32Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(intArray)` ignores the provided intArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Int32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 25:13
+posCursor:[25:13] posNoWhite:[25:12] Found expr:[25:3->25:13]
+Pexp_field [25:3->25:12] _:[28:0->25:13]
+Completable: Cpath Value[int8Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[int8Array].""
+ContextPath Value[int8Array]
+Path int8Array
+ContextPath Value[int8Array]->
+ContextPath Value[int8Array]
+Path int8Array
+CPPipe pathFromEnv:Stdlib.Int8Array found:false
+Path Stdlib.Int8Array.
+Path Stdlib.TypedArray.
+Path 
+[{
+    "label": "->Int8Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(intArray)` ignores the provided intArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Int8Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 25, "character": 12}, "end": {"line": 25, "character": 13}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 29:15
+posCursor:[29:15] posNoWhite:[29:14] Found expr:[29:3->29:15]
+Pexp_field [29:3->29:14] _:[32:0->29:15]
+Completable: Cpath Value[uint16Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[uint16Array].""
+ContextPath Value[uint16Array]
+Path uint16Array
+ContextPath Value[uint16Array]->
+ContextPath Value[uint16Array]
+Path uint16Array
+CPPipe pathFromEnv:Stdlib.Uint16Array found:false
+Path Stdlib.Uint16Array.
+Path 
+[{
+    "label": "->Uint16Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Uint16Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 33:15
+posCursor:[33:15] posNoWhite:[33:14] Found expr:[33:3->33:15]
+Pexp_field [33:3->33:14] _:[36:0->33:15]
+Completable: Cpath Value[uint32Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[uint32Array].""
+ContextPath Value[uint32Array]
+Path uint32Array
+ContextPath Value[uint32Array]->
+ContextPath Value[uint32Array]
+Path uint32Array
+CPPipe pathFromEnv:Stdlib.Uint32Array found:false
+Path Stdlib.Uint32Array.
+Path 
+[{
+    "label": "->Uint32Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Uint32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 37:14
+posCursor:[37:14] posNoWhite:[37:13] Found expr:[37:3->37:14]
+Pexp_field [37:3->37:13] _:[40:0->37:14]
+Completable: Cpath Value[uint8Array].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[uint8Array].""
+ContextPath Value[uint8Array]
+Path uint8Array
+ContextPath Value[uint8Array]->
+ContextPath Value[uint8Array]
+Path uint8Array
+CPPipe pathFromEnv:Stdlib.Uint8Array found:false
+Path Stdlib.Uint8Array.
+Path 
+[{
+    "label": "->Uint8Array.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Uint8Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }]
+
+Complete src/CompletionTypedArrays.res 41:21
+posCursor:[41:21] posNoWhite:[41:20] Found expr:[41:3->41:21]
+Pexp_field [41:3->41:20] _:[44:0->41:21]
+Completable: Cpath Value[uint8ClampedArray].""
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[uint8ClampedArray].""
+ContextPath Value[uint8ClampedArray]
+Path uint8ClampedArray
+ContextPath Value[uint8ClampedArray]->
+ContextPath Value[uint8ClampedArray]
+Path uint8ClampedArray
+CPPipe pathFromEnv:Stdlib.Uint8ClampedArray found:false
+Path Stdlib.Uint8ClampedArray.
+Path 
+[{
+    "label": "->Uint8ClampedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->Uint8ClampedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }]
+

--- a/tests/analysis_tests/tests/src/expected/CompletionTypedArrays.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionTypedArrays.res.txt
@@ -12,6 +12,7 @@ ContextPath Value[bigInt64Array]
 Path bigInt64Array
 CPPipe pathFromEnv:Stdlib.BigInt64Array found:false
 Path Stdlib.BigInt64Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->BigInt64Array.ignore",
@@ -21,6 +22,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(bigIntArray)` ignores the provided bigIntArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->BigInt64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 1, "character": 16}, "end": {"line": 1, "character": 17}},
       "newText": ""
@@ -41,6 +702,7 @@ ContextPath Value[bigUint64Array]
 Path bigUint64Array
 CPPipe pathFromEnv:Stdlib.BigUint64Array found:false
 Path Stdlib.BigUint64Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->BigUint64Array.ignore",
@@ -50,6 +712,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(bigUintArray)` ignores the provided bigUintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->BigUint64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 5, "character": 17}, "end": {"line": 5, "character": 18}},
       "newText": ""
@@ -70,6 +1392,7 @@ ContextPath Value[float32Array]
 Path float32Array
 CPPipe pathFromEnv:Stdlib.Float32Array found:false
 Path Stdlib.Float32Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Float32Array.ignore",
@@ -79,6 +1402,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(floatArray)` ignores the provided floatArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Float32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 9, "character": 15}, "end": {"line": 9, "character": 16}},
       "newText": ""
@@ -99,6 +2082,7 @@ ContextPath Value[float64Array]
 Path float64Array
 CPPipe pathFromEnv:Stdlib.Float64Array found:false
 Path Stdlib.Float64Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Float64Array.ignore",
@@ -108,6 +2092,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(floatArray)` ignores the provided floatArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Float64Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 13, "character": 15}, "end": {"line": 13, "character": 16}},
       "newText": ""
@@ -128,6 +2772,7 @@ ContextPath Value[int16Array]
 Path int16Array
 CPPipe pathFromEnv:Stdlib.Int16Array found:false
 Path Stdlib.Int16Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Int16Array.ignore",
@@ -137,6 +2782,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(intArray)` ignores the provided intArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Int16Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 17, "character": 13}, "end": {"line": 17, "character": 14}},
       "newText": ""
@@ -157,6 +3462,7 @@ ContextPath Value[int32Array]
 Path int32Array
 CPPipe pathFromEnv:Stdlib.Int32Array found:false
 Path Stdlib.Int32Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Int32Array.ignore",
@@ -166,6 +3472,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(intArray)` ignores the provided intArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Int32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 21, "character": 13}, "end": {"line": 21, "character": 14}},
       "newText": ""
@@ -876,6 +4842,7 @@ ContextPath Value[uint16Array]
 Path uint16Array
 CPPipe pathFromEnv:Stdlib.Uint16Array found:false
 Path Stdlib.Uint16Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Uint16Array.ignore",
@@ -885,6 +4852,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Uint16Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 29, "character": 14}, "end": {"line": 29, "character": 15}},
       "newText": ""
@@ -905,6 +5532,7 @@ ContextPath Value[uint32Array]
 Path uint32Array
 CPPipe pathFromEnv:Stdlib.Uint32Array found:false
 Path Stdlib.Uint32Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Uint32Array.ignore",
@@ -914,6 +5542,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Uint32Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 33, "character": 14}, "end": {"line": 33, "character": 15}},
       "newText": ""
@@ -934,6 +6222,7 @@ ContextPath Value[uint8Array]
 Path uint8Array
 CPPipe pathFromEnv:Stdlib.Uint8Array found:false
 Path Stdlib.Uint8Array.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Uint8Array.ignore",
@@ -943,6 +6232,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Uint8Array.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 37, "character": 13}, "end": {"line": 37, "character": 14}},
       "newText": ""
@@ -963,6 +6912,7 @@ ContextPath Value[uint8ClampedArray]
 Path uint8ClampedArray
 CPPipe pathFromEnv:Stdlib.Uint8ClampedArray found:false
 Path Stdlib.Uint8ClampedArray.
+Path Stdlib.TypedArray.
 Path 
 [{
     "label": "->Uint8ClampedArray.ignore",
@@ -972,6 +6922,666 @@ Path
     "documentation": {"kind": "markdown", "value": "\n  `ignore(uintArray)` ignores the provided uintArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
     "sortText": "ignore",
     "insertText": "->Uint8ClampedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndexWithIndex",
+    "insertText": "->TypedArray.findLastIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "lastIndexOf",
+    "insertText": "->TypedArray.lastIndexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLastWithIndex",
+    "insertText": "->TypedArray.findLastWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLast",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findLast",
+    "insertText": "->TypedArray.findLast",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filter",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filter",
+    "insertText": "->TypedArray.filter",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteLength",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteLength",
+    "insertText": "->TypedArray.byteLength",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.ignore",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": {"kind": "markdown", "value": "\n  `ignore(typedArray)` ignores the provided typedArray and returns unit.\n\n  This helper is useful when you want to discard a value (for example, the result of an operation with side effects)\n  without having to store or process it further.\n"},
+    "sortText": "ignore",
+    "insertText": "->TypedArray.ignore",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRightWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRightWithIndex",
+    "insertText": "->TypedArray.reduceRightWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceRight",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceRight",
+    "insertText": "->TypedArray.reduceRight",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.joinWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, string) => string",
+    "documentation": null,
+    "sortText": "joinWith",
+    "insertText": "->TypedArray.joinWith",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.buffer",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => ArrayBuffer.t",
+    "documentation": null,
+    "sortText": "buffer",
+    "insertText": "->TypedArray.buffer",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduce",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduce",
+    "insertText": "->TypedArray.reduce",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEachWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => unit) => unit",
+    "documentation": null,
+    "sortText": "forEachWithIndex",
+    "insertText": "->TypedArray.forEachWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copy",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "copy",
+    "insertText": "->TypedArray.copy",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.someWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "someWithIndex",
+    "insertText": "->TypedArray.someWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndexWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => int",
+    "documentation": null,
+    "sortText": "findIndexWithIndex",
+    "insertText": "->TypedArray.findIndexWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sliceToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `slice` instead\n\n"},
+    "sortText": "sliceToEnd",
+    "insertText": "->TypedArray.sliceToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.slice",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "slice",
+    "insertText": "->TypedArray.slice",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findLastIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findLastIndex",
+    "insertText": "->TypedArray.findLastIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.includes",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => bool",
+    "documentation": null,
+    "sortText": "includes",
+    "insertText": "->TypedArray.includes",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `fill` instead\n\n"},
+    "sortText": "fillToEnd",
+    "insertText": "->TypedArray.fillToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fillAll",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "fillAll",
+    "insertText": "->TypedArray.fillAll",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.find",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "find",
+    "insertText": "->TypedArray.find",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarrayToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~start: int) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `subarray` instead\n\n"},
+    "sortText": "subarrayToEnd",
+    "insertText": "->TypedArray.subarrayToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.set",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => unit",
+    "documentation": null,
+    "sortText": "set",
+    "insertText": "->TypedArray.set",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toLocaleString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toLocaleString",
+    "insertText": "->TypedArray.toLocaleString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.lastIndexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "lastIndexOfFrom",
+    "insertText": "->TypedArray.lastIndexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => int",
+    "documentation": null,
+    "sortText": "findIndex",
+    "insertText": "->TypedArray.findIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.filterWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => t<'a>",
+    "documentation": null,
+    "sortText": "filterWithIndex",
+    "insertText": "->TypedArray.filterWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.sort",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => unit",
+    "documentation": null,
+    "sortText": "sort",
+    "insertText": "->TypedArray.sort",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.mapWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "mapWithIndex",
+    "insertText": "->TypedArray.mapWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.every",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "every",
+    "insertText": "->TypedArray.every",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.length",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "length",
+    "insertText": "->TypedArray.length",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOf",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a) => int",
+    "documentation": null,
+    "sortText": "indexOf",
+    "insertText": "->TypedArray.indexOf",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithinToEnd",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, ~target: int, ~start: int) => array<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use `copyWithin` instead\n\n"},
+    "sortText": "copyWithinToEnd",
+    "insertText": "->TypedArray.copyWithinToEnd",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.some",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => bool) => bool",
+    "documentation": null,
+    "sortText": "some",
+    "insertText": "->TypedArray.some",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reduceWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('b, 'a, int) => 'b, 'b) => 'b",
+    "documentation": null,
+    "sortText": "reduceWithIndex",
+    "insertText": "->TypedArray.reduceWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.map",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => 'b) => t<'b>",
+    "documentation": null,
+    "sortText": "map",
+    "insertText": "->TypedArray.map",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toSorted",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, 'a) => Ordering.t) => t<'a>",
+    "documentation": null,
+    "sortText": "toSorted",
+    "insertText": "->TypedArray.toSorted",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyAllWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int) => array<'a>",
+    "documentation": null,
+    "sortText": "copyAllWithin",
+    "insertText": "->TypedArray.copyAllWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.subarray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "subarray",
+    "insertText": "->TypedArray.subarray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArray",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>) => unit",
+    "documentation": null,
+    "sortText": "setArray",
+    "insertText": "->TypedArray.setArray",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.get",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int) => option<'a>",
+    "documentation": null,
+    "sortText": "get",
+    "insertText": "->TypedArray.get",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.with",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, int, 'a) => t<'a>",
+    "documentation": null,
+    "sortText": "with",
+    "insertText": "->TypedArray.with",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toReversed",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => t<'a>",
+    "documentation": null,
+    "sortText": "toReversed",
+    "insertText": "->TypedArray.toReversed",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.copyWithin",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ~target: int, ~start: int, ~end: int=?) => array<'a>",
+    "documentation": null,
+    "sortText": "copyWithin",
+    "insertText": "->TypedArray.copyWithin",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.everyWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => bool",
+    "documentation": null,
+    "sortText": "everyWithIndex",
+    "insertText": "->TypedArray.everyWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => string",
+    "documentation": null,
+    "sortText": "toString",
+    "insertText": "->TypedArray.toString",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.setArrayFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, array<'a>, int) => unit",
+    "documentation": null,
+    "sortText": "setArrayFrom",
+    "insertText": "->TypedArray.setArrayFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.forEach",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a => unit) => unit",
+    "documentation": null,
+    "sortText": "forEach",
+    "insertText": "->TypedArray.forEach",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.findWithIndex",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, ('a, int) => bool) => option<'a>",
+    "documentation": null,
+    "sortText": "findWithIndex",
+    "insertText": "->TypedArray.findWithIndex",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.fill",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, ~start: int, ~end: int=?) => t<'a>",
+    "documentation": null,
+    "sortText": "fill",
+    "insertText": "->TypedArray.fill",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.indexOfFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t<'a>, 'a, int) => int",
+    "documentation": null,
+    "sortText": "indexOfFrom",
+    "insertText": "->TypedArray.indexOfFrom",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.reverse",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => unit",
+    "documentation": null,
+    "sortText": "reverse",
+    "insertText": "->TypedArray.reverse",
+    "additionalTextEdits": [{
+      "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
+      "newText": ""
+      }]
+  }, {
+    "label": "->TypedArray.byteOffset",
+    "kind": 12,
+    "tags": [],
+    "detail": "t<'a> => int",
+    "documentation": null,
+    "sortText": "byteOffset",
+    "insertText": "->TypedArray.byteOffset",
     "additionalTextEdits": [{
       "range": {"start": {"line": 41, "character": 20}, "end": {"line": 41, "character": 21}},
       "newText": ""


### PR DESCRIPTION
The standard library's typed arrays use `Stdlib_TypedArray.t` but we don't currently show completions for `Stdlib.TypedArray`.

I've fixed this by adding `@editor.completeFrom(Stdlib.TypedArray)` to each typed array's type.