### PR TITLE
Error messages cleanup: Don't please the user

### DIFF
--- a/compiler/bsb/bsb_exception.ml
+++ b/compiler/bsb/bsb_exception.ml
@@ -52,7 +52,7 @@ let print (fmt : Format.formatter) (x : error) =
         "File \"rescript.json\", line 1\n\
          @{<error>Error:@} package @{<error>%s@} is not found\n\
          It's the basic, required package. If you have it installed globally,\n\
-         Please run `npm link rescript` to make it available"
+         Run `npm link rescript` to make it available."
         name
     else
       Format.fprintf fmt
@@ -64,7 +64,7 @@ let print (fmt : Format.formatter) (x : error) =
     Format.fprintf fmt
       "File %S, line %d:\n\
        @{<error>Error:@} %s \n\
-       For more details, please check out the schema at \
+       For more details, check out the schema at \
        https://rescript-lang.org/docs/manual/latest/build-configuration-schema"
       pos.pos_fname pos.pos_lnum s
   | Invalid_spec s ->

--- a/compiler/core/js_packages_info.ml
+++ b/compiler/core/js_packages_info.ml
@@ -183,7 +183,7 @@ let get_output_dir (info : t) ~package_dir module_system =
 
 let add_npm_package_path (packages_info : t) (s : string) : t =
   if is_empty packages_info then
-    Bsc_args.bad_arg "please set package name first using -bs-package-name "
+    Bsc_args.bad_arg "Set package name first using -bs-package-name"
   else
     let handle_module_system module_system =
       match module_system_of_string module_system with

--- a/compiler/depends/bs_exception.ml
+++ b/compiler/depends/bs_exception.ml
@@ -64,7 +64,7 @@ let report_error ppf = function
   | Bs_main_not_exist main -> Format.fprintf ppf "File %s not found " main
   | Bs_package_not_found package ->
     Format.fprintf ppf
-      "Package %s not found or %s/lib/ocaml does not exist or please set \
+      "Package %s not found or %s/lib/ocaml does not exist or set \
        npm_config_prefix correctly"
       package package
   | Bs_invalid_path path -> Format.pp_print_string ppf ("Invalid path: " ^ path)

--- a/compiler/ext/warnings.ml
+++ b/compiler/ext/warnings.ml
@@ -423,11 +423,11 @@ let message = function
   | Unused_rec_flag -> "unused rec flag."
   | Ambiguous_name ([s], tl, false) ->
     s ^ " belongs to several types: " ^ String.concat " " tl
-    ^ "\nThe first one was selected. Please disambiguate if this is wrong."
+    ^ "\nThe first one was selected. Disambiguate if this is wrong."
   | Ambiguous_name (_, _, false) -> assert false
   | Ambiguous_name (_slist, tl, true) ->
     "these field labels belong to several types: " ^ String.concat " " tl
-    ^ "\nThe first one was selected. Please disambiguate if this is wrong."
+    ^ "\nThe first one was selected. Disambiguate if this is wrong."
   | Nonoptional_label s -> "the label " ^ s ^ " is not optional."
   | Open_shadow_identifier (kind, s) ->
     Printf.sprintf

--- a/compiler/frontend/bs_ast_invariant.ml
+++ b/compiler/frontend/bs_ast_invariant.ml
@@ -86,7 +86,7 @@ let emit_external_warnings : iterator =
               [{ptype_kind = Ptype_variant ({pcd_res = Some _} :: _)}] ) ->
           Location.raise_errorf ~loc:str_item.pstr_loc
             "GADTs require recursive type syntax.\n\
-             Please define your type using `type rec` instead of `type`.\n\
+             Define your type using `type rec` instead of `type`.\n\
              Example: type rec t = ..."
         | _ -> super.structure_item self str_item);
     expr =

--- a/compiler/ml/typemod.ml
+++ b/compiler/ml/typemod.ml
@@ -1821,7 +1821,7 @@ let report_error ppf = function
   | Cannot_eliminate_dependency mty ->
     fprintf ppf
       "@[This functor has type@ %a@ The parameter cannot be eliminated in the \
-       result type.@  Please bind the argument to a module identifier.@]"
+       result type.@  Bind the argument to a module identifier.@]"
       modtype mty
   | Signature_expected -> fprintf ppf "This module type is not a signature"
   | Structure_expected mty ->

--- a/compiler/syntax/src/jsx_v4.ml
+++ b/compiler/syntax/src/jsx_v4.ml
@@ -809,8 +809,7 @@ let map_binding ~config ~empty_loc ~pstr_loc ~file_name ~rec_flag binding =
             | Pexp_fun {arg_label = Labelled _ | Optional _} ->
               Location.raise_errorf ~loc:expr.pexp_loc
                 "Components using React.forwardRef cannot use \
-                 @react.componentWithProps. Please use @react.component \
-                 instead."
+                 @react.componentWithProps. Use @react.component instead."
             | Pexp_fun {arg_label = Nolabel; rhs = body} ->
               check_invalid_forward_ref body
             | _ -> ()

--- a/tests/build_tests/super_errors/expected/gadt_rec_missing.res.expected
+++ b/tests/build_tests/super_errors/expected/gadt_rec_missing.res.expected
@@ -12,5 +12,5 @@
   9 [2m│[0m 
 
   GADTs require recursive type syntax.
-Please define your type using `type rec` instead of `type`.
+Define your type using `type rec` instead of `type`.
 Example: type rec t = ...

--- a/tests/build_tests/super_errors/expected/react_component_with_props.res.expected
+++ b/tests/build_tests/super_errors/expected/react_component_with_props.res.expected
@@ -12,4 +12,4 @@
   14 [2m│[0m   )
   15 [2m│[0m }
 
-  Components using React.forwardRef cannot use @react.componentWithProps. Please use @react.component instead.
+  Components using React.forwardRef cannot use @react.componentWithProps. Use @react.component instead.


### PR DESCRIPTION
> Avoid the word “please,” except in situations in which the user is asked to do something inconvenient (such as creating a GitHub issue) or the software is to blame for the situation.

Fixes this: https://github.com/rescript-lang/rescript/pull/7830#discussion_r2316669680