### PR TITLE
Fix experimental rescript config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Show `Stdlib.Null` and `Stdlib.Nullable` completions for `Stdlib.null<'a>` and `Stdlib.nullable<'a>` types, respectively. https://github.com/rescript-lang/rescript/pull/7826
 - Fix generation of interfaces for module types containing multiple type constraints. https://github.com/rescript-lang/rescript/pull/7825
 - JSX preserve mode: fix "make is not a valid component name". https://github.com/rescript-lang/rescript/pull/7831
+- Rewatch: include parser arguments of experimental features. https://github.com/rescript-lang/rescript/pull/7836
 
 #### :memo: Documentation
 

--- a/rewatch/src/build/parse.rs
+++ b/rewatch/src/build/parse.rs
@@ -253,6 +253,7 @@ pub fn parser_args(
     let jsx_module_args = root_config.get_jsx_module_args();
     let jsx_mode_args = root_config.get_jsx_mode_args();
     let jsx_preserve_args = root_config.get_jsx_preserve_args();
+    let experimental_features_args = root_config.get_experimental_features_args();
     let bsc_flags = config::flatten_flags(&package_config.compiler_flags);
 
     let file = PathBuf::from("..").join("..").join(file);
@@ -265,6 +266,7 @@ pub fn parser_args(
             jsx_module_args,
             jsx_mode_args,
             jsx_preserve_args,
+            experimental_features_args,
             bsc_flags,
             vec![
                 "-absname".to_string(),

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -251,8 +251,7 @@ impl<'de> serde::Deserialize<'de> for ExperimentalFeature {
                     other => {
                         let available = ["LetUnwrap"].join(", ");
                         Err(DeError::custom(format!(
-                            "Unknown experimental feature '{}'. Available features: {}",
-                            other, available
+                            "Unknown experimental feature '{other}'. Available features: {available}",
                         )))
                     }
                 }

--- a/rewatch/tests/experimental.sh
+++ b/rewatch/tests/experimental.sh
@@ -23,11 +23,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# Expect repeated string-list style: presence of -enable-experimental and LetUnwrap entries
-echo "$stdout" | grep -q '"-enable-experimental"' && echo "$stdout" | grep -q '"LetUnwrap"'
-if [ $? -ne 0 ]; then
+# Expect repeated string-list style: two "-enable-experimental" entries and "LetUnwrap" present
+enable_count=$(echo "$stdout" | grep -o '"-enable-experimental"' | wc -l | xargs)
+echo "$stdout" | grep -q '"LetUnwrap"'
+letunwrap_ok=$?
+if [ "$enable_count" -ne 2 ] || [ $letunwrap_ok -ne 0 ]; then
   mv rescript.json.bak rescript.json
-  error "-enable-experimental / LetUnwrap not found in compiler-args output"
+  error "Expected two occurrences of -enable-experimental and presence of LetUnwrap in compiler-args output"
   echo "$stdout"
   exit 1
 fi
@@ -35,4 +37,4 @@ fi
 # Restore original rescript.json
 mv rescript.json.bak rescript.json
 
-success "experimentalFeatures emits -enable-experimental as string list"
+success "experimentalFeatures emits -enable-experimental twice as string list"


### PR DESCRIPTION
The parser arguments were not added for new `LetUnwrap` features.

Note: in the future we might want to split up `get_experimental_features_args` to differentiate  between parser and compiler. But for now that doesn't apply and I didn't bother.