### PR TITLE
Add prepareRename command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 #### :house: Internal
 
+- Add a `prepareRename` command the LSP can use for faster renames. https://github.com/rescript-lang/rescript/pull/7847
+
 # 12.0.0-beta.9
 
 #### :boom: Breaking Change

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -11,6 +11,7 @@ API examples:
   ./rescript-editor-analysis.exe documentSymbol src/Foo.res
   ./rescript-editor-analysis.exe hover src/MyFile.res 10 2 true
   ./rescript-editor-analysis.exe references src/MyFile.res 10 2
+  ./rescript-editor-analysis.exe prepareRename src/MyFile.res 10 2
   ./rescript-editor-analysis.exe rename src/MyFile.res 10 2 foo
   ./rescript-editor-analysis.exe diagnosticSyntax src/MyFile.res
   ./rescript-editor-analysis.exe inlayHint src/MyFile.res 0 3 25
@@ -48,6 +49,10 @@ Options:
   references: get all references to item in MyFile.res at line 10 column 2:
 
     ./rescript-editor-analysis.exe references src/MyFile.res 10 2
+
+  prepareRename: quickly compute the identifier range (and placeholder) for item at line 10 column 2 without scanning references:
+
+    ./rescript-editor-analysis.exe prepareRename src/MyFile.res 10 2
 
   rename: rename all appearances of item in MyFile.res at line 10 column 2 with foo:
 
@@ -195,6 +200,10 @@ let main () =
     Reanalyze.cli ()
   | [_; "references"; path; line; col] ->
     Commands.references ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug
+  | [_; "prepareRename"; path; line; col] ->
+    Commands.prepareRename ~path
       ~pos:(int_of_string line, int_of_string col)
       ~debug
   | [_; "rename"; path; line; col; newName] ->

--- a/tests/analysis_tests/tests/src/PrepareRename.res
+++ b/tests/analysis_tests/tests/src/PrepareRename.res
@@ -1,0 +1,6 @@
+let x = 12
+//  ^pre
+
+let foo = (~xx) => xx + 1
+//                 ^pre
+

--- a/tests/analysis_tests/tests/src/expected/PrepareRename.res.txt
+++ b/tests/analysis_tests/tests/src/expected/PrepareRename.res.txt
@@ -1,0 +1,12 @@
+PrepareRename src/PrepareRename.res 0:4
+{
+    "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}},
+    "placeholder": "x"
+  }
+
+PrepareRename src/PrepareRename.res 3:19
+{
+    "range": {"start": {"line": 3, "character": 19}, "end": {"line": 3, "character": 21}},
+    "placeholder": "xx"
+  }
+


### PR DESCRIPTION
This adds a `prepareRename` command to the analysis bin that the editor tooling can use to get quick feedback for whether the target thing can be renamed or not.

Background for this is that our current rename functionality feels _slow_, and that's because it does all the heavy lifting of figuring out all places a rename needs to be applied, plus producing the actual text edits, twice - once to simply check if something can be renamed, and then again to do the actual rename. The command added in this PR replaces the first with a light weight super fast command that only looks at the untyped AST.

Will need adjustments in the editor tooling repo too for this to actually work.