### PR TITLE
syntax: catch Syntaxerr.Variable_in_scope from locally abstract type …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Avoid crash when using locally abstract types in `type … .` annotations with ticked params; emit a proper diagnostic. https://github.com/rescript-lang/rescript/pull/7851
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/tests/build_tests/super_errors/expected/locally_abstract_type_ticked_params.res.expected
+++ b/tests/build_tests/super_errors/expected/locally_abstract_type_ticked_params.res.expected
@@ -1,0 +1,12 @@
+
+  [1;31mSyntax error![0m
+  [36m/.../fixtures/locally_abstract_type_ticked_params.res[0m:[2m11:55-56[0m
+
+   9 [2m│[0m   | End
+  10 [2m│[0m 
+  [1;31m11[0m [2m│[0m let rec patternMatching : type inputStream callback. ([1;31mev[0m: event<'inputS
+     [2m│[0m [1;31mtream, 'callback>) => unit {[0m
+  12 [2m│[0m   switch ev {
+  13 [2m│[0m   | Pipe => patternMatching(Data)
+
+  A labeled parameter starts with a `~`. Did you mean: `~ev`?

--- a/tests/build_tests/super_errors/fixtures/locally_abstract_type_ticked_params.res
+++ b/tests/build_tests/super_errors/fixtures/locally_abstract_type_ticked_params.res
@@ -1,0 +1,18 @@
+// Repro for rescript-lang/rescript#7850
+// Using locally abstract types with ticked params inside the annotation
+// previously threw an uncaught Syntaxerr.Error. This fixture ensures we
+// surface a proper diagnostic instead.
+
+type event<'inputStream,'callback> =
+  | Pipe
+  | Data
+  | End
+
+let rec patternMatching : type inputStream callback. (ev: event<'inputStream, 'callback>) => unit {
+  switch ev {
+  | Pipe => patternMatching(Data)
+  | Data => patternMatching(End)
+  | End => ()
+  }
+}
+


### PR DESCRIPTION
…annotation to avoid crash; emit diagnostic instead (fixes #7850)

- Wrap varify_constructors call and surface friendly error
- Add super-error fixture for ticked params under type ... .

Refs: rescript-lang/rescript#7850