### PR TITLE
String.charCodeAt should return int

### DIFF
--- a/packages/@rescript/runtime/Stdlib_String.res
+++ b/packages/@rescript/runtime/Stdlib_String.res
@@ -17,7 +17,7 @@ external compare: (string, string) => Stdlib_Ordering.t = "%compare"
 @get_index external getUnsafe: (string, int) => string = ""
 @send external charAt: (string, int) => string = "charAt"
 
-@send external charCodeAt: (string, int) => float = "charCodeAt"
+@send external charCodeAt: (string, int) => int = "charCodeAt"
 @send external codePointAt: (string, int) => option<int> = "codePointAt"
 
 @send external concat: (string, string) => string = "concat"

--- a/packages/@rescript/runtime/Stdlib_String.resi
+++ b/packages/@rescript/runtime/Stdlib_String.resi
@@ -220,12 +220,12 @@ See [`String.charCodeAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 ## Examples
 
 ```rescript
-String.charCodeAt(`😺`, 0) == 0xd83d->Int.toFloat
+String.charCodeAt(`😺`, 0) == 0xd83d
 String.codePointAt(`😺`, 0) == Some(0x1f63a)
 ```
 */
 @send
-external charCodeAt: (string, int) => float = "charCodeAt"
+external charCodeAt: (string, int) => int = "charCodeAt"
 
 /**
 `codePointAt(str, index)` returns the code point at position `index` within


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt

> The charCodeAt() method of [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) values returns an integer between 0 and 65535 ...