### PR TITLE
Fix crash with `@get` on external of type `unit => 'a`

### DIFF
--- a/compiler/core/lam_compile_external_call.ml
+++ b/compiler/core/lam_compile_external_call.ml
@@ -421,7 +421,11 @@ let translate_ffi ?(transformed_jsx = false) (cxt : Lam_compile_context.t)
     | [obj] ->
       let obj = translate_scoped_access scopes obj in
       E.dot obj name
-    | _ -> assert false
+    | _ ->
+      (* This should have been caught in the frontend validation. *)
+      invalid_arg
+        "Internal compiler error: @get external called with wrong number of \
+         arguments. Expected exactly one object argument."
     (* Note these assertion happens in call site *))
   | Js_set {js_set_name = name; js_set_scopes = scopes} -> (
     (* assert (js_splice = false) ;  *)

--- a/compiler/frontend/ast_external_process.ml
+++ b/compiler/frontend/ast_external_process.ml
@@ -899,7 +899,12 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
    tagged_template = _;
   } ->
     if arg_type_specs_length = 1 then
-      Js_get {js_get_name = name; js_get_scopes = scopes}
+      (* Check if the first argument is unit, which is invalid for @get *)
+      match arg_type_specs with
+      | [{arg_type = Extern_unit}] ->
+        Location.raise_errorf ~loc
+          "Ill defined attribute %@get (unit argument is not allowed)"
+      | _ -> Js_get {js_get_name = name; js_get_scopes = scopes}
     else
       Location.raise_errorf ~loc
         "Ill defined attribute %@get (only one argument)"

--- a/tests/build_tests/super_errors/expected/get_unit_arg.res.expected
+++ b/tests/build_tests/super_errors/expected/get_unit_arg.res.expected
@@ -1,0 +1,12 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/get_unit_arg.res[0m:[2m2:1-3:36[0m
+
+  1 [2m│[0m // Test case for issue #7676 - @get external with unit => 'a should give
+    [2m│[0m  proper error
+  [1;31m2[0m [2m│[0m [1;31m@get[0m
+  [1;31m3[0m [2m│[0m [1;31mexternal foo: unit => string = "foo"[0m
+  4 [2m│[0m 
+  5 [2m│[0m let x = foo()
+
+  Ill defined attribute @get (unit argument is not allowed)

--- a/tests/build_tests/super_errors/fixtures/get_unit_arg.res
+++ b/tests/build_tests/super_errors/fixtures/get_unit_arg.res
@@ -1,0 +1,5 @@
+// Test case for issue #7676 - @get external with unit => 'a should give proper error
+@get
+external foo: unit => string = "foo"
+
+let x = foo()


### PR DESCRIPTION
Fixes #7676