### PR TITLE
setup trusted publishers and provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,8 @@ jobs:
         shell: bash
 
   publish:
+    permissions:
+      id-token: write
     needs:
       - test-installation-npm
       - test-installation-pnpm
@@ -701,11 +703,9 @@ jobs:
         shell: bash
 
       - name: Publish packages on npm with tag "ci"
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           yarn workspaces foreach -W --no-private \
-            npm publish --tolerate-republish --tag ci
+            npm publish --provenance --tolerate-republish --tag ci
 
       - name: Update Website Playground
         run: curl -X POST "${{ secrets.CLOUDFLARE_PAGES_DEPLOYMENT_HOOK }}"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "Paul Tsnobiladzé (https://github.com/tsnobip)",
     "Woonki Moon (https://github.com/mununki)"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "engines": {
     "node": ">=20.11.0"
   },

--- a/packages/@rescript/darwin-arm64/package.json
+++ b/packages/@rescript/darwin-arm64/package.json
@@ -28,6 +28,7 @@
   ],
   "publishConfig": {
     "access": "public",
+    "provenance": true,
     "executableFiles": [
       "./bin/bsb_helper.exe",
       "./bin/bsc.exe",

--- a/packages/@rescript/darwin-x64/package.json
+++ b/packages/@rescript/darwin-x64/package.json
@@ -28,6 +28,7 @@
   ],
   "publishConfig": {
     "access": "public",
+    "provenance": true,
     "executableFiles": [
       "./bin/bsb_helper.exe",
       "./bin/bsc.exe",

--- a/packages/@rescript/linux-arm64/package.json
+++ b/packages/@rescript/linux-arm64/package.json
@@ -28,6 +28,7 @@
   ],
   "publishConfig": {
     "access": "public",
+    "provenance": true,
     "executableFiles": [
       "./bin/bsb_helper.exe",
       "./bin/bsc.exe",

--- a/packages/@rescript/linux-x64/package.json
+++ b/packages/@rescript/linux-x64/package.json
@@ -28,6 +28,7 @@
   ],
   "publishConfig": {
     "access": "public",
+    "provenance": true,
     "executableFiles": [
       "./bin/bsb_helper.exe",
       "./bin/bsc.exe",

--- a/packages/@rescript/runtime/package.json
+++ b/packages/@rescript/runtime/package.json
@@ -27,7 +27,8 @@
     "Woonki Moon (https://github.com/mununki)"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "lib"

--- a/packages/@rescript/win32-x64/package.json
+++ b/packages/@rescript/win32-x64/package.json
@@ -28,6 +28,7 @@
   ],
   "publishConfig": {
     "access": "public",
+    "provenance": true,
     "executableFiles": [
       "./bin/bsb_helper.exe",
       "./bin/bsc.exe",


### PR DESCRIPTION
The largest supply chain attack has recently affected many popular packages. It was a simple phishing attack targeted the maintainer's account and 2FA token.

While this doesn't prevent attacks directly targeting maintainers, it does make package usage more secure.

- [Trusted publishers](https://docs.npmjs.com/trusted-publishers) allow tokenless workflows via OIDC and prevent abuse of authorized maintainer access tokens.
- [Provenance](https://docs.npmjs.com/generating-provenance-statements) allows you to verify that a version was published through a reviewed workflow.

administration guide:
- Set up the trusted publisher first in the NPM package settings page.  (I don't have permission, maybe @cknitt has?)
- Disallow publishing via token, bypassing the 2FA.
- Remove the NPM token from this repository's secrets.