### PR TITLE
Keep track of compiler info during build

### DIFF
--- a/rewatch/src/build/build_types.rs
+++ b/rewatch/src/build/build_types.rs
@@ -2,6 +2,7 @@ use crate::build::packages::{Namespace, Package};
 use crate::config::Config;
 use crate::project_context::ProjectContext;
 use ahash::{AHashMap, AHashSet};
+use blake3::Hash;
 use std::{fmt::Display, path::PathBuf, time::SystemTime};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -96,8 +97,15 @@ pub struct BuildState {
     pub packages: AHashMap<String, Package>,
     pub module_names: AHashSet<String>,
     pub deleted_modules: AHashSet<String>,
-    pub bsc_path: PathBuf,
+    pub compiler_info: CompilerInfo,
     pub deps_initialized: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompilerInfo {
+    pub bsc_path: PathBuf,
+    pub bsc_hash: Hash,
+    pub runtime_path: PathBuf,
 }
 
 impl BuildState {
@@ -111,7 +119,7 @@ impl BuildState {
     pub fn new(
         project_context: ProjectContext,
         packages: AHashMap<String, Package>,
-        bsc_path: PathBuf,
+        compiler: CompilerInfo,
     ) -> Self {
         Self {
             project_context,
@@ -119,7 +127,7 @@ impl BuildState {
             modules: AHashMap::new(),
             packages,
             deleted_modules: AHashSet::new(),
-            bsc_path,
+            compiler_info: compiler,
             deps_initialized: false,
         }
     }

--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -764,9 +764,6 @@ fn compile_file(
                 }
             });
 
-            // TODO: Optionally record per-module successful compile timestamps if needed
-            //       for future metadata-based invalidation. Current metadata is per-package.
-
             if helpers::contains_ascii_characters(&err) {
                 if package.is_local_dep {
                     // suppress warnings of external deps

--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -16,7 +16,9 @@ use console::style;
 use log::{debug, trace};
 use rayon::prelude::*;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
 use std::time::SystemTime;
 
 pub fn compile(
@@ -336,22 +338,36 @@ pub fn compile(
     Ok((compile_errors, compile_warnings, num_compiled_modules))
 }
 
-pub fn get_runtime_path_args(
-    package_config: &Config,
-    project_context: &ProjectContext,
-) -> Result<Vec<String>> {
-    match std::env::var("RESCRIPT_RUNTIME") {
-        Ok(runtime_path) => Ok(vec!["-runtime-path".to_string(), runtime_path]),
+static RUNTIME_PATH_MEMO: OnceLock<PathBuf> = OnceLock::new();
+
+pub fn get_runtime_path(package_config: &Config, project_context: &ProjectContext) -> Result<PathBuf> {
+    if let Some(p) = RUNTIME_PATH_MEMO.get() {
+        return Ok(p.clone());
+    }
+
+    let resolved = match std::env::var("RESCRIPT_RUNTIME") {
+        Ok(runtime_path) => Ok(PathBuf::from(runtime_path)),
         Err(_) => match helpers::try_package_path(package_config, project_context, "@rescript/runtime") {
-            Ok(runtime_path) => Ok(vec![
-                "-runtime-path".to_string(),
-                runtime_path.to_string_lossy().to_string(),
-            ]),
+            Ok(runtime_path) => Ok(runtime_path),
             Err(err) => Err(anyhow!(
                 "The rescript runtime package could not be found.\nPlease set RESCRIPT_RUNTIME environment variable or make sure the runtime package is installed.\nError: {err}"
             )),
         },
-    }
+    }?;
+
+    let _ = RUNTIME_PATH_MEMO.set(resolved.clone());
+    Ok(resolved)
+}
+
+pub fn get_runtime_path_args(
+    package_config: &Config,
+    project_context: &ProjectContext,
+) -> Result<Vec<String>> {
+    let runtime_path = get_runtime_path(package_config, project_context)?;
+    Ok(vec![
+        "-runtime-path".to_string(),
+        runtime_path.to_string_lossy().to_string(),
+    ])
 }
 
 pub fn compiler_args(
@@ -581,7 +597,7 @@ fn compile_file(
     let BuildState {
         packages,
         project_context,
-        bsc_path,
+        compiler_info,
         ..
     } = build_state;
     let root_config = build_state.get_root_config();
@@ -612,7 +628,7 @@ fn compile_file(
         package.is_local_dep,
     )?;
 
-    let to_mjs = Command::new(bsc_path)
+    let to_mjs = Command::new(&compiler_info.bsc_path)
         .current_dir(
             build_path_abs
                 .canonicalize()
@@ -747,6 +763,9 @@ fn compile_file(
                     }
                 }
             });
+
+            // TODO: Optionally record per-module successful compile timestamps if needed
+            //       for future metadata-based invalidation. Current metadata is per-package.
 
             if helpers::contains_ascii_characters(&err) {
                 if package.is_local_dep {

--- a/rewatch/src/build/compiler_info.rs
+++ b/rewatch/src/build/compiler_info.rs
@@ -1,3 +1,5 @@
+use crate::helpers;
+
 use super::build_types::{BuildState, CompilerInfo};
 use super::clean;
 use super::packages;
@@ -12,21 +14,21 @@ use std::io::Write;
 // If something is not there, that is fine, we will treat it as a mismatch
 #[derive(Serialize, Deserialize)]
 struct CompilerInfoFile {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bsc_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bsc_hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    runtime_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    generated_at: Option<String>,
+    version: String,
+    bsc_path: String,
+    bsc_hash: String,
+    rescript_config_hash: String,
+    runtime_path: String,
+    generated_at: String,
 }
 
 pub enum CompilerCheckResult {
     SameCompilerAsLastRun,
     CleanedPackagesDueToCompiler,
+}
+
+fn get_rescript_config_hash(package: &packages::Package) -> Option<String> {
+    helpers::compute_file_hash(&package.config.path).map(|hash| hash.to_hex().to_string())
 }
 
 pub fn verify_compiler_info(
@@ -51,32 +53,45 @@ pub fn verify_compiler_info(
             let current_bsc_path_str = compiler.bsc_path.to_string_lossy();
             let current_bsc_hash_hex = compiler.bsc_hash.to_hex().to_string();
             let current_runtime_path_str = compiler.runtime_path.to_string_lossy();
+            let current_rescript_config_hash = match get_rescript_config_hash(package) {
+                Some(hash) => hash,
+                None => return true, // can't compute hash -> treat as mismatch
+            };
 
             let mut mismatch = false;
-            if parsed.bsc_path.as_deref() != Some(&current_bsc_path_str) {
+            if parsed.bsc_path != current_bsc_path_str {
                 log::debug!(
                     "compiler-info mismatch for {}: bsc_path changed (stored='{}', current='{}')",
                     package.name,
-                    parsed.bsc_path.as_deref().unwrap_or("<missing>"),
+                    parsed.bsc_path,
                     current_bsc_path_str
                 );
                 mismatch = true;
             }
-            if parsed.bsc_hash.as_deref() != Some(&current_bsc_hash_hex) {
+            if parsed.bsc_hash != current_bsc_hash_hex {
                 log::debug!(
                     "compiler-info mismatch for {}: bsc_hash changed (stored='{}', current='{}')",
                     package.name,
-                    parsed.bsc_hash.as_deref().unwrap_or("<missing>"),
+                    parsed.bsc_hash,
                     current_bsc_hash_hex
                 );
                 mismatch = true;
             }
-            if parsed.runtime_path.as_deref() != Some(&current_runtime_path_str) {
+            if parsed.runtime_path != current_runtime_path_str {
                 log::debug!(
                     "compiler-info mismatch for {}: runtime_path changed (stored='{}', current='{}')",
                     package.name,
-                    parsed.runtime_path.as_deref().unwrap_or("<missing>"),
+                    parsed.runtime_path,
                     current_runtime_path_str
+                );
+                mismatch = true;
+            }
+            if parsed.rescript_config_hash != current_rescript_config_hash {
+                log::debug!(
+                    "compiler-info mismatch for {}: rescript_config_hash changed (stored='{}', current='{}')",
+                    package.name,
+                    parsed.rescript_config_hash,
+                    current_rescript_config_hash
                 );
                 mismatch = true;
             }
@@ -98,46 +113,58 @@ pub fn verify_compiler_info(
 }
 
 pub fn write_compiler_info(build_state: &BuildState) {
-    let bsc_path_str = build_state.compiler_info.bsc_path.to_string_lossy().to_string();
-    let bsc_hash_hex = build_state.compiler_info.bsc_hash.to_hex().to_string();
-    let runtime_path_str = build_state
+    let bsc_path = build_state.compiler_info.bsc_path.to_string_lossy().to_string();
+    let bsc_hash = build_state.compiler_info.bsc_hash.to_hex().to_string();
+    let runtime_path = build_state
         .compiler_info
         .runtime_path
         .to_string_lossy()
         .to_string();
-
     // derive version from the crate version
     let version = env!("CARGO_PKG_VERSION").to_string();
     let generated_at = crate::helpers::get_system_time().to_string();
 
-    let out = CompilerInfoFile {
-        version: Some(version),
-        bsc_path: Some(bsc_path_str),
-        bsc_hash: Some(bsc_hash_hex),
-        runtime_path: Some(runtime_path_str),
-        generated_at: Some(generated_at),
-    };
-    let contents = serde_json::to_string_pretty(&out).unwrap_or_else(|_| String::new());
+    // Borrowing serializer to avoid cloning the constant fields for every package
+    #[derive(Serialize)]
+    struct CompilerInfoFileRef<'a> {
+        version: &'a str,
+        bsc_path: &'a str,
+        bsc_hash: &'a str,
+        rescript_config_hash: String,
+        runtime_path: &'a str,
+        generated_at: &'a str,
+    }
 
     build_state.packages.values().par_bridge().for_each(|package| {
-        let info_path = package.get_compiler_info_path();
-        let should_write = match std::fs::read_to_string(&info_path) {
-            Ok(existing) => existing != contents,
-            Err(_) => true,
-        };
+        if let Some(rescript_config_hash) = helpers::compute_file_hash(&package.config.path) {
+            let out = CompilerInfoFileRef {
+                version: &version,
+                bsc_path: &bsc_path,
+                bsc_hash: &bsc_hash,
+                rescript_config_hash: rescript_config_hash.to_hex().to_string(),
+                runtime_path: &runtime_path,
+                generated_at: &generated_at,
+            };
+            let contents = serde_json::to_string_pretty(&out).unwrap_or_else(|_| String::new());
+            let info_path = package.get_compiler_info_path();
+            let should_write = match std::fs::read_to_string(&info_path) {
+                Ok(existing) => existing != contents,
+                Err(_) => true,
+            };
 
-        if should_write {
-            if let Some(parent) = info_path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            // We write atomically to avoid leaving a partially written JSON file
-            // (e.g. process interruption) that would be read on the next init as an
-            // invalid/mismatched compiler-info, causing unnecessary cleans. The
-            // rename within the same directory is atomic on common platforms.
-            let tmp = info_path.with_extension("json.tmp");
-            if let Ok(mut f) = File::create(&tmp) {
-                let _ = f.write_all(contents.as_bytes());
-                let _ = std::fs::rename(&tmp, &info_path);
+            if should_write {
+                if let Some(parent) = info_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                // We write atomically to avoid leaving a partially written JSON file
+                // (e.g. process interruption) that would be read on the next init as an
+                // invalid/mismatched compiler-info, causing unnecessary cleans. The
+                // rename within the same directory is atomic on common platforms.
+                let tmp = info_path.with_extension("json.tmp");
+                if let Ok(mut f) = File::create(&tmp) {
+                    let _ = f.write_all(contents.as_bytes());
+                    let _ = std::fs::rename(&tmp, &info_path);
+                }
             }
         }
     });

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -91,6 +91,10 @@ impl Package {
         get_build_path(&self.path)
     }
 
+    pub fn get_compiler_info_path(&self) -> PathBuf {
+        self.get_build_path().join("compiler-info.json")
+    }
+
     pub fn get_js_path(&self) -> PathBuf {
         get_js_path(&self.path)
     }

--- a/rewatch/src/build/parse.rs
+++ b/rewatch/src/build/parse.rs
@@ -196,7 +196,7 @@ pub fn generate_asts(
                         &build_state.project_context,
                         package,
                         module_name,
-                        &build_state.bsc_path,
+                        &build_state.compiler_info.bsc_path,
                     ) {
                         has_failure = true;
                         stderr.push_str(&format!("{}\n", err));
@@ -310,7 +310,7 @@ fn generate_ast(
 
     /* Create .ast */
     let result = match Some(
-        Command::new(&build_state.bsc_path)
+        Command::new(&build_state.compiler_info.bsc_path)
             .current_dir(&build_path_abs)
             .args(parser_args)
             .output()


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript/issues/7436

It produces a `lib/bs/compiler-info.json` file which contains:
```json
{
  "version": "12.0.0-beta.12",
  "bsc_path": "/Users/nojaf/Projects/vrindelycker/node_modules/@rescript/darwin-arm64/bin/bsc.exe",
  "bsc_hash": "7d113813ca550965be97771da2ce2d47f85d297eda9e568763e54d31e0b8098d",
  "rescript_config_hash": "226055db0876bea957f7b3b597478f95fdaefb4547704d6557c5dceb64772a1b",
  "runtime_path": "/Users/nojaf/Projects/vrindelycker/node_modules/@rescript/runtime",
  "generated_at": "1757936814848"
}
```

`"runtime_path"` and `"bsc_path"` might be interesting for tooling to pick up.

That hash compare is also really useful when working with a local compiler.
