### PR TITLE
Dedicated error for dict literal spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 #### :nail_care: Polish
 
 - Add (dev-)dependencies to build schema. https://github.com/rescript-lang/rescript/pull/7892
+- Dedicated error for dict literal spreads. https://github.com/rescript-lang/rescript/pull/7901
 
 #### :house: Internal
 

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -97,6 +97,8 @@ module ErrorMessages = struct
      ...b}` wouldn't make sense, as `b` would override every field of `a` \
      anyway."
 
+  let dict_expr_spread = "Dict literals do not support spread (`...`) yet."
+
   let variant_ident =
     "A polymorphic variant (e.g. #id) must start with an alphabetical letter \
      or be a number (e.g. #742)"
@@ -3368,6 +3370,11 @@ and parse_record_expr_row p :
 
 and parse_dict_expr_row p =
   match p.Parser.token with
+  | DotDotDot ->
+    Parser.err p (Diagnostics.message ErrorMessages.dict_expr_spread);
+    Parser.next p;
+    let _spread_expr = parse_constrained_or_coerced_expr p in
+    None
   | String s -> (
     let loc = mk_loc p.start_pos p.end_pos in
     Parser.next p;

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -3373,6 +3373,7 @@ and parse_dict_expr_row p =
   | DotDotDot ->
     Parser.err p (Diagnostics.message ErrorMessages.dict_expr_spread);
     Parser.next p;
+    (* Parse the expr so it's consumed *)
     let _spread_expr = parse_constrained_or_coerced_expr p in
     None
   | String s -> (

--- a/tests/syntax_tests/data/parsing/errors/other/dict_spread.res
+++ b/tests/syntax_tests/data/parsing/errors/other/dict_spread.res
@@ -1,2 +1,2 @@
-let x = dict{...foo}
+let x = dict{...foo, "bar": 3}
 

--- a/tests/syntax_tests/data/parsing/errors/other/dict_spread.res
+++ b/tests/syntax_tests/data/parsing/errors/other/dict_spread.res
@@ -1,0 +1,2 @@
+let x = dict{...foo}
+

--- a/tests/syntax_tests/data/parsing/errors/other/expected/dict_spread.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/other/expected/dict_spread.res.txt
@@ -1,0 +1,11 @@
+
+  Syntax error!
+  syntax_tests/data/parsing/errors/other/dict_spread.res:1:14-16
+
+  1 │ let x = dict{...foo}
+  2 │ 
+  3 │ 
+
+  Dict literals do not support spread (`...`) yet.
+
+let x = Primitive_dict.make [||]

--- a/tests/syntax_tests/data/parsing/errors/other/expected/dict_spread.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/other/expected/dict_spread.res.txt
@@ -2,10 +2,10 @@
   Syntax error!
   syntax_tests/data/parsing/errors/other/dict_spread.res:1:14-16
 
-  1 │ let x = dict{...foo}
+  1 │ let x = dict{...foo, "bar": 3}
   2 │ 
   3 │ 
 
   Dict literals do not support spread (`...`) yet.
 
-let x = Primitive_dict.make [||]
+let x = Primitive_dict.make [|("bar", 3)|]


### PR DESCRIPTION
We do not support spreads in dict literals yet, but one day we will. This gives a proper error for the spread in the meantime.