### PR TITLE
Use Rust 1.88 during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,9 @@ jobs:
         if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.88.0
           targets: ${{ matrix.rust-target }}
+          components: clippy, rustfmt
 
       - name: Build rewatch
         if: steps.rewatch-build-cache.outputs.cache-hit != 'true'

--- a/rewatch/Cargo.toml
+++ b/rewatch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rescript"
 version = "12.0.0-beta.12"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 ahash = "0.8.3"

--- a/rewatch/src/build/parse.rs
+++ b/rewatch/src/build/parse.rs
@@ -199,7 +199,7 @@ pub fn generate_asts(
                         &build_state.bsc_path,
                     ) {
                         has_failure = true;
-                        stderr.push_str(&format!("{}\n", err));
+                        stderr.push_str(&format!("{err}\n"));
                     }
                     let mlmap_hash_after = helpers::compute_file_hash(Path::new(&compile_path));
 


### PR DESCRIPTION
I’ve had some builds that install version 1.90 unexpectedly. Please pin it to version 1.88 until we intentionally move to a newer version. Any upgrade should be a conscious decision.

Failed build: https://github.com/rescript-lang/rescript/actions/runs/17830424349/job/50693695893#step:11:138

Notice
```
rustc 1.90.0 (1159e78c4 2025-09-14)
binary: rustc
commit-hash: 1159e78c4747b02ef996e55082b704c09b970588
commit-date: 2025-09-14
host: x86_64-unknown-linux-gnu
release: 1.90.0
LLVM version: 20.1.8
```