### PR TITLE
CI: macos runners: use macos-15/macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
             benchmarks: true
             node-target: linux-arm64
             rust-target: aarch64-unknown-linux-musl
-          - os: macos-13 # x64
+          - os: macos-15-intel # x64
             ocaml_compiler: 5.3.0
             upload_binaries: true
             node-target: darwin-x64
             rust-target: x86_64-apple-darwin
-          - os: macos-14 # ARM
+          - os: macos-15 # ARM
             ocaml_compiler: 5.3.0
             upload_binaries: true
             node-target: darwin-arm64
@@ -539,8 +539,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
-          - os: macos-14
+          - os: macos-15-intel
+          - os: macos-15
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
           - os: windows-2022
@@ -590,8 +590,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
-          - os: macos-14
+          - os: macos-15-intel
+          - os: macos-15
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
           - os: windows-2022
@@ -645,8 +645,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
-          - os: macos-14
+          - os: macos-15-intel
+          - os: macos-15
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
           - os: windows-2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 #### :house: Internal
 
+- CI: run macOS builds on macOS 15. https://github.com/rescript-lang/rescript/pull/7935
+
 # 12.0.0-beta.13
 
 #### :bug: Bug fix


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

> The macOS 13 runner image will be retired by December 4th, 2025.