### PR TITLE
Fix: use configured Jsx module for constraining component return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix: use configured Jsx module for constraining component return type. https://github.com/rescript-lang/rescript/pull/7945
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CreateInterface.res.txt
@@ -2,18 +2,18 @@ Create Interface src/CreateInterface.res
 type r = {name: string, age: int}
 let add: (~x: int, ~y: int) => int
 @react.component
-let make: (~name: string) => Jsx.element
+let make: (~name: string) => React.element
 module Other: {
   @react.component
-  let otherComponentName: (~name: string) => Jsx.element
+  let otherComponentName: (~name: string) => React.element
 }
 module Mod: {
   @react.component
-  let make: (~name: string) => Jsx.element
+  let make: (~name: string) => React.element
 }
 module type ModTyp = {
   @react.component
-  let make: (~name: string) => Jsx.element
+  let make: (~name: string) => React.element
 }
 @module("path") external dirname: string => string = "dirname"
 @module("path") @variadic
@@ -49,21 +49,21 @@ module RFS: {
 module Functor: () =>
 {
   @react.component
-  let make: unit => Jsx.element
+  let make: unit => React.element
 }
 module type FT = {
   module Functor: (
     X: {
       let a: int
       @react.component
-      let make: (~name: string) => Jsx.element
+      let make: (~name: string) => React.element
       let b: int
     },
     Y: ModTyp,
   ) =>
   {
     @react.component
-    let make: (~name: string) => Jsx.element
+    let make: (~name: string) => React.element
   }
 }
 module NormaList = List
@@ -73,34 +73,34 @@ module rec RM: ModTyp
 and D: ModTyp
 module type OptT = {
   @react.component
-  let withOpt1: (~x: int=?, ~y: int) => Jsx.element
+  let withOpt1: (~x: int=?, ~y: int) => React.element
   module type Opt2 = {
     @react.component
-    let withOpt2: (~x: int=?, ~y: int) => Jsx.element
+    let withOpt2: (~x: int=?, ~y: int) => React.element
   }
   module type Opt3 = {
     @react.component
-    let withOpt3: (~x: option<int>, ~y: int) => Jsx.element
+    let withOpt3: (~x: option<int>, ~y: int) => React.element
   }
 }
 module Opt: {
   @react.component
-  let withOpt1: (~x: int=?, ~y: int) => Jsx.element
+  let withOpt1: (~x: int=?, ~y: int) => React.element
   module Opt2: {
     @react.component
-    let withOpt2: (~x: int=?, ~y: int) => Jsx.element
+    let withOpt2: (~x: int=?, ~y: int) => React.element
   }
   module type Opt2 = {
     @react.component
-    let withOpt2: (~x: int=?, ~y: int) => Jsx.element
+    let withOpt2: (~x: int=?, ~y: int) => React.element
   }
   module Opt3: {
     @react.component
-    let withOpt3: (~x: option<int>, ~y: int) => Jsx.element
+    let withOpt3: (~x: option<int>, ~y: int) => React.element
   }
   module type Opt3 = {
     @react.component
-    let withOpt3: (~x: option<int>, ~y: int) => Jsx.element
+    let withOpt3: (~x: option<int>, ~y: int) => React.element
   }
 }
 module Opt2: OptT
@@ -122,7 +122,7 @@ external upperBound: ([< #d | #e | #f]) => unit = "myexternal"
 external lowerBound: ([> #d | #e | #f]) => unit = "myexternal"
 module ComponentWithPolyProp: {
   @react.component
-  let make: (~size: [< #large | #small]=?) => Jsx.element
+  let make: (~size: [< #large | #small]=?) => React.element
 }
 module OrderedSet: {
   type t<'a, 'identity> = {

--- a/tests/analysis_tests/tests/src/expected/Jsx2.resi.txt
+++ b/tests/analysis_tests/tests/src/expected/Jsx2.resi.txt
@@ -1,5 +1,5 @@
 Hover src/Jsx2.resi 1:4
-{"contents": {"kind": "markdown", "value": "```rescript\nJsx.element\n```\n\n---\n\n```\n \n```\n```rescript\ntype Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Jsx.res%22%2C25%2C0%5D)\n"}}
+{"contents": {"kind": "markdown", "value": "```rescript\nReact.element\n```\n\n---\n\n```\n \n```\n```rescript\ntype React.element = Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C0%2C0%5D)\n"}}
 
 Hover src/Jsx2.resi 4:4
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}

--- a/tests/analysis_tests/tests/src/expected/JsxV4.res.txt
+++ b/tests/analysis_tests/tests/src/expected/JsxV4.res.txt
@@ -22,14 +22,14 @@ Hover src/JsxV4.res 14:9
 Create Interface src/JsxV4.res
 module M4: {
   @react.component
-  let make: (~first: string, ~fun: string=?, ~second: string=?) => Jsx.element
+  let make: (~first: string, ~fun: string=?, ~second: string=?) => React.element
 }
 module MM: {
   @react.component
-  let make: unit => Jsx.element
+  let make: unit => React.element
 }
 module Other: {
   @react.component
-  let make: (~name: string) => Jsx.element
+  let make: (~name: string) => React.element
 }
 

--- a/tests/build_tests/super_errors/fixtures/react_async_component_missing_jsx_element.res
+++ b/tests/build_tests/super_errors/fixtures/react_async_component_missing_jsx_element.res
@@ -1,4 +1,4 @@
-@@jsxConfig({version: 4})
+@@jsxConfig({version: 4, module_: "Jsx"})
 
 @react.component
 let make = async () => 1

--- a/tests/build_tests/super_errors/fixtures/react_componentWithProps_missing_jsx_element.res
+++ b/tests/build_tests/super_errors/fixtures/react_componentWithProps_missing_jsx_element.res
@@ -1,4 +1,4 @@
-@@jsxConfig({version: 4})
+@@jsxConfig({version: 4, module_: "Jsx"})
 
 type props<'a> = {value: 'a}
 

--- a/tests/build_tests/super_errors/fixtures/react_component_missing_jsx_element.res
+++ b/tests/build_tests/super_errors/fixtures/react_component_missing_jsx_element.res
@@ -1,4 +1,4 @@
-@@jsxConfig({version: 4})
+@@jsxConfig({version: 4, module_: "Jsx"})
 
 @react.component
 let make = () => 1

--- a/tests/build_tests/super_errors/fixtures/react_forwardRef_missing_jsx_element.res
+++ b/tests/build_tests/super_errors/fixtures/react_forwardRef_missing_jsx_element.res
@@ -1,4 +1,4 @@
-@@jsxConfig({version: 4})
+@@jsxConfig({version: 4, module_: "Jsx"})
 
 @react.component
 let make = React.forwardRef((_, _ref) => 1)

--- a/tests/syntax_tests/data/ppx/react/expected/aliasProps.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/aliasProps.res.txt
@@ -9,7 +9,7 @@ module C0 = {
     | Some(text) => text
     | None => "Test"
     }
-    (React.string(text): Jsx.element)
+    (React.string(text): React.element)
   }
   let make = {
     let \"AliasProps$C0" = (props: props<_>) => make(props)
@@ -27,7 +27,7 @@ module C1 = {
     | Some(text) => text
     | None => "Test"
     }
-    (React.string(p ++ text): Jsx.element)
+    (React.string(p ++ text): React.element)
   }
   let make = {
     let \"AliasProps$C1" = (props: props<_>) => make(props)
@@ -45,7 +45,7 @@ module C2 = {
     | Some(foo) => foo
     | None => ""
     }
-    (React.string(bar): Jsx.element)
+    (React.string(bar): React.element)
   }
   let make = {
     let \"AliasProps$C2" = (props: props<_>) => make(props)
@@ -70,7 +70,7 @@ module C3 = {
     (
       {
         React.string(bar ++ a ++ b)
-      }: Jsx.element
+      }: React.element
     )
   }
   let make = {
@@ -89,7 +89,7 @@ module C4 = {
     | Some(x) => x
     | None => true
     }
-    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement(b)}): Jsx.element)
+    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement(b)}): React.element)
   }
   let make = {
     let \"AliasProps$C4" = (props: props<_>) => make(props)
@@ -107,7 +107,7 @@ module C5 = {
     | Some(z) => z
     | None => 3
     }
-    (x + y + z: Jsx.element)
+    (x + y + z: React.element)
   }
   let make = {
     let \"AliasProps$C5" = (props: props<_>) => make(props)
@@ -121,12 +121,12 @@ module C6 = {
     @res.jsxComponentProps
     type props = {}
 
-    let make: React.componentLike<props, Jsx.element>
+    let make: React.componentLike<props, React.element>
   }
   @res.jsxComponentProps
   type props<'comp, 'x> = {comp: 'comp, x: 'x}
 
-  let make = ({comp: module(Comp: Comp), x: (a, b), _}: props<_, _>): Jsx.element =>
+  let make = ({comp: module(Comp: Comp), x: (a, b), _}: props<_, _>): React.element =>
     React.jsx(Comp.make, {})
   let make = {
     let \"AliasProps$C6" = (props: props<_>) => make(props)

--- a/tests/syntax_tests/data/ppx/react/expected/asyncAwait.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/asyncAwait.res.txt
@@ -6,7 +6,7 @@ module C0 = {
 
   let make = async ({a, _}: props<_>) => {
     let a = await f(a)
-    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement({React.int(a)})}): Jsx.element)
+    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement({React.int(a)})}): React.element)
   }
   let make = {
     let \"AsyncAwait$C0" = (props: props<_>) => Jsx.promise(make(props))
@@ -19,7 +19,7 @@ module C1 = {
   @res.jsxComponentProps
   type props<'status> = {status: 'status}
 
-  let make = async ({status, _}: props<_>): Jsx.element => {
+  let make = async ({status, _}: props<_>): React.element => {
     switch status {
     | #on => React.string("on")
     | #off => React.string("off")

--- a/tests/syntax_tests/data/ppx/react/expected/commentAtTop.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/commentAtTop.res.txt
@@ -1,7 +1,7 @@
 @res.jsxComponentProps
 type props<'msg> = {msg: 'msg} // test React JSX file
 
-let make = ({msg, _}: props<_>): Jsx.element => {
+let make = ({msg, _}: props<_>): React.element => {
   ReactDOM.jsx("div", {children: ?ReactDOM.someElement({msg->React.string})})
 }
 let make = {

--- a/tests/syntax_tests/data/ppx/react/expected/defaultValueProp.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/defaultValueProp.res.txt
@@ -10,7 +10,7 @@ module C0 = {
     | Some(b) => b
     | None => a * 2
     }
-    (React.int(a + b): Jsx.element)
+    (React.int(a + b): React.element)
   }
   let make = {
     let \"DefaultValueProp$C0" = (props: props<_>) => make(props)
@@ -27,7 +27,7 @@ module C1 = {
     | Some(a) => a
     | None => 2
     }
-    (React.int(a + b): Jsx.element)
+    (React.int(a + b): React.element)
   }
   let make = {
     let \"DefaultValueProp$C1" = (props: props<_>) => make(props)
@@ -46,7 +46,7 @@ module C2 = {
     | Some(a) => a
     | None => a
     }
-    (React.string(a): Jsx.element)
+    (React.string(a): React.element)
   }
   let make = {
     let \"DefaultValueProp$C2" = (props: props<_>) => make(props)
@@ -67,7 +67,7 @@ module C3 = {
     (
       {
         React.string(everythingDisabled ? "true" : "false")
-      }: Jsx.element
+      }: React.element
     )
   }
   let make = {

--- a/tests/syntax_tests/data/ppx/react/expected/externalWithCustomName.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/externalWithCustomName.res.txt
@@ -5,7 +5,7 @@ module Foo = {
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")
-  external component: React.componentLike<props<int, string>, Jsx.element> = "component"
+  external component: React.componentLike<props<int, string>, React.element> = "component"
 }
 
 let t = React.jsx(Foo.component, {a: 1, b: {"1"}})

--- a/tests/syntax_tests/data/ppx/react/expected/externalWithRef.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/externalWithRef.res.txt
@@ -8,6 +8,6 @@ module V4C = {
   }
 
   @module("componentForwardRef")
-  external make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, Jsx.element> =
+  external make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element> =
     "component"
 }

--- a/tests/syntax_tests/data/ppx/react/expected/externalWithTypeVariables.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/externalWithTypeVariables.res.txt
@@ -8,5 +8,5 @@ module V4C = {
   }
 
   @module("c")
-  external make: React.componentLike<props<t<'a>, React.element>, Jsx.element> = "component"
+  external make: React.componentLike<props<t<'a>, React.element>, React.element> = "component"
 }

--- a/tests/syntax_tests/data/ppx/react/expected/fileLevelConfig.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/fileLevelConfig.res.txt
@@ -4,7 +4,7 @@ module V4A = {
   @res.jsxComponentProps
   type props<'msg> = {msg: 'msg}
 
-  let make = ({msg, _}: props<_>): Jsx.element => {
+  let make = ({msg, _}: props<_>): React.element => {
     ReactDOM.jsx("div", {children: ?ReactDOM.someElement({msg->React.string})})
   }
   let make = {

--- a/tests/syntax_tests/data/ppx/react/expected/firstClassModules.resi.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/firstClassModules.resi.txt
@@ -20,6 +20,6 @@ module Select: {
       option<'key> => unit,
       array<'a>,
     >,
-    Jsx.element,
+    React.element,
   >
 }

--- a/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/forwardRef.res.txt
@@ -12,7 +12,7 @@ module V4A = {
     let make = (
       {?className, children, _}: props<_, _, 'ref>,
       ref: Js.Nullable.t<'ref>,
-    ): Jsx.element =>
+    ): React.element =>
       ReactDOM.jsxs(
         "div",
         {
@@ -48,7 +48,7 @@ module V4A = {
             React.jsx(FancyInput.make, {ref: input, children: {React.string("Click to focus")}}),
           ),
         },
-      ): Jsx.element
+      ): React.element
     )
   }
   let make = {
@@ -70,7 +70,7 @@ module V4AUncurried = {
     let make = (
       {?className, children, _}: props<_, _, 'ref>,
       ref: Js.Nullable.t<'ref>,
-    ): Jsx.element =>
+    ): React.element =>
       ReactDOM.jsxs(
         "div",
         {
@@ -106,7 +106,7 @@ module V4AUncurried = {
             React.jsx(FancyInput.make, {ref: input, children: {React.string("Click to focus")}}),
           ),
         },
-      ): Jsx.element
+      ): React.element
     )
   }
   let make = {

--- a/tests/syntax_tests/data/ppx/react/expected/forwardRef.resi.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/forwardRef.resi.txt
@@ -11,7 +11,7 @@ module V4C: {
 
     let make: React.componentLike<
       props<string, React.element, ReactDOM.Ref.currentDomRef>,
-      Jsx.element,
+      React.element,
     >
   }
 
@@ -19,7 +19,7 @@ module V4C: {
     @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
-    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, Jsx.element>
+    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
   }
 }
 
@@ -34,7 +34,7 @@ module V4CUncurried: {
 
     let make: React.componentLike<
       props<string, React.element, ReactDOM.Ref.currentDomRef>,
-      Jsx.element,
+      React.element,
     >
   }
 
@@ -42,7 +42,7 @@ module V4CUncurried: {
     @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
-    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, Jsx.element>
+    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
   }
 }
 
@@ -59,7 +59,7 @@ module V4A: {
 
     let make: React.componentLike<
       props<string, React.element, ReactDOM.Ref.currentDomRef>,
-      Jsx.element,
+      React.element,
     >
   }
 
@@ -67,7 +67,7 @@ module V4A: {
     @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
-    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, Jsx.element>
+    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
   }
 }
 
@@ -82,7 +82,7 @@ module V4AUncurried: {
 
     let make: React.componentLike<
       props<string, React.element, ReactDOM.Ref.currentDomRef>,
-      Jsx.element,
+      React.element,
     >
   }
 
@@ -90,6 +90,6 @@ module V4AUncurried: {
     @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
-    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, Jsx.element>
+    let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
   }
 }

--- a/tests/syntax_tests/data/ppx/react/expected/interface.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/interface.res.txt
@@ -1,7 +1,7 @@
 module A = {
   @res.jsxComponentProps
   type props<'x> = {x: 'x}
-  let make = ({x, _}: props<_>): Jsx.element => React.string(x)
+  let make = ({x, _}: props<_>): React.element => React.string(x)
   let make = {
     let \"Interface$A" = (props: props<_>) => make(props)
     \"Interface$A"
@@ -12,7 +12,7 @@ module NoProps = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props): Jsx.element => ReactDOM.jsx("div", {})
+  let make = (_: props): React.element => ReactDOM.jsx("div", {})
   let make = {
     let \"Interface$NoProps" = props => make(props)
 

--- a/tests/syntax_tests/data/ppx/react/expected/interface.resi.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/interface.resi.txt
@@ -1,12 +1,12 @@
 module A: {
   @res.jsxComponentProps
   type props<'x> = {x: 'x}
-  let make: React.componentLike<props<string>, Jsx.element>
+  let make: React.componentLike<props<string>, React.element>
 }
 
 module NoProps: {
   @res.jsxComponentProps
   type props = {}
 
-  let make: React.componentLike<props, Jsx.element>
+  let make: React.componentLike<props, React.element>
 }

--- a/tests/syntax_tests/data/ppx/react/expected/interfaceWithRef.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/interfaceWithRef.res.txt
@@ -4,7 +4,7 @@ let make = (
   ref: Js.Nullable.t<ReactDOM.Ref.currentDomRef>,
 ) => {
   let _ = ref->Js.Nullable.toOption->Belt.Option.map(ReactDOM.Ref.domRef)
-  (React.string(x): Jsx.element)
+  (React.string(x): React.element)
 }
 let make = React.forwardRef({
   let \"InterfaceWithRef" = (props: props<_>, ref) => make(props, ref)

--- a/tests/syntax_tests/data/ppx/react/expected/interfaceWithRef.resi.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/interfaceWithRef.resi.txt
@@ -1,2 +1,2 @@
 @res.jsxComponentProps type props<'x, 'ref> = {x: 'x, ref?: 'ref}
-let make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, Jsx.element>
+let make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element>

--- a/tests/syntax_tests/data/ppx/react/expected/mangleKeyword.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/mangleKeyword.res.txt
@@ -4,7 +4,7 @@ module C4A0 = {
   @res.jsxComponentProps
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
-  let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>): Jsx.element =>
+  let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>): React.element =>
     React.string(_open)
   let make = {
     let \"MangleKeyword$C4A0" = (props: props<_>) => make(props)
@@ -16,7 +16,7 @@ module C4A1 = {
   @res.jsxComponentProps @live
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
-  external make: React.componentLike<props<string, string>, Jsx.element> = "default"
+  external make: React.componentLike<props<string, string>, React.element> = "default"
 }
 
 let c4a0 = React.jsx(C4A0.make, {_open: "x", _type: "t"})

--- a/tests/syntax_tests/data/ppx/react/expected/nested.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/nested.res.txt
@@ -1,12 +1,12 @@
 module Outer = {
   @res.jsxComponentProps
   type props = {}
-  let make = (_: props): Jsx.element => {
+  let make = (_: props): React.element => {
     module Inner = {
       @res.jsxComponentProps
       type props = {}
 
-      let make = (_: props): Jsx.element => ReactDOM.jsx("div", {})
+      let make = (_: props): React.element => ReactDOM.jsx("div", {})
       let make = {
         let \"Nested$Outer" = props => make(props)
 

--- a/tests/syntax_tests/data/ppx/react/expected/newtype.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/newtype.res.txt
@@ -4,7 +4,7 @@ module V4A = {
   @res.jsxComponentProps
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
-  let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>): Jsx.element =>
+  let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>): React.element =>
     ReactDOM.jsx("div", {})
   let make = {
     let \"Newtype$V4A" = (props: props<_>) => make(props)
@@ -17,7 +17,7 @@ module V4A1 = {
   @res.jsxComponentProps
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
-  let make = (type x y, {a, b, c, _}: props<x, array<y>, 'a>): Jsx.element =>
+  let make = (type x y, {a, b, c, _}: props<x, array<y>, 'a>): React.element =>
     ReactDOM.jsx("div", {})
   let make = {
     let \"Newtype$V4A1" = (props: props<_>) => make(props)
@@ -34,7 +34,7 @@ module V4A2 = {
   @res.jsxComponentProps
   type props<'foo> = {foo: 'foo}
 
-  let make = (type a, {foo: (foo: module(T with type t = a)), _}: props<_>): Jsx.element => {
+  let make = (type a, {foo: (foo: module(T with type t = a)), _}: props<_>): React.element => {
     module T = unpack(foo)
     ReactDOM.jsx("div", {})
   }
@@ -49,7 +49,7 @@ module V4A3 = {
   @res.jsxComponentProps
   type props<'foo> = {foo: 'foo}
 
-  let make = (type a, {foo, _}: props<_>): Jsx.element => {
+  let make = (type a, {foo, _}: props<_>): React.element => {
     module T = unpack(foo: T with type t = a)
     foo
   }
@@ -62,7 +62,7 @@ module V4A3 = {
 @res.jsxComponentProps
 type props<'x, 'q> = {x: 'x, q: 'q}
 
-let make = ({x, q, _}: props<('a, 'b), 'a>): Jsx.element => [fst(x), q]
+let make = ({x, q, _}: props<('a, 'b), 'a>): React.element => [fst(x), q]
 let make = {
   let \"Newtype" = (props: props<_>) => make(props)
 
@@ -75,7 +75,7 @@ module Uncurried = {
   @res.jsxComponentProps
   type props<'foo> = {foo?: 'foo}
 
-  let make = (type a, {?foo, _}: props<_>): Jsx.element => React.null
+  let make = (type a, {?foo, _}: props<_>): React.element => React.null
   let make = {
     let \"Newtype$Uncurried" = (props: props<_>) => make(props)
 

--- a/tests/syntax_tests/data/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/noPropsWithKey.res.txt
@@ -4,7 +4,7 @@ module V4CA = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props): Jsx.element => ReactDOM.jsx("div", {})
+  let make = (_: props): React.element => ReactDOM.jsx("div", {})
   let make = {
     let \"NoPropsWithKey$V4CA" = props => make(props)
 
@@ -17,14 +17,14 @@ module V4CB = {
   type props = {}
 
   @module("c")
-  external make: React.componentLike<props, Jsx.element> = "component"
+  external make: React.componentLike<props, React.element> = "component"
 }
 
 module V4C = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props): Jsx.element =>
+  let make = (_: props): React.element =>
     React.jsxs(
       React.jsxFragment,
       {

--- a/tests/syntax_tests/data/ppx/react/expected/optimizeAutomaticMode.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/optimizeAutomaticMode.res.txt
@@ -7,7 +7,7 @@ module User = {
   @res.jsxComponentProps
   type props<'doctor> = {doctor: 'doctor}
 
-  let make = ({doctor, _}: props<_>): Jsx.element => {
+  let make = ({doctor, _}: props<_>): React.element => {
     ReactDOM.jsx("h1", {id: "h1", children: ?ReactDOM.someElement({React.string(format(doctor))})})
   }
   let make = {

--- a/tests/syntax_tests/data/ppx/react/expected/returnConstraint.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/returnConstraint.res.txt
@@ -4,7 +4,7 @@ module Standard = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props): Jsx.element => React.string("ok")
+  let make = (_: props): React.element => React.string("ok")
   let make = {
     let \"ReturnConstraint$Standard" = props => make(props)
 
@@ -16,7 +16,7 @@ module ForwardRef = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props, _ref): Jsx.element => ReactDOM.jsx("div", {})
+  let make = (_: props, _ref): React.element => ReactDOM.jsx("div", {})
   let make = React.forwardRef({
     let \"ReturnConstraint$ForwardRef" = (props, ref) => make(props, ref)
 
@@ -27,10 +27,10 @@ module ForwardRef = {
 module WithProps = {
   type props = {value: int}
 
-  let make = (props: props): Jsx.element =>
+  let make = (props: props): React.element =>
     ReactDOM.jsx("span", {children: ?ReactDOM.someElement({React.int(props.value)})})
   let make = {
-    let \"ReturnConstraint$WithProps" = (props: props): Jsx.element => make(props)
+    let \"ReturnConstraint$WithProps" = (props: props): React.element => make(props)
     \"ReturnConstraint$WithProps"
   }
 }
@@ -39,7 +39,7 @@ module Async = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = async (_: props): Jsx.element =>
+  let make = async (_: props): React.element =>
     ReactDOM.jsx("div", {children: ?ReactDOM.someElement({React.string("async")})})
   let make = {
     let \"ReturnConstraint$Async" = props => Jsx.promise(make(props))

--- a/tests/syntax_tests/data/ppx/react/expected/sharedProps.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/sharedProps.res.txt
@@ -3,7 +3,7 @@
 module V4A1 = {
   type props = sharedProps<string>
 
-  let make = ({x, y, _}: props): Jsx.element => React.string(x ++ y)
+  let make = ({x, y, _}: props): React.element => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A1" = props => make(props)
 
@@ -14,7 +14,7 @@ module V4A1 = {
 module V4A2 = {
   type props<'a> = sharedProps<'a>
 
-  let make = ({x, y, _}: props<_>): Jsx.element => React.string(x ++ y)
+  let make = ({x, y, _}: props<_>): React.element => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A2" = (props: props<_>) => make(props)
 
@@ -25,7 +25,7 @@ module V4A2 = {
 module V4A3 = {
   type props<'a> = sharedProps<string, 'a>
 
-  let make = ({x, y, _}: props<_>): Jsx.element => React.string(x ++ y)
+  let make = ({x, y, _}: props<_>): React.element => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A3" = (props: props<_>) => make(props)
 
@@ -36,7 +36,7 @@ module V4A3 = {
 module V4A4 = {
   type props = sharedProps
 
-  let make = ({x, y, _}: props): Jsx.element => React.string(x ++ y)
+  let make = ({x, y, _}: props): React.element => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A4" = props => make(props)
 
@@ -47,23 +47,23 @@ module V4A4 = {
 module V4A5 = {
   type props = sharedProps<string>
 
-  external make: React.componentLike<props, Jsx.element> = "default"
+  external make: React.componentLike<props, React.element> = "default"
 }
 
 module V4A6 = {
   type props<'a> = sharedProps<'a>
 
-  external make: React.componentLike<props<_>, Jsx.element> = "default"
+  external make: React.componentLike<props<_>, React.element> = "default"
 }
 
 module V4A7 = {
   type props<'a> = sharedProps<string, 'a>
 
-  external make: React.componentLike<props<_>, Jsx.element> = "default"
+  external make: React.componentLike<props<_>, React.element> = "default"
 }
 
 module V4A8 = {
   type props = sharedProps
 
-  external make: React.componentLike<props, Jsx.element> = "default"
+  external make: React.componentLike<props, React.element> = "default"
 }

--- a/tests/syntax_tests/data/ppx/react/expected/sharedProps.resi.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/sharedProps.resi.txt
@@ -3,25 +3,25 @@
 module V4C1: {
   type props = sharedProps<string>
 
-  let make: React.componentLike<props, Jsx.element>
+  let make: React.componentLike<props, React.element>
 }
 
 module V4C2: {
   type props<'a> = sharedProps<'a>
 
-  let make: React.componentLike<props<_>, Jsx.element>
+  let make: React.componentLike<props<_>, React.element>
 }
 
 module V4C3: {
   type props<'a> = sharedProps<string, 'a>
 
-  let make: React.componentLike<props<_>, Jsx.element>
+  let make: React.componentLike<props<_>, React.element>
 }
 
 module V4C4: {
   type props = sharedProps
 
-  let make: React.componentLike<props, Jsx.element>
+  let make: React.componentLike<props, React.element>
 }
 
 @@jsxConfig({version: 4, mode: "automatic"})
@@ -29,23 +29,23 @@ module V4C4: {
 module V4A1: {
   type props = sharedProps<string>
 
-  let make: React.componentLike<props, Jsx.element>
+  let make: React.componentLike<props, React.element>
 }
 
 module V4A2: {
   type props<'a> = sharedProps<'a>
 
-  let make: React.componentLike<props<_>, Jsx.element>
+  let make: React.componentLike<props<_>, React.element>
 }
 
 module V4A3: {
   type props<'a> = sharedProps<string, 'a>
 
-  let make: React.componentLike<props<_>, Jsx.element>
+  let make: React.componentLike<props<_>, React.element>
 }
 
 module V4A4: {
   type props = sharedProps
 
-  let make: React.componentLike<props, Jsx.element>
+  let make: React.componentLike<props, React.element>
 }

--- a/tests/syntax_tests/data/ppx/react/expected/sharedPropsWithProps.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/sharedPropsWithProps.res.txt
@@ -4,36 +4,36 @@ let f = a => Js.Promise.resolve(a + a)
 
 module V4A1 = {
   type props = sharedProps
-  let make = (props): Jsx.element => React.string(props.x ++ props.y)
+  let make = (props): React.element => React.string(props.x ++ props.y)
   let make = {
-    let \"SharedPropsWithProps$V4A1" = (props): Jsx.element => make(props)
+    let \"SharedPropsWithProps$V4A1" = (props): React.element => make(props)
     \"SharedPropsWithProps$V4A1"
   }
 }
 
 module V4A2 = {
   type props = sharedProps
-  let make = (props: props): Jsx.element => React.string(props.x ++ props.y)
+  let make = (props: props): React.element => React.string(props.x ++ props.y)
   let make = {
-    let \"SharedPropsWithProps$V4A2" = (props: props): Jsx.element => make(props)
+    let \"SharedPropsWithProps$V4A2" = (props: props): React.element => make(props)
     \"SharedPropsWithProps$V4A2"
   }
 }
 
 module V4A3 = {
   type props<'a> = sharedProps<'a>
-  let make = ({x, y}: props<_>): Jsx.element => React.string(x ++ y)
+  let make = ({x, y}: props<_>): React.element => React.string(x ++ y)
   let make = {
-    let \"SharedPropsWithProps$V4A3" = (props: props<_>): Jsx.element => make(props)
+    let \"SharedPropsWithProps$V4A3" = (props: props<_>): React.element => make(props)
     \"SharedPropsWithProps$V4A3"
   }
 }
 
 module V4A4 = {
   type props<'a> = sharedProps<string, 'a>
-  let make = ({x, y}: props<_>): Jsx.element => React.string(x ++ y)
+  let make = ({x, y}: props<_>): React.element => React.string(x ++ y)
   let make = {
-    let \"SharedPropsWithProps$V4A4" = (props: props<_>): Jsx.element => make(props)
+    let \"SharedPropsWithProps$V4A4" = (props: props<_>): React.element => make(props)
     \"SharedPropsWithProps$V4A4"
   }
 }
@@ -42,24 +42,24 @@ module V4A5 = {
   type props<'a> = {a: 'a}
   let make = async ({a}: props<_>) => {
     let a = await f(a)
-    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement({React.int(a)})}): Jsx.element)
+    (ReactDOM.jsx("div", {children: ?ReactDOM.someElement({React.int(a)})}): React.element)
   }
   let make = {
-    let \"SharedPropsWithProps$V4A5" = (props: props<_>): Jsx.element => Jsx.promise(make(props))
+    let \"SharedPropsWithProps$V4A5" = (props: props<_>): React.element => Jsx.promise(make(props))
     \"SharedPropsWithProps$V4A5"
   }
 }
 
 module V4A6 = {
   type props<'status> = {status: 'status}
-  let make = async ({status}: props<_>): Jsx.element => {
+  let make = async ({status}: props<_>): React.element => {
     switch status {
     | #on => React.string("on")
     | #off => React.string("off")
     }
   }
   let make = {
-    let \"SharedPropsWithProps$V4A6" = (props: props<_>): Jsx.element => Jsx.promise(make(props))
+    let \"SharedPropsWithProps$V4A6" = (props: props<_>): React.element => Jsx.promise(make(props))
     \"SharedPropsWithProps$V4A6"
   }
 }
@@ -67,11 +67,12 @@ module V4A6 = {
 module V4A7 = {
   type props = {count: int}
 
-  let make = (props): Jsx.element => {
+  let make = (props): React.element => {
     React.int(props.count)
   }
   let make = {
-    let \"SharedPropsWithProps$V4A7" = @directive("'use memo'") (props): Jsx.element => make(props)
+    let \"SharedPropsWithProps$V4A7" =
+      @directive("'use memo'") (props): React.element => make(props)
     \"SharedPropsWithProps$V4A7"
   }
 }

--- a/tests/syntax_tests/data/ppx/react/expected/topLevel.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/topLevel.res.txt
@@ -6,7 +6,7 @@ module V4A = {
 
   let make = ({a, b, _}: props<_, _>) => {
     Js.log("This function should be named 'TopLevel.react'")
-    (ReactDOM.jsx("div", {}): Jsx.element)
+    (ReactDOM.jsx("div", {}): React.element)
   }
   let make = {
     let \"TopLevel$V4A" = (props: props<_>) => make(props)

--- a/tests/syntax_tests/data/ppx/react/expected/typeConstraint.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/typeConstraint.res.txt
@@ -4,7 +4,7 @@ module V4A = {
   @res.jsxComponentProps
   type props<'a, 'b> = {a: 'a, b: 'b}
 
-  let make = (type a, {a, b, _}: props<_, _>): Jsx.element => ReactDOM.jsx("div", {})
+  let make = (type a, {a, b, _}: props<_, _>): React.element => ReactDOM.jsx("div", {})
   let make = {
     let \"TypeConstraint$V4A" = (props: props<_>) => make(props)
 

--- a/tests/syntax_tests/data/ppx/react/expected/uncurriedProps.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/uncurriedProps.res.txt
@@ -7,7 +7,7 @@ let make = ({a: ?__a, _}: props<unit => unit>) => {
   | Some(a) => a
   | None => () => ()
   }
-  (React.null: Jsx.element)
+  (React.null: React.element)
 }
 let make = {
   let \"UncurriedProps" = (props: props<_>) => make(props)
@@ -37,7 +37,7 @@ module Foo = {
     (
       {
         React.null
-      }: Jsx.element
+      }: React.element
     )
   }
   let make = {
@@ -51,7 +51,7 @@ module Bar = {
   @res.jsxComponentProps
   type props = {}
 
-  let make = (_: props): Jsx.element => React.jsx(Foo.make, {callback: {(_, _, _) => ()}})
+  let make = (_: props): React.element => React.jsx(Foo.make, {callback: {(_, _, _) => ()}})
   let make = {
     let \"UncurriedProps$Bar" = props => make(props)
 

--- a/tests/syntax_tests/data/ppx/react/expected/v4.res.txt
+++ b/tests/syntax_tests/data/ppx/react/expected/v4.res.txt
@@ -1,6 +1,6 @@
 @res.jsxComponentProps
 type props<'x, 'y> = {x: 'x, y: 'y} // Component with type constraint
-let make = ({x, y, _}: props<string, string>): Jsx.element => React.string(x ++ y)
+let make = ({x, y, _}: props<string, string>): React.element => React.string(x ++ y)
 let make = {
   let \"V4" = (props: props<_>) => make(props)
   \"V4"
@@ -11,7 +11,7 @@ module AnotherName = {
   type // Component with another name than "make"
   props<'x> = {x: 'x}
 
-  let anotherName = ({x, _}: props<_>): Jsx.element => React.string(x)
+  let anotherName = ({x, _}: props<_>): React.element => React.string(x)
   let anotherName = {
     let \"V4$AnotherName$anotherName" = (props: props<_>) => anotherName(props)
 
@@ -23,7 +23,7 @@ module Uncurried = {
   @res.jsxComponentProps
   type props<'x> = {x: 'x}
 
-  let make = ({x, _}: props<_>): Jsx.element => React.string(x)
+  let make = ({x, _}: props<_>): React.element => React.string(x)
   let make = {
     let \"V4$Uncurried" = (props: props<_>) => make(props)
 
@@ -35,21 +35,21 @@ module type TUncurried = {
   @res.jsxComponentProps
   type props<'x> = {x: 'x}
 
-  let make: React.componentLike<props<string>, Jsx.element>
+  let make: React.componentLike<props<string>, React.element>
 }
 
 module E = {
   @res.jsxComponentProps @live
   type props<'x> = {x: 'x}
 
-  external make: React.componentLike<props<string>, Jsx.element> = "default"
+  external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module EUncurried = {
   @res.jsxComponentProps @live
   type props<'x> = {x: 'x}
 
-  external make: React.componentLike<props<string>, Jsx.element> = "default"
+  external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module Rec = {
@@ -57,7 +57,7 @@ module Rec = {
   type props = {}
 
   let rec make = {
-    let \"make$Internal" = (_: props): Jsx.element => {
+    let \"make$Internal" = (_: props): React.element => {
       make(({}: props))
     }
     let make = {
@@ -74,7 +74,7 @@ module Rec1 = {
   type props = {}
 
   let rec make = {
-    let \"make$Internal" = (_: props): Jsx.element => {
+    let \"make$Internal" = (_: props): React.element => {
       React.null
     }
     let make = {
@@ -91,7 +91,7 @@ module Rec2 = {
   type props = {}
 
   let rec make = {
-    let \"make$Internal" = (_: props): Jsx.element => {
+    let \"make$Internal" = (_: props): React.element => {
       mm(({}: props))
     }
     let make = {


### PR DESCRIPTION
Determine module to use for the return type constraint from the Jsx config.