### PR TITLE
Fix error handling when rescript.json parsing fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Fix missing `ignore` function in some Stdlib modules. https://github.com/rescript-lang/rescript/pull/8060
 - Fix signature matching for externals when abstract alias hides function arity. https://github.com/rescript-lang/rescript/pull/8045
 - Fix arity detection for arrows returning nested generics. https://github.com/rescript-lang/rescript/pull/8064
-- Fix error handling when rescript.json parsing fails. https://github.com/rescript-lang/rescript/pull/8067
+- Fix error handling when rescript.json parsing fails and improve error message. https://github.com/rescript-lang/rescript/pull/8067
 
 #### :memo: Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix missing `ignore` function in some Stdlib modules. https://github.com/rescript-lang/rescript/pull/8060
 - Fix signature matching for externals when abstract alias hides function arity. https://github.com/rescript-lang/rescript/pull/8045
 - Fix arity detection for arrows returning nested generics. https://github.com/rescript-lang/rescript/pull/8064
+- Fix error handling when rescript.json parsing fails. https://github.com/rescript-lang/rescript/pull/8067
 
 #### :memo: Documentation
 

--- a/rewatch/Cargo.lock
+++ b/rewatch/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "serde_path_to_error",
  "sysinfo",
  "tempfile",
 ]
@@ -872,6 +873,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/rewatch/Cargo.toml
+++ b/rewatch/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93" }
 serde_ignored = "0.1.11"
+serde_path_to_error = "0.1.16"
 sysinfo = "0.29.10"
 tempfile = "3.10.1"
 

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -16,7 +16,7 @@ use crate::helpers::emojis::*;
 use crate::helpers::{self};
 use crate::project_context::ProjectContext;
 use crate::{config, sourcedirs};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use build_types::*;
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -501,7 +501,7 @@ pub fn build(
         plain_output,
         warn_error,
     )
-    .map_err(|e| anyhow!("Could not initialize build. Error: {e}"))?;
+    .with_context(|| "Could not initialize build")?;
 
     match incremental_build(
         &mut build_state,

--- a/rewatch/src/main.rs
+++ b/rewatch/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
                 (*build_args.warn_error).clone(),
             ) {
                 Err(e) => {
-                    println!("{e}");
+                    println!("{:#}", e);
                     std::process::exit(1)
                 }
                 Ok(_) => {
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
                 );
             }
 
-            watcher::start(
+            match watcher::start(
                 &watch_args.filter,
                 show_progress,
                 &watch_args.folder,
@@ -84,9 +84,13 @@ fn main() -> Result<()> {
                 *watch_args.create_sourcedirs,
                 plain_output,
                 (*watch_args.warn_error).clone(),
-            );
-
-            Ok(())
+            ) {
+                Err(e) => {
+                    println!("{:#}", e);
+                    std::process::exit(1)
+                }
+                Ok(_) => Ok(()),
+            }
         }
         cli::Command::Clean { folder, dev } => {
             let _lock = get_lock(&folder);

--- a/rewatch/src/project_context.rs
+++ b/rewatch/src/project_context.rs
@@ -2,8 +2,8 @@ use crate::build::packages;
 use crate::config::Config;
 use crate::helpers;
 use ahash::{AHashMap, AHashSet};
-use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::{Context, Result};
 use log::debug;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -168,7 +168,7 @@ impl ProjectContext {
     pub fn new(path: &Path) -> Result<ProjectContext> {
         let path = helpers::get_abs_path(path);
         let current_config = packages::read_config(&path)
-            .map_err(|_| anyhow!("Could not read rescript.json at {}", path.to_string_lossy()))?;
+            .with_context(|| format!("Could not read rescript.json at {}", path.to_string_lossy()))?;
         let nearest_parent_config_path = match path.parent() {
             None => Err(anyhow!(
                 "The current path \"{}\" does not have a parent folder",

--- a/rewatch/tests/experimental.sh
+++ b/rewatch/tests/experimental.sh
@@ -38,3 +38,88 @@ fi
 mv rescript.json.bak rescript.json
 
 success "experimental-features emits -enable-experimental twice as string list"
+
+bold "Test: build surfaces experimental-features list parse error"
+
+cp rescript.json rescript.json.bak
+
+node -e '
+const fs = require("fs");
+const j = JSON.parse(fs.readFileSync("rescript.json", "utf8"));
+j["experimental-features"] = ["LetUnwrap"];
+fs.writeFileSync("rescript.json", JSON.stringify(j, null, 2));
+'
+
+out=$(rewatch build 2>&1)
+status=$?
+
+mv rescript.json.bak rescript.json
+rm -f lib/rescript.lock
+
+if [ $status -eq 0 ]; then
+  error "Expected build to fail for experimental-features list input"
+  echo "$out"
+  exit 1
+fi
+
+echo "$out" | grep -q "Could not read rescript.json"
+if [ $? -ne 0 ]; then
+  error "Missing rescript.json path context in build error"
+  echo "$out"
+  exit 1
+fi
+
+echo "$out" | grep -qi "invalid type"
+if [ $? -ne 0 ]; then
+  error "Missing detailed parse error in build output"
+  echo "$out"
+  exit 1
+fi
+
+success "Experimental-features list produces detailed build error"
+
+bold "Test: watch reports invalid experimental-features without panicking"
+
+cp rescript.json rescript.json.bak
+
+node -e '
+const fs = require("fs");
+const cfg = JSON.parse(fs.readFileSync("rescript.json", "utf8"));
+cfg["experimental-features"] = ["LetUnwrap"];
+fs.writeFileSync("rescript.json", JSON.stringify(cfg, null, 2));
+'
+
+out=$(rewatch watch 2>&1)
+status=$?
+
+mv rescript.json.bak rescript.json
+rm -f lib/rescript.lock
+
+if [ $status -eq 0 ]; then
+  error "Expected watch to fail for invalid experimental-features list"
+  echo "$out"
+  exit 1
+fi
+
+echo "$out" | grep -q "Could not read rescript.json"
+if [ $? -ne 0 ]; then
+  error "Missing rescript.json path context in watch error"
+  echo "$out"
+  exit 1
+fi
+
+echo "$out" | grep -qi "invalid type"
+if [ $? -ne 0 ]; then
+  error "Missing detailed parse error for experimental-features list"
+  echo "$out"
+  exit 1
+fi
+
+echo "$out" | grep -q "panicked"
+if [ $? -eq 0 ]; then
+  error "Watcher should not panic when config is invalid"
+  echo "$out"
+  exit 1
+fi
+
+success "Invalid experimental-features list handled without panic"

--- a/rewatch/tests/experimental.sh
+++ b/rewatch/tests/experimental.sh
@@ -69,7 +69,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "$out" | grep -qi "invalid type"
+echo "$out" | grep -qi "experimental-features.*invalid type"
 if [ $? -ne 0 ]; then
   error "Missing detailed parse error in build output"
   echo "$out"
@@ -108,7 +108,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "$out" | grep -qi "invalid type"
+echo "$out" | grep -qi "experimental-features.*invalid type"
 if [ $? -ne 0 ]; then
   error "Missing detailed parse error for experimental-features list"
   echo "$out"

--- a/rewatch/tests/snapshots/clean-rebuild.txt
+++ b/rewatch/tests/snapshots/clean-rebuild.txt
@@ -11,6 +11,6 @@ Use 'dev-dependencies' instead.
 The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
 Use 'compiler-flags' instead.
 
-The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript's new build system (rewatch).
+The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.


### PR DESCRIPTION
Fixes #8034, and also makes sure that the error message is helpful to the user (pointing to the error location).

I.e., instead of a panic with

> Can't initialize build: Could not read rescript.json at /some/path

we'll now get a clean exit with

> Could not initialize build: Could not read rescript.json at /some/path: Failed to parse rescript.json at experimental-features: invalid type: sequence, expected a map at line 33 column 27