### PR TITLE
Fix incorrect analysis report for optional function args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix reanalyze optional-argument diagnostics for functions passed or returned as first-class values. https://github.com/rescript-lang/rescript/pull/8321
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### :bug: Bug fix
 
 - Preserve multibyte characters when wrapping long source lines in compiler code frames. https://github.com/rescript-lang/rescript/pull/8520
+- Fix reanalyze optional-argument diagnostics for functions passed or returned as first-class values. https://github.com/rescript-lang/rescript/pull/8321
 
 #### :memo: Documentation
 

--- a/analysis/reanalyze/src/cross_file_items.ml
+++ b/analysis/reanalyze/src/cross_file_items.ml
@@ -16,24 +16,36 @@ type optional_arg_call = {
 
 type function_ref = {pos_from: Lexing.position; pos_to: Lexing.position}
 
+type optional_arg_value_escape = {
+  pos_from: Lexing.position;
+  pos_to: Lexing.position;
+}
+
 (** {2 Types} *)
 
 type t = {
   exception_refs: exception_ref list;
   optional_arg_calls: optional_arg_call list;
   function_refs: function_ref list;
+  optional_arg_value_escapes: optional_arg_value_escape list;
 }
 
 type builder = {
   mutable exception_refs: exception_ref list;
   mutable optional_arg_calls: optional_arg_call list;
   mutable function_refs: function_ref list;
+  mutable optional_arg_value_escapes: optional_arg_value_escape list;
 }
 
 (** {2 Builder API} *)
 
 let create_builder () : builder =
-  {exception_refs = []; optional_arg_calls = []; function_refs = []}
+  {
+    exception_refs = [];
+    optional_arg_calls = [];
+    function_refs = [];
+    optional_arg_value_escapes = [];
+  }
 
 let add_exception_ref (b : builder) ~exception_path ~loc_from =
   b.exception_refs <- {exception_path; loc_from} :: b.exception_refs
@@ -46,6 +58,10 @@ let add_optional_arg_call (b : builder) ~pos_from ~pos_to ~arg_names
 let add_function_reference (b : builder) ~pos_from ~pos_to =
   b.function_refs <- {pos_from; pos_to} :: b.function_refs
 
+let add_optional_arg_value_escape (b : builder) ~pos_from ~pos_to =
+  b.optional_arg_value_escapes <-
+    {pos_from; pos_to} :: b.optional_arg_value_escapes
+
 (** {2 Merge API} *)
 
 let merge_all (builders : builder list) : t =
@@ -56,7 +72,15 @@ let merge_all (builders : builder list) : t =
     builders |> List.concat_map (fun b -> b.optional_arg_calls)
   in
   let function_refs = builders |> List.concat_map (fun b -> b.function_refs) in
-  {exception_refs; optional_arg_calls; function_refs}
+  let optional_arg_value_escapes =
+    builders |> List.concat_map (fun b -> b.optional_arg_value_escapes)
+  in
+  {
+    exception_refs;
+    optional_arg_calls;
+    function_refs;
+    optional_arg_value_escapes;
+  }
 
 (** {2 Builder extraction for reactive merge} *)
 
@@ -65,6 +89,7 @@ let builder_to_t (builder : builder) : t =
     exception_refs = builder.exception_refs;
     optional_arg_calls = builder.optional_arg_calls;
     function_refs = builder.function_refs;
+    optional_arg_value_escapes = builder.optional_arg_value_escapes;
   }
 
 (** {2 Processing API} *)

--- a/analysis/reanalyze/src/cross_file_items.mli
+++ b/analysis/reanalyze/src/cross_file_items.mli
@@ -18,12 +18,18 @@ type optional_arg_call = {
 
 type function_ref = {pos_from: Lexing.position; pos_to: Lexing.position}
 
+type optional_arg_value_escape = {
+  pos_from: Lexing.position;
+  pos_to: Lexing.position;
+}
+
 (** {2 Types} *)
 
 type t = {
   exception_refs: exception_ref list;
   optional_arg_calls: optional_arg_call list;
   function_refs: function_ref list;
+  optional_arg_value_escapes: optional_arg_value_escape list;
 }
 (** Immutable cross-file items - for processing after merge *)
 
@@ -49,7 +55,10 @@ val add_optional_arg_call :
 
 val add_function_reference :
   builder -> pos_from:Lexing.position -> pos_to:Lexing.position -> unit
-(** Add a cross-file function reference (for optional args combining). *)
+
+val add_optional_arg_value_escape :
+  builder -> pos_from:Lexing.position -> pos_to:Lexing.position -> unit
+(** Record an optional-arg function used as a first-class value. *)
 
 (** {2 Merge API} *)
 

--- a/analysis/reanalyze/src/cross_file_items_store.ml
+++ b/analysis/reanalyze/src/cross_file_items_store.ml
@@ -80,4 +80,21 @@ let compute_live_optional_arg_value_escapes (store : t) ~is_live : Pos_set.t =
   iter_optional_arg_value_escapes store
     (fun {Cross_file_items.pos_from; pos_to} ->
       if is_live pos_from then escapes := Pos_set.add pos_to !escapes);
-  !escapes
+  let function_refs = ref [] in
+  iter_function_refs store (fun {Cross_file_items.pos_from; pos_to} ->
+      if is_live pos_from then
+        function_refs := (pos_from, pos_to) :: !function_refs);
+  (* A function reference aliases both declaration positions. Close escapes over
+     the undirected links so aliases and interface/implementation pairs agree. *)
+  let rec propagate escapes =
+    let propagated =
+      List.fold_left
+        (fun escapes (pos_from, pos_to) ->
+          if Pos_set.mem pos_from escapes then Pos_set.add pos_to escapes
+          else if Pos_set.mem pos_to escapes then Pos_set.add pos_from escapes
+          else escapes)
+        escapes !function_refs
+    in
+    if Pos_set.equal propagated escapes then escapes else propagate propagated
+  in
+  propagate !escapes

--- a/analysis/reanalyze/src/cross_file_items_store.ml
+++ b/analysis/reanalyze/src/cross_file_items_store.ml
@@ -28,6 +28,15 @@ let iter_function_refs t f =
       (fun _path items -> List.iter f items.Cross_file_items.function_refs)
       r
 
+let iter_optional_arg_value_escapes t f =
+  match t with
+  | Frozen cfi -> List.iter f cfi.Cross_file_items.optional_arg_value_escapes
+  | Reactive r ->
+    Reactive.iter
+      (fun _path items ->
+        List.iter f items.Cross_file_items.optional_arg_value_escapes)
+      r
+
 (** Compute optional args state from calls and function references.
     Returns a map from position to final OptionalArgs.t state.
     Pure function - does not mutate declarations. *)
@@ -65,3 +74,10 @@ let compute_optional_args_state (store : t) ~find_decl ~is_live :
           set_state pos_from updated_from;
           set_state pos_to updated_to));
   state
+
+let compute_live_optional_arg_value_escapes (store : t) ~is_live : Pos_set.t =
+  let escapes = ref Pos_set.empty in
+  iter_optional_arg_value_escapes store
+    (fun {Cross_file_items.pos_from; pos_to} ->
+      if is_live pos_from then escapes := Pos_set.add pos_to !escapes);
+  !escapes

--- a/analysis/reanalyze/src/cross_file_items_store.ml
+++ b/analysis/reanalyze/src/cross_file_items_store.ml
@@ -65,22 +65,3 @@ let compute_optional_args_state (store : t) ~find_decl ~is_live :
           set_state pos_from updated_from;
           set_state pos_to updated_to));
   state
-
-let compute_live_direct_optional_arg_calls (store : t) ~find_decl ~is_live :
-    Pos_set.t =
-  let direct_calls = ref Pos_set.empty in
-  iter_optional_arg_calls store (fun {Cross_file_items.pos_from; pos_to; _} ->
-      if is_live pos_from then
-        match find_decl pos_to with
-        | Some
-            {
-              Decl.decl_kind =
-                Value
-                  {
-                    optional_args_report =
-                      Decl.Kind.ReportOptionalArgsIfDirectCall;
-                  };
-            } ->
-          direct_calls := Pos_set.add pos_to !direct_calls
-        | _ -> ());
-  !direct_calls

--- a/analysis/reanalyze/src/cross_file_items_store.ml
+++ b/analysis/reanalyze/src/cross_file_items_store.ml
@@ -65,3 +65,22 @@ let compute_optional_args_state (store : t) ~find_decl ~is_live :
           set_state pos_from updated_from;
           set_state pos_to updated_to));
   state
+
+let compute_live_direct_optional_arg_calls (store : t) ~find_decl ~is_live :
+    Pos_set.t =
+  let direct_calls = ref Pos_set.empty in
+  iter_optional_arg_calls store (fun {Cross_file_items.pos_from; pos_to; _} ->
+      if is_live pos_from then
+        match find_decl pos_to with
+        | Some
+            {
+              Decl.decl_kind =
+                Value
+                  {
+                    optional_args_report =
+                      Decl.Kind.ReportOptionalArgsIfDirectCall;
+                  };
+            } ->
+          direct_calls := Pos_set.add pos_to !direct_calls
+        | _ -> ());
+  !direct_calls

--- a/analysis/reanalyze/src/cross_file_items_store.ml
+++ b/analysis/reanalyze/src/cross_file_items_store.ml
@@ -76,6 +76,9 @@ let compute_optional_args_state (store : t) ~find_decl ~is_live :
   state
 
 let compute_live_optional_arg_value_escapes (store : t) ~is_live : Pos_set.t =
+  (* Compute this as a batch after solver propagation: the result depends on
+     final liveness and on the fully merged cross-file items. If it becomes a
+     cached/reactive value, both dependencies must participate in invalidation. *)
   let escapes = ref Pos_set.empty in
   iter_optional_arg_value_escapes store
     (fun {Cross_file_items.pos_from; pos_to} ->

--- a/analysis/reanalyze/src/cross_file_items_store.mli
+++ b/analysis/reanalyze/src/cross_file_items_store.mli
@@ -22,9 +22,17 @@ val iter_optional_arg_calls :
 val iter_function_refs : t -> (Cross_file_items.function_ref -> unit) -> unit
 (** Iterate over all function refs *)
 
+val iter_optional_arg_value_escapes :
+  t -> (Cross_file_items.optional_arg_value_escape -> unit) -> unit
+(** Iterate over optional-arg functions used as first-class values *)
+
 val compute_optional_args_state :
   t ->
   find_decl:(Lexing.position -> Decl.t option) ->
   is_live:(Lexing.position -> bool) ->
   Optional_args_state.t
 (** Compute optional args state from calls and function references *)
+
+val compute_live_optional_arg_value_escapes :
+  t -> is_live:(Lexing.position -> bool) -> Pos_set.t
+(** Compute optional-arg declarations with live first-class value escapes *)

--- a/analysis/reanalyze/src/cross_file_items_store.mli
+++ b/analysis/reanalyze/src/cross_file_items_store.mli
@@ -28,3 +28,10 @@ val compute_optional_args_state :
   is_live:(Lexing.position -> bool) ->
   Optional_args_state.t
 (** Compute optional args state from calls and function references *)
+
+val compute_live_direct_optional_arg_calls :
+  t ->
+  find_decl:(Lexing.position -> Decl.t option) ->
+  is_live:(Lexing.position -> bool) ->
+  Pos_set.t
+(** Compute live optional-arg call targets that hit reporting declarations directly *)

--- a/analysis/reanalyze/src/cross_file_items_store.mli
+++ b/analysis/reanalyze/src/cross_file_items_store.mli
@@ -28,10 +28,3 @@ val compute_optional_args_state :
   is_live:(Lexing.position -> bool) ->
   Optional_args_state.t
 (** Compute optional args state from calls and function references *)
-
-val compute_live_direct_optional_arg_calls :
-  t ->
-  find_decl:(Lexing.position -> Decl.t option) ->
-  is_live:(Lexing.position -> bool) ->
-  Pos_set.t
-(** Compute live optional-arg call targets that hit reporting declarations directly *)

--- a/analysis/reanalyze/src/dead_common.ml
+++ b/analysis/reanalyze/src/dead_common.ml
@@ -124,13 +124,13 @@ let addDeclaration_ ~config ~decls ~(file : File_context.t) ?pos_end ?pos_start
     Declarations.add decls pos decl)
 
 let add_value_declaration ~config ~decls ~file ?(is_toplevel = true)
-    ?(reports_optional_args = false) ~(loc : Location.t) ~module_loc
-    ?(optional_args = Optional_args.empty) ~path ~side_effects name =
+    ?(optional_args_report = Decl.Kind.NoOptionalArgReport) ~(loc : Location.t)
+    ~module_loc ?(optional_args = Optional_args.empty) ~path ~side_effects name
+    =
   name
   |> addDeclaration_ ~config ~decls ~file
        ~decl_kind:
-         (Value
-            {is_toplevel; reports_optional_args; optional_args; side_effects})
+         (Value {is_toplevel; optional_args_report; optional_args; side_effects})
        ~loc ~module_loc ~path
 
 (** Create a dead code issue. Pure - no side effects. *)

--- a/analysis/reanalyze/src/dead_common.ml
+++ b/analysis/reanalyze/src/dead_common.ml
@@ -124,11 +124,13 @@ let addDeclaration_ ~config ~decls ~(file : File_context.t) ?pos_end ?pos_start
     Declarations.add decls pos decl)
 
 let add_value_declaration ~config ~decls ~file ?(is_toplevel = true)
-    ~(loc : Location.t) ~module_loc ?(optional_args = Optional_args.empty) ~path
-    ~side_effects name =
+    ?(reports_optional_args = false) ~(loc : Location.t) ~module_loc
+    ?(optional_args = Optional_args.empty) ~path ~side_effects name =
   name
   |> addDeclaration_ ~config ~decls ~file
-       ~decl_kind:(Value {is_toplevel; optional_args; side_effects})
+       ~decl_kind:
+         (Value
+            {is_toplevel; reports_optional_args; optional_args; side_effects})
        ~loc ~module_loc ~path
 
 (** Create a dead code issue. Pure - no side effects. *)

--- a/analysis/reanalyze/src/dead_common.ml
+++ b/analysis/reanalyze/src/dead_common.ml
@@ -124,13 +124,13 @@ let addDeclaration_ ~config ~decls ~(file : File_context.t) ?pos_end ?pos_start
     Declarations.add decls pos decl)
 
 let add_value_declaration ~config ~decls ~file ?(is_toplevel = true)
-    ?(optional_args_report = Decl.Kind.NoOptionalArgReport) ~(loc : Location.t)
-    ~module_loc ?(optional_args = Optional_args.empty) ~path ~side_effects name
-    =
+    ?(reports_optional_args = false) ~(loc : Location.t) ~module_loc
+    ?(optional_args = Optional_args.empty) ~path ~side_effects name =
   name
   |> addDeclaration_ ~config ~decls ~file
        ~decl_kind:
-         (Value {is_toplevel; optional_args_report; optional_args; side_effects})
+         (Value
+            {is_toplevel; reports_optional_args; optional_args; side_effects})
        ~loc ~module_loc ~path
 
 (** Create a dead code issue. Pure - no side effects. *)

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -78,19 +78,10 @@ let add_references ~config ~cross_file ~(loc_from : Location.t)
 
 (** Check for optional args issues. Returns issues instead of logging.
     Uses optional_args_state map for final computed state. *)
-let check ~optional_args_state ~direct_optional_arg_calls ~ann_store ~config:_
-    decl : Issue.t list =
-  let should_report_optional_args =
-    let open Decl.Kind in
-    match decl.Decl.decl_kind with
-    | Value {optional_args_report = ReportOptionalArgs} -> true
-    | Value {optional_args_report = ReportOptionalArgsIfDirectCall} ->
-      Pos_set.mem decl.pos direct_optional_arg_calls
-    | _ -> false
-  in
+let check ~optional_args_state ~ann_store ~config:_ decl : Issue.t list =
   match decl with
-  | {Decl.decl_kind = Value {optional_args}}
-    when active () && should_report_optional_args
+  | {Decl.decl_kind = Value {reports_optional_args = true; optional_args}}
+    when active ()
          && not
               (Annotation_store.is_annotated_gentype_or_live ann_store decl.pos)
     ->

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -78,10 +78,12 @@ let add_references ~config ~cross_file ~(loc_from : Location.t)
 
 (** Check for optional args issues. Returns issues instead of logging.
     Uses optional_args_state map for final computed state. *)
-let check ~optional_args_state ~ann_store ~config:_ decl : Issue.t list =
+let check ~optional_args_state ~optional_arg_value_escapes ~ann_store ~config:_
+    decl : Issue.t list =
   match decl with
   | {Decl.decl_kind = Value {reports_optional_args = true; optional_args}}
     when active ()
+         && (not (Pos_set.mem decl.pos optional_arg_value_escapes))
          && not
               (Annotation_store.is_annotated_gentype_or_live ann_store decl.pos)
     ->

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -14,7 +14,12 @@ let add_function_reference ~config ~decls ~cross_file ~(loc_from : Location.t)
       | _ -> false
     in
     let should_add =
-      has_optional_arg_state pos_from && has_optional_arg_state pos_to
+      if
+        pos_to.pos_fname <> pos_from.pos_fname
+        && (file_is_implementation_of pos_to.pos_fname pos_from.pos_fname
+           || file_is_implementation_of pos_from.pos_fname pos_to.pos_fname)
+      then has_optional_arg_state pos_to
+      else has_optional_arg_state pos_from && has_optional_arg_state pos_to
     in
     if should_add then (
       if config.Dce_config.cli.debug then
@@ -73,10 +78,19 @@ let add_references ~config ~cross_file ~(loc_from : Location.t)
 
 (** Check for optional args issues. Returns issues instead of logging.
     Uses optional_args_state map for final computed state. *)
-let check ~optional_args_state ~ann_store ~config:_ decl : Issue.t list =
+let check ~optional_args_state ~direct_optional_arg_calls ~ann_store ~config:_
+    decl : Issue.t list =
+  let should_report_optional_args =
+    let open Decl.Kind in
+    match decl.Decl.decl_kind with
+    | Value {optional_args_report = ReportOptionalArgs} -> true
+    | Value {optional_args_report = ReportOptionalArgsIfDirectCall} ->
+      Pos_set.mem decl.pos direct_optional_arg_calls
+    | _ -> false
+  in
   match decl with
-  | {Decl.decl_kind = Value {reports_optional_args = true; optional_args}}
-    when active ()
+  | {Decl.decl_kind = Value {optional_args}}
+    when active () && should_report_optional_args
          && not
               (Annotation_store.is_annotated_gentype_or_live ann_store decl.pos)
     ->

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -2,32 +2,6 @@ open Dead_common
 
 let active () = true
 
-let add_function_reference ~config ~decls ~cross_file ~(loc_from : Location.t)
-    ~(loc_to : Location.t) =
-  if active () then
-    let pos_to = loc_to.loc_start in
-    let pos_from = loc_from.loc_start in
-    let has_optional_arg_state pos =
-      match Declarations.find_opt_builder decls pos with
-      | Some {decl_kind = Value {optional_args}} ->
-        not (Optional_args.is_empty optional_args)
-      | _ -> false
-    in
-    let should_add =
-      if
-        pos_to.pos_fname <> pos_from.pos_fname
-        && (file_is_implementation_of pos_to.pos_fname pos_from.pos_fname
-           || file_is_implementation_of pos_from.pos_fname pos_to.pos_fname)
-      then has_optional_arg_state pos_to
-      else has_optional_arg_state pos_from && has_optional_arg_state pos_to
-    in
-    if should_add then (
-      if config.Dce_config.cli.debug then
-        Log_.item "OptionalArgs.addFunctionReference %s %s@."
-          (pos_from |> Pos.to_string)
-          (pos_to |> Pos.to_string);
-      Cross_file_items.add_function_reference cross_file ~pos_from ~pos_to)
-
 let rec has_optional_args (texpr : Types.type_expr) =
   match texpr.desc with
   | _ when not (active ()) -> false
@@ -36,6 +10,17 @@ let rec has_optional_args (texpr : Types.type_expr) =
   | Tlink t -> has_optional_args t
   | Tsubst t -> has_optional_args t
   | _ -> false
+
+let add_function_reference ~config ~cross_file ~(loc_from : Location.t)
+    ~(loc_to : Location.t) ~type_from ~type_to =
+  if has_optional_args type_from && has_optional_args type_to then (
+    let pos_to = loc_to.loc_start in
+    let pos_from = loc_from.loc_start in
+    if config.Dce_config.cli.debug then
+      Log_.item "OptionalArgs.addFunctionReference %s %s@."
+        (pos_from |> Pos.to_string)
+        (pos_to |> Pos.to_string);
+    Cross_file_items.add_function_reference cross_file ~pos_from ~pos_to)
 
 let rec from_type_expr (texpr : Types.type_expr) =
   match texpr.desc with

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -7,12 +7,14 @@ let add_function_reference ~config ~decls ~cross_file ~(loc_from : Location.t)
   if active () then
     let pos_to = loc_to.loc_start in
     let pos_from = loc_from.loc_start in
-    (* Check if target has optional args - for filtering and debug logging *)
-    let should_add =
-      match Declarations.find_opt_builder decls pos_to with
+    let has_optional_arg_state pos =
+      match Declarations.find_opt_builder decls pos with
       | Some {decl_kind = Value {optional_args}} ->
         not (Optional_args.is_empty optional_args)
       | _ -> false
+    in
+    let should_add =
+      has_optional_arg_state pos_from && has_optional_arg_state pos_to
     in
     if should_add then (
       if config.Dce_config.cli.debug then
@@ -39,6 +41,18 @@ let rec from_type_expr (texpr : Types.type_expr) =
   | Tsubst t -> from_type_expr t
   | _ -> []
 
+let rec from_type_expr_with_arity (texpr : Types.type_expr) arity =
+  if arity <= 0 then []
+  else
+    match texpr.desc with
+    | _ when not (active ()) -> []
+    | Tarrow ({lbl = Optional {txt = s}}, t_to, _, _) ->
+      s :: from_type_expr_with_arity t_to (arity - 1)
+    | Tarrow (_, t_to, _, _) -> from_type_expr_with_arity t_to (arity - 1)
+    | Tlink t -> from_type_expr_with_arity t arity
+    | Tsubst t -> from_type_expr_with_arity t arity
+    | _ -> []
+
 let add_references ~config ~cross_file ~(loc_from : Location.t)
     ~(loc_to : Location.t) ~(binding : Location.t) ~path
     (arg_names, arg_names_maybe) =
@@ -61,7 +75,7 @@ let add_references ~config ~cross_file ~(loc_from : Location.t)
     Uses optional_args_state map for final computed state. *)
 let check ~optional_args_state ~ann_store ~config:_ decl : Issue.t list =
   match decl with
-  | {Decl.decl_kind = Value {optional_args}}
+  | {Decl.decl_kind = Value {reports_optional_args = true; optional_args}}
     when active ()
          && not
               (Annotation_store.is_annotated_gentype_or_live ann_store decl.pos)

--- a/analysis/reanalyze/src/dead_optional_args.ml
+++ b/analysis/reanalyze/src/dead_optional_args.ml
@@ -13,6 +13,9 @@ let rec has_optional_args (texpr : Types.type_expr) =
 
 let add_function_reference ~config ~cross_file ~(loc_from : Location.t)
     ~(loc_to : Location.t) ~type_from ~type_to =
+  (* Keep this filter type-based rather than consulting the declaration table.
+     References can be collected before their target declaration is visited,
+     notably in [let rec ... and ...] groups. *)
   if has_optional_args type_from && has_optional_args type_to then (
     let pos_to = loc_to.loc_start in
     let pos_from = loc_from.loc_start in
@@ -43,6 +46,13 @@ let rec from_type_expr_with_arity (texpr : Types.type_expr) arity =
     | Tsubst t -> from_type_expr_with_arity t arity
     | _ -> []
 
+let rec from_type_expr_with_declared_arity (texpr : Types.type_expr) =
+  match texpr.desc with
+  | Tarrow (_, _, _, Some arity) -> from_type_expr_with_arity texpr arity
+  | Tlink t -> from_type_expr_with_declared_arity t
+  | Tsubst t -> from_type_expr_with_declared_arity t
+  | _ -> from_type_expr texpr
+
 let add_references ~config ~cross_file ~(loc_from : Location.t)
     ~(loc_to : Location.t) ~(binding : Location.t) ~path
     (arg_names, arg_names_maybe) =
@@ -68,6 +78,9 @@ let check ~optional_args_state ~optional_arg_value_escapes ~ann_store ~config:_
   match decl with
   | {Decl.decl_kind = Value {reports_optional_args = true; optional_args}}
     when active ()
+         (* A live escape makes both diagnostic classes unknown: unseen callers
+            may either omit or supply an optional argument, so neither "never
+            used" nor "always supplied" remains trustworthy. *)
          && (not (Pos_set.mem decl.pos optional_arg_value_escapes))
          && not
               (Annotation_store.is_annotated_gentype_or_live ann_store decl.pos)

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -2,6 +2,14 @@
 
 open Dead_common
 
+(** Identity avoids conflating generated expressions that share source locations. *)
+module Expression_table = Hashtbl.Make (struct
+  type t = Typedtree.expression
+
+  let equal = ( == )
+  let hash (e : t) = Hashtbl.hash e.exp_loc
+end)
+
 let check_any_value_binding_with_no_side_effects ~config ~decls ~file
     ~(module_path : Module_path.t)
     ({vb_pat = {pat_desc}; vb_expr = expr; vb_loc = loc} :
@@ -124,9 +132,8 @@ let process_optional_args ~config ~cross_file ~exp_type ~(loc_from : Location.t)
     |> Dead_optional_args.add_references ~config ~cross_file ~loc_from ~loc_to
          ~binding ~path)
 
-let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
-    ~ignored_escape_locs ~(last_binding : Location.t) super self
-    (e : Typedtree.expression) =
+let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
+    ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
   let add_optional_arg_value_escape ~val_type pos_from pos_to =
@@ -134,54 +141,6 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
       Cross_file_items.add_optional_arg_value_escape cross_file ~pos_from
         ~pos_to
   in
-  let rec remove_first target = function
-    | [] -> []
-    | x :: xs when x = target -> xs
-    | x :: xs -> x :: remove_first target xs
-  in
-  let callee_loc_opt =
-    match e.exp_desc with
-    | Texp_apply {funct = {exp_desc = Texp_ident (_, _, _); exp_loc}; _} ->
-      Some exp_loc
-    | _ -> None
-  in
-  let ignored_escape_loc_opt =
-    match e.exp_desc with
-    | Texp_let
-        ( Nonrecursive,
-          [
-            {
-              vb_pat = {pat_desc = Tpat_var (id_arg, _)};
-              vb_expr =
-                {exp_desc = Texp_ident (_, _, _); exp_loc = wrapper_ident_loc};
-            };
-          ],
-          {
-            exp_desc =
-              Texp_function
-                {
-                  case =
-                    {
-                      c_lhs = {pat_desc = Tpat_var (eta_arg, _)};
-                      c_rhs =
-                        {
-                          exp_desc =
-                            Texp_apply
-                              {funct = {exp_desc = Texp_ident (id_arg2, _, _)}};
-                        };
-                    };
-                };
-          } )
-      when Ident.name id_arg = "arg"
-           && Ident.name eta_arg = "eta"
-           && Path.name id_arg2 = "arg" ->
-      Some wrapper_ident_loc
-    | _ -> None
-  in
-  Option.iter (fun loc -> callee_locs := loc :: !callee_locs) callee_loc_opt;
-  Option.iter
-    (fun loc -> ignored_escape_locs := loc :: !ignored_escape_locs)
-    ignored_escape_loc_opt;
   (match e.exp_desc with
   | Texp_ident
       (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to; val_type})
@@ -199,10 +158,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     else (
       add_value_reference ~config ~refs ~file_deps ~binding
         ~add_file_reference:true ~loc_from ~loc_to;
-      if
-        (not (List.mem loc_from !callee_locs))
-        && not (List.mem loc_from !ignored_escape_locs)
-      then
+      if not (Expression_table.mem direct_callees e) then
         let pos_from =
           if binding = Location.none then loc_from.loc_start
           else binding.loc_start
@@ -216,9 +172,10 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
               Texp_ident
                 (path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to});
             exp_type;
-          };
+          } as direct_callee;
         args;
       } ->
+    Expression_table.replace direct_callees direct_callee ();
     args
     |> process_optional_args ~config ~cross_file ~exp_type
          ~loc_from:(loc_from : Location.t)
@@ -235,7 +192,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
                   Texp_ident
                     (path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to});
                 exp_type;
-              };
+              } as direct_callee;
           };
         ],
         {
@@ -260,6 +217,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     when Ident.name id_arg = "arg"
          && Ident.name eta_arg = "eta"
          && Path.name id_arg2 = "arg" ->
+    Expression_table.replace direct_callees direct_callee ();
     args
     |> process_optional_args ~config ~cross_file ~exp_type
          ~loc_from:(loc_from : Location.t)
@@ -289,25 +247,16 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     fields
     |> Array.iter (fun (_, record_label_definition, _) ->
            match record_label_definition with
-           | Typedtree.Overridden (_, e) -> (
-             match e with
-             | {exp_loc; _} when exp_loc.loc_ghost ->
-               (* Punned field in OCaml projects has ghost location in expression *)
-               let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
-               collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~callee_locs ~ignored_escape_locs ~last_binding super self e
-               |> ignore
-             | _ -> ())
+           | Typedtree.Overridden (_, ({exp_loc} as e)) when exp_loc.loc_ghost
+             ->
+             (* Punned field in OCaml projects has ghost location in expression *)
+             let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
+             collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
+               ~last_binding super self e
+             |> ignore
            | _ -> ())
   | _ -> ());
-  let result = super.Tast_mapper.expr self e in
-  Option.iter
-    (fun loc -> callee_locs := remove_first loc !callee_locs)
-    callee_loc_opt;
-  Option.iter
-    (fun loc -> ignored_escape_locs := remove_first loc !ignored_escape_locs)
-    ignored_escape_loc_opt;
-  result
+  super.Tast_mapper.expr self e
 
 (*
   type k. is a locally abstract type
@@ -474,8 +423,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
 (* Traverse the AST *)
 let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
     ~do_types ~do_externals (structure : Typedtree.structure) : unit =
-  let callee_locs = ref [] in
-  let ignored_escape_locs = ref [] in
+  let direct_callees = Expression_table.create 16 in
   let rec create_mapper (last_binding : Location.t)
       (module_path : Module_path.t) =
     let super = Tast_mapper.default in
@@ -485,8 +433,8 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
         expr =
           (fun _self e ->
             e
-            |> collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~callee_locs ~ignored_escape_locs ~last_binding super mapper);
+            |> collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
+                 ~last_binding super mapper);
         pat =
           (fun _self p ->
             p
@@ -624,25 +572,27 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
   mapper.structure mapper structure |> ignore
 
 (* Merge a location's references to another one's *)
-let process_value_dependency ~config ~decls ~refs ~file_deps ~cross_file
+let process_value_dependency ~config ~refs ~file_deps ~cross_file
     ( ({
          val_loc =
            {loc_start = {pos_fname = fn_to} as pos_to; loc_ghost = ghost1} as
            loc_to;
+         val_type = type_to;
        } :
         Types.value_description),
       ({
          val_loc =
            {loc_start = {pos_fname = fn_from} as pos_from; loc_ghost = ghost2}
            as loc_from;
+         val_type = type_from;
        } :
         Types.value_description) ) =
   if (not ghost1) && (not ghost2) && pos_to <> pos_from then (
     let add_file_reference = file_is_implementation_of fn_to fn_from in
     add_value_reference ~config ~refs ~file_deps ~binding:Location.none
       ~add_file_reference ~loc_from ~loc_to;
-    Dead_optional_args.add_function_reference ~config ~decls ~cross_file
-      ~loc_from ~loc_to)
+    Dead_optional_args.add_function_reference ~config ~cross_file ~loc_from
+      ~loc_to ~type_from ~type_to)
 
 let process_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
     ~cmt_value_dependencies ~do_types ~do_externals
@@ -651,5 +601,4 @@ let process_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
     ~do_externals structure;
   let value_dependencies = cmt_value_dependencies |> List.rev in
   value_dependencies
-  |> List.iter
-       (process_value_dependency ~config ~decls ~refs ~file_deps ~cross_file)
+  |> List.iter (process_value_dependency ~config ~refs ~file_deps ~cross_file)

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -27,27 +27,28 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc})
       when (not loc_ghost) && not vb.vb_loc.loc_ghost ->
       let name = Ident.name id |> Name.create ~is_interface:false in
-      let optional_args, reports_optional_args =
+      let optional_args, optional_args_report =
+        let open Decl.Kind in
         match vb.vb_expr.exp_desc with
         | Texp_function {arity = Some arity; _} ->
           ( vb.vb_expr.exp_type
             |> (fun texpr ->
-                 Dead_optional_args.from_type_expr_with_arity texpr arity)
+            Dead_optional_args.from_type_expr_with_arity texpr arity)
             |> Optional_args.from_list,
-            true )
+            ReportOptionalArgs )
         | Texp_function _ ->
           ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
             |> Optional_args.from_list,
-            true )
+            ReportOptionalArgs )
         | _ ->
           ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
             |> Optional_args.from_list,
-            false )
+            NoOptionalArgReport )
       in
       let exists =
         match Declarations.find_opt_builder decls loc_start with
         | Some {decl_kind = Value r} ->
-          r.reports_optional_args <- reports_optional_args;
+          r.optional_args_report <- optional_args_report;
           r.optional_args <- optional_args;
           true
         | _ -> false
@@ -64,8 +65,8 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
          let side_effects = Side_effects.check_expr vb.vb_expr in
          name
          |> add_value_declaration ~config ~decls ~file ~is_toplevel ~loc
-              ~module_loc:module_path.loc ~reports_optional_args
-              ~optional_args ~path ~side_effects);
+              ~module_loc:module_path.loc ~optional_args_report ~optional_args
+              ~path ~side_effects);
       (match Declarations.find_opt_builder decls loc_start with
       | None -> ()
       | Some decl ->
@@ -124,10 +125,76 @@ let process_optional_args ~config ~cross_file ~exp_type ~(loc_from : Location.t)
     |> Dead_optional_args.add_references ~config ~cross_file ~loc_from ~loc_to
          ~binding ~path)
 
-let rec collect_expr ~config ~refs ~file_deps ~cross_file
+let value_use_target_pos (e : Typedtree.expression) =
+  match e.exp_desc with
+  | Texp_ident (_, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
+    Some loc_to.loc_start
+  | Texp_let
+      ( Nonrecursive,
+        [
+          {
+            vb_pat = {pat_desc = Tpat_var (id_arg, _)};
+            vb_expr =
+              {
+                Typedtree.exp_desc =
+                  Texp_ident
+                    (_, _, {Types.val_loc = {loc_ghost = false; _} as loc_to});
+                _;
+              };
+            _;
+          };
+        ],
+        {
+          Typedtree.exp_desc =
+            Texp_function
+              {
+                case =
+                  {
+                    c_lhs = {pat_desc = Tpat_var (eta_arg, _)};
+                    c_rhs =
+                      {
+                        Typedtree.exp_desc =
+                          Texp_apply
+                            {funct = {exp_desc = Texp_ident (id_arg2, _, _)}; _};
+                        _;
+                      };
+                    _;
+                  };
+                _;
+              };
+          _;
+        } )
+    when Ident.name id_arg = "arg"
+         && Ident.name eta_arg = "eta"
+         && Path.name id_arg2 = "arg" ->
+    Some loc_to.loc_start
+  | _ -> None
+
+let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
+  let require_direct_optional_arg_call pos =
+    match Declarations.find_opt_builder decls pos with
+    | Some
+        ({
+           decl_kind =
+             Value
+               ({optional_args_report = Decl.Kind.ReportOptionalArgs} as
+                value_kind);
+         } as decl) ->
+      Declarations.replace_builder decls pos
+        {
+          decl with
+          decl_kind =
+            Value
+              {
+                value_kind with
+                optional_args_report = Decl.Kind.ReportOptionalArgsIfDirectCall;
+              };
+        }
+    | _ -> ()
+  in
   (match e.exp_desc with
   | Texp_ident (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
     (* if Path.name _path = "rc" then assert false; *)
@@ -157,7 +224,14 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file
     args
     |> process_optional_args ~config ~cross_file ~exp_type
          ~loc_from:(loc_from : Location.t)
-         ~binding:last_binding ~loc_to ~path
+         ~binding:last_binding ~loc_to ~path;
+    args
+    |> List.iter (fun (_, arg) ->
+           match arg with
+           | Some arg ->
+             arg |> value_use_target_pos
+             |> Option.iter require_direct_optional_arg_call
+           | _ -> ())
   | Texp_let
       ( (* generated for functions with optional args *)
         Nonrecursive,
@@ -224,13 +298,17 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file
     fields
     |> Array.iter (fun (_, record_label_definition, _) ->
            match record_label_definition with
-           | Typedtree.Overridden (_, ({exp_loc} as e)) when exp_loc.loc_ghost
-             ->
-             (* Punned field in OCaml projects has ghost location in expression *)
-             let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
-             collect_expr ~config ~refs ~file_deps ~cross_file ~last_binding
-               super self e
-             |> ignore
+           | Typedtree.Overridden (_, e) -> (
+             e |> value_use_target_pos
+             |> Option.iter require_direct_optional_arg_call;
+             match e with
+             | {exp_loc; _} when exp_loc.loc_ghost ->
+               (* Punned field in OCaml projects has ghost location in expression *)
+               let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
+               collect_expr ~config ~decls ~refs ~file_deps ~cross_file
+                 ~last_binding super self e
+               |> ignore
+             | _ -> ())
            | _ -> ())
   | _ -> ());
   super.Tast_mapper.expr self e
@@ -366,8 +444,10 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
           val_type |> Dead_optional_args.from_type_expr
           |> Optional_args.from_list
         in
-        let reports_optional_args =
-          not (Optional_args.is_empty optional_args)
+        let optional_args_report =
+          if Optional_args.is_empty optional_args then
+            Decl.Kind.NoOptionalArgReport
+          else Decl.Kind.ReportOptionalArgs
         in
 
         (* if Ident.name id = "someValue" then
@@ -375,7 +455,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
         Ident.name id
         |> Name.create ~is_interface:false
         |> add_value_declaration ~config ~decls ~file ~loc ~module_loc
-             ~reports_optional_args ~optional_args ~path ~side_effects:false
+             ~optional_args_report ~optional_args ~path ~side_effects:false
   | Sig_module (id, {Types.md_type = module_type; md_loc = module_loc}, _)
   | Sig_modtype (id, {Types.mtd_type = Some module_type; mtd_loc = module_loc})
     ->
@@ -409,8 +489,8 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
         expr =
           (fun _self e ->
             e
-            |> collect_expr ~config ~refs ~file_deps ~cross_file ~last_binding
-                 super mapper);
+            |> collect_expr ~config ~decls ~refs ~file_deps ~cross_file
+                 ~last_binding super mapper);
         pat =
           (fun _self p ->
             p

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -173,17 +173,19 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
-  let suppress_optional_arg_report pos =
-    match Declarations.find_opt_builder decls pos with
-    | Some
-        ({decl_kind = Value ({reports_optional_args = true} as value_kind)} as
-         decl) ->
-      Declarations.replace_builder decls pos
-        {
-          decl with
-          decl_kind = Value {value_kind with reports_optional_args = false};
-        }
+  let add_optional_arg_value_escape pos_from pos_to =
+    match Declarations.find_opt_builder decls pos_to with
+    | Some {decl_kind = Value {reports_optional_args = true}} ->
+      Cross_file_items.add_optional_arg_value_escape cross_file ~pos_from
+        ~pos_to
     | _ -> ()
+  in
+  let add_optional_arg_value_escape_from_expr arg =
+    let pos_from =
+      if binding = Location.none then loc_from.loc_start else binding.loc_start
+    in
+    arg |> value_use_target_pos
+    |> Option.iter (add_optional_arg_value_escape pos_from)
   in
   (match e.exp_desc with
   | Texp_ident (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
@@ -218,9 +220,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     args
     |> List.iter (fun (_, arg) ->
            match arg with
-           | Some arg ->
-             arg |> value_use_target_pos
-             |> Option.iter suppress_optional_arg_report
+           | Some arg -> add_optional_arg_value_escape_from_expr arg
            | _ -> ())
   | Texp_let
       ( (* generated for functions with optional args *)
@@ -289,8 +289,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     |> Array.iter (fun (_, record_label_definition, _) ->
            match record_label_definition with
            | Typedtree.Overridden (_, e) -> (
-             e |> value_use_target_pos
-             |> Option.iter suppress_optional_arg_report;
+             add_optional_arg_value_escape_from_expr e;
              match e with
              | {exp_loc; _} when exp_loc.loc_ghost ->
                (* Punned field in OCaml projects has ghost location in expression *)

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -27,13 +27,27 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc})
       when (not loc_ghost) && not vb.vb_loc.loc_ghost ->
       let name = Ident.name id |> Name.create ~is_interface:false in
-      let optional_args =
-        vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
-        |> Optional_args.from_list
+      let optional_args, reports_optional_args =
+        match vb.vb_expr.exp_desc with
+        | Texp_function {arity = Some arity; _} ->
+          ( vb.vb_expr.exp_type
+            |> (fun texpr ->
+                 Dead_optional_args.from_type_expr_with_arity texpr arity)
+            |> Optional_args.from_list,
+            true )
+        | Texp_function _ ->
+          ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
+            |> Optional_args.from_list,
+            true )
+        | _ ->
+          ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
+            |> Optional_args.from_list,
+            false )
       in
       let exists =
         match Declarations.find_opt_builder decls loc_start with
         | Some {decl_kind = Value r} ->
+          r.reports_optional_args <- reports_optional_args;
           r.optional_args <- optional_args;
           true
         | _ -> false
@@ -50,7 +64,8 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
          let side_effects = Side_effects.check_expr vb.vb_expr in
          name
          |> add_value_declaration ~config ~decls ~file ~is_toplevel ~loc
-              ~module_loc:module_path.loc ~optional_args ~path ~side_effects);
+              ~module_loc:module_path.loc ~reports_optional_args
+              ~optional_args ~path ~side_effects);
       (match Declarations.find_opt_builder decls loc_start with
       | None -> ()
       | Some decl ->
@@ -351,13 +366,16 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
           val_type |> Dead_optional_args.from_type_expr
           |> Optional_args.from_list
         in
+        let reports_optional_args =
+          not (Optional_args.is_empty optional_args)
+        in
 
         (* if Ident.name id = "someValue" then
            Printf.printf "XXX %s\n" (Ident.name id); *)
         Ident.name id
         |> Name.create ~is_interface:false
         |> add_value_declaration ~config ~decls ~file ~loc ~module_loc
-             ~optional_args ~path ~side_effects:false
+             ~reports_optional_args ~optional_args ~path ~side_effects:false
   | Sig_module (id, {Types.md_type = module_type; md_loc = module_loc}, _)
   | Sig_modtype (id, {Types.mtd_type = Some module_type; mtd_loc = module_loc})
     ->

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -128,12 +128,10 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
-  let add_optional_arg_value_escape pos_from pos_to =
-    match Declarations.find_opt_builder decls pos_to with
-    | Some {decl_kind = Value {reports_optional_args = true}} ->
+  let add_optional_arg_value_escape ~val_type pos_from pos_to =
+    if Dead_optional_args.has_optional_args val_type then
       Cross_file_items.add_optional_arg_value_escape cross_file ~pos_from
         ~pos_to
-    | _ -> ()
   in
   let rec remove_first target = function
     | [] -> []
@@ -148,7 +146,9 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
   in
   Option.iter (fun loc -> callee_locs := loc :: !callee_locs) callee_loc_opt;
   (match e.exp_desc with
-  | Texp_ident (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
+  | Texp_ident
+      (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to; val_type})
+    ->
     (* if Path.name _path = "rc" then assert false; *)
     if loc_from = loc_to && _path |> Path.name = "emptyArray" then (
       (* Work around lowercase jsx with no children producing an artifact `emptyArray`
@@ -167,7 +167,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
           if binding = Location.none then loc_from.loc_start
           else binding.loc_start
         in
-        add_optional_arg_value_escape pos_from loc_to.loc_start)
+        add_optional_arg_value_escape ~val_type pos_from loc_to.loc_start)
   | Texp_apply
       {
         funct =

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -125,7 +125,8 @@ let process_optional_args ~config ~cross_file ~exp_type ~(loc_from : Location.t)
          ~binding ~path)
 
 let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
-    ~(last_binding : Location.t) super self (e : Typedtree.expression) =
+    ~ignored_escape_locs ~(last_binding : Location.t) super self
+    (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
   let add_optional_arg_value_escape ~val_type pos_from pos_to =
@@ -144,7 +145,43 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
       Some exp_loc
     | _ -> None
   in
+  let ignored_escape_loc_opt =
+    match e.exp_desc with
+    | Texp_let
+        ( Nonrecursive,
+          [
+            {
+              vb_pat = {pat_desc = Tpat_var (id_arg, _)};
+              vb_expr =
+                {exp_desc = Texp_ident (_, _, _); exp_loc = wrapper_ident_loc};
+            };
+          ],
+          {
+            exp_desc =
+              Texp_function
+                {
+                  case =
+                    {
+                      c_lhs = {pat_desc = Tpat_var (eta_arg, _)};
+                      c_rhs =
+                        {
+                          exp_desc =
+                            Texp_apply
+                              {funct = {exp_desc = Texp_ident (id_arg2, _, _)}};
+                        };
+                    };
+                };
+          } )
+      when Ident.name id_arg = "arg"
+           && Ident.name eta_arg = "eta"
+           && Path.name id_arg2 = "arg" ->
+      Some wrapper_ident_loc
+    | _ -> None
+  in
   Option.iter (fun loc -> callee_locs := loc :: !callee_locs) callee_loc_opt;
+  Option.iter
+    (fun loc -> ignored_escape_locs := loc :: !ignored_escape_locs)
+    ignored_escape_loc_opt;
   (match e.exp_desc with
   | Texp_ident
       (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to; val_type})
@@ -162,7 +199,10 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     else (
       add_value_reference ~config ~refs ~file_deps ~binding
         ~add_file_reference:true ~loc_from ~loc_to;
-      if not (List.mem loc_from !callee_locs) then
+      if
+        (not (List.mem loc_from !callee_locs))
+        && not (List.mem loc_from !ignored_escape_locs)
+      then
         let pos_from =
           if binding = Location.none then loc_from.loc_start
           else binding.loc_start
@@ -255,7 +295,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
                (* Punned field in OCaml projects has ghost location in expression *)
                let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
                collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~callee_locs ~last_binding super self e
+                 ~callee_locs ~ignored_escape_locs ~last_binding super self e
                |> ignore
              | _ -> ())
            | _ -> ())
@@ -264,6 +304,9 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
   Option.iter
     (fun loc -> callee_locs := remove_first loc !callee_locs)
     callee_loc_opt;
+  Option.iter
+    (fun loc -> ignored_escape_locs := remove_first loc !ignored_escape_locs)
+    ignored_escape_loc_opt;
   result
 
 (*
@@ -432,6 +475,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
 let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
     ~do_types ~do_externals (structure : Typedtree.structure) : unit =
   let callee_locs = ref [] in
+  let ignored_escape_locs = ref [] in
   let rec create_mapper (last_binding : Location.t)
       (module_path : Module_path.t) =
     let super = Tast_mapper.default in
@@ -442,7 +486,7 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
           (fun _self e ->
             e
             |> collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~callee_locs ~last_binding super mapper);
+                 ~callee_locs ~ignored_escape_locs ~last_binding super mapper);
         pat =
           (fun _self p ->
             p

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -124,52 +124,7 @@ let process_optional_args ~config ~cross_file ~exp_type ~(loc_from : Location.t)
     |> Dead_optional_args.add_references ~config ~cross_file ~loc_from ~loc_to
          ~binding ~path)
 
-let value_use_target_pos (e : Typedtree.expression) =
-  match e.exp_desc with
-  | Texp_ident (_, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
-    Some loc_to.loc_start
-  | Texp_let
-      ( Nonrecursive,
-        [
-          {
-            vb_pat = {pat_desc = Tpat_var (id_arg, _)};
-            vb_expr =
-              {
-                Typedtree.exp_desc =
-                  Texp_ident
-                    (_, _, {Types.val_loc = {loc_ghost = false; _} as loc_to});
-                _;
-              };
-            _;
-          };
-        ],
-        {
-          Typedtree.exp_desc =
-            Texp_function
-              {
-                case =
-                  {
-                    c_lhs = {pat_desc = Tpat_var (eta_arg, _)};
-                    c_rhs =
-                      {
-                        Typedtree.exp_desc =
-                          Texp_apply
-                            {funct = {exp_desc = Texp_ident (id_arg2, _, _)}; _};
-                        _;
-                      };
-                    _;
-                  };
-                _;
-              };
-          _;
-        } )
-    when Ident.name id_arg = "arg"
-         && Ident.name eta_arg = "eta"
-         && Path.name id_arg2 = "arg" ->
-    Some loc_to.loc_start
-  | _ -> None
-
-let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
+let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~callee_locs
     ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
@@ -180,13 +135,18 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
         ~pos_to
     | _ -> ()
   in
-  let add_optional_arg_value_escape_from_expr arg =
-    let pos_from =
-      if binding = Location.none then loc_from.loc_start else binding.loc_start
-    in
-    arg |> value_use_target_pos
-    |> Option.iter (add_optional_arg_value_escape pos_from)
+  let rec remove_first target = function
+    | [] -> []
+    | x :: xs when x = target -> xs
+    | x :: xs -> x :: remove_first target xs
   in
+  let callee_loc_opt =
+    match e.exp_desc with
+    | Texp_apply {funct = {exp_desc = Texp_ident (_, _, _); exp_loc}; _} ->
+      Some exp_loc
+    | _ -> None
+  in
+  Option.iter (fun loc -> callee_locs := loc :: !callee_locs) callee_loc_opt;
   (match e.exp_desc with
   | Texp_ident (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to}) ->
     (* if Path.name _path = "rc" then assert false; *)
@@ -199,9 +159,15 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
           (loc_to.loc_start |> Pos.to_string);
       References.add_value_ref refs ~pos_to:loc_to.loc_start
         ~pos_from:Location.none.loc_start)
-    else
+    else (
       add_value_reference ~config ~refs ~file_deps ~binding
-        ~add_file_reference:true ~loc_from ~loc_to
+        ~add_file_reference:true ~loc_from ~loc_to;
+      if not (List.mem loc_from !callee_locs) then
+        let pos_from =
+          if binding = Location.none then loc_from.loc_start
+          else binding.loc_start
+        in
+        add_optional_arg_value_escape pos_from loc_to.loc_start)
   | Texp_apply
       {
         funct =
@@ -216,12 +182,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     args
     |> process_optional_args ~config ~cross_file ~exp_type
          ~loc_from:(loc_from : Location.t)
-         ~binding:last_binding ~loc_to ~path;
-    args
-    |> List.iter (fun (_, arg) ->
-           match arg with
-           | Some arg -> add_optional_arg_value_escape_from_expr arg
-           | _ -> ())
+         ~binding:last_binding ~loc_to ~path
   | Texp_let
       ( (* generated for functions with optional args *)
         Nonrecursive,
@@ -289,18 +250,21 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     |> Array.iter (fun (_, record_label_definition, _) ->
            match record_label_definition with
            | Typedtree.Overridden (_, e) -> (
-             add_optional_arg_value_escape_from_expr e;
              match e with
              | {exp_loc; _} when exp_loc.loc_ghost ->
                (* Punned field in OCaml projects has ghost location in expression *)
                let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
                collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~last_binding super self e
+                 ~callee_locs ~last_binding super self e
                |> ignore
              | _ -> ())
            | _ -> ())
   | _ -> ());
-  super.Tast_mapper.expr self e
+  let result = super.Tast_mapper.expr self e in
+  Option.iter
+    (fun loc -> callee_locs := remove_first loc !callee_locs)
+    callee_loc_opt;
+  result
 
 (*
   type k. is a locally abstract type
@@ -467,6 +431,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
 (* Traverse the AST *)
 let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
     ~do_types ~do_externals (structure : Typedtree.structure) : unit =
+  let callee_locs = ref [] in
   let rec create_mapper (last_binding : Location.t)
       (module_path : Module_path.t) =
     let super = Tast_mapper.default in
@@ -477,7 +442,7 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
           (fun _self e ->
             e
             |> collect_expr ~config ~decls ~refs ~file_deps ~cross_file
-                 ~last_binding super mapper);
+                 ~callee_locs ~last_binding super mapper);
         pat =
           (fun _self p ->
             p

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -27,28 +27,27 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc})
       when (not loc_ghost) && not vb.vb_loc.loc_ghost ->
       let name = Ident.name id |> Name.create ~is_interface:false in
-      let optional_args, optional_args_report =
-        let open Decl.Kind in
+      let optional_args, reports_optional_args =
         match vb.vb_expr.exp_desc with
         | Texp_function {arity = Some arity; _} ->
           ( vb.vb_expr.exp_type
             |> (fun texpr ->
             Dead_optional_args.from_type_expr_with_arity texpr arity)
             |> Optional_args.from_list,
-            ReportOptionalArgs )
+            true )
         | Texp_function _ ->
           ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
             |> Optional_args.from_list,
-            ReportOptionalArgs )
+            true )
         | _ ->
           ( vb.vb_expr.exp_type |> Dead_optional_args.from_type_expr
             |> Optional_args.from_list,
-            NoOptionalArgReport )
+            false )
       in
       let exists =
         match Declarations.find_opt_builder decls loc_start with
         | Some {decl_kind = Value r} ->
-          r.optional_args_report <- optional_args_report;
+          r.reports_optional_args <- reports_optional_args;
           r.optional_args <- optional_args;
           true
         | _ -> false
@@ -65,7 +64,7 @@ let collect_value_binding ~config ~decls ~file ~(current_binding : Location.t)
          let side_effects = Side_effects.check_expr vb.vb_expr in
          name
          |> add_value_declaration ~config ~decls ~file ~is_toplevel ~loc
-              ~module_loc:module_path.loc ~optional_args_report ~optional_args
+              ~module_loc:module_path.loc ~reports_optional_args ~optional_args
               ~path ~side_effects);
       (match Declarations.find_opt_builder decls loc_start with
       | None -> ()
@@ -174,24 +173,15 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
     ~(last_binding : Location.t) super self (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
-  let require_direct_optional_arg_call pos =
+  let suppress_optional_arg_report pos =
     match Declarations.find_opt_builder decls pos with
     | Some
-        ({
-           decl_kind =
-             Value
-               ({optional_args_report = Decl.Kind.ReportOptionalArgs} as
-                value_kind);
-         } as decl) ->
+        ({decl_kind = Value ({reports_optional_args = true} as value_kind)} as
+         decl) ->
       Declarations.replace_builder decls pos
         {
           decl with
-          decl_kind =
-            Value
-              {
-                value_kind with
-                optional_args_report = Decl.Kind.ReportOptionalArgsIfDirectCall;
-              };
+          decl_kind = Value {value_kind with reports_optional_args = false};
         }
     | _ -> ()
   in
@@ -230,7 +220,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
            match arg with
            | Some arg ->
              arg |> value_use_target_pos
-             |> Option.iter require_direct_optional_arg_call
+             |> Option.iter suppress_optional_arg_report
            | _ -> ())
   | Texp_let
       ( (* generated for functions with optional args *)
@@ -300,7 +290,7 @@ let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file
            match record_label_definition with
            | Typedtree.Overridden (_, e) -> (
              e |> value_use_target_pos
-             |> Option.iter require_direct_optional_arg_call;
+             |> Option.iter suppress_optional_arg_report;
              match e with
              | {exp_loc; _} when exp_loc.loc_ghost ->
                (* Punned field in OCaml projects has ghost location in expression *)
@@ -444,10 +434,8 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
           val_type |> Dead_optional_args.from_type_expr
           |> Optional_args.from_list
         in
-        let optional_args_report =
-          if Optional_args.is_empty optional_args then
-            Decl.Kind.NoOptionalArgReport
-          else Decl.Kind.ReportOptionalArgs
+        let reports_optional_args =
+          not (Optional_args.is_empty optional_args)
         in
 
         (* if Ident.name id = "someValue" then
@@ -455,7 +443,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
         Ident.name id
         |> Name.create ~is_interface:false
         |> add_value_declaration ~config ~decls ~file ~loc ~module_loc
-             ~optional_args_report ~optional_args ~path ~side_effects:false
+             ~reports_optional_args ~optional_args ~path ~side_effects:false
   | Sig_module (id, {Types.md_type = module_type; md_loc = module_loc}, _)
   | Sig_modtype (id, {Types.mtd_type = Some module_type; mtd_loc = module_loc})
     ->

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -2,7 +2,14 @@
 
 open Dead_common
 
-(** Identity avoids conflating generated expressions that share source locations. *)
+(** Physical identity avoids conflating generated expressions that share source
+    locations. Hashing by [exp_loc] is safe because [==] disambiguates collisions
+    during the bucket scan.
+
+    This table relies on [Tast_mapper] visiting an enclosing [Texp_apply] before
+    its callee child and passing the same physical expression object to the child
+    callback. If either invariant changes, direct calls are conservatively
+    classified as escapes and optional-argument diagnostics silently disappear. *)
 module Expression_table = Hashtbl.Make (struct
   type t = Typedtree.expression
 
@@ -160,6 +167,10 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
         ~add_file_reference:true ~loc_from ~loc_to;
       if not (Expression_table.mem direct_callees e) then
         let pos_from =
+          (* [Location.none] identifies a top-level [Tstr_eval], which executes
+             unconditionally, so use the expression's own position. Both
+             liveness implementations deliberately treat non-declaration
+             positions as live; that behavior is load-bearing here. *)
           if binding = Location.none then loc_from.loc_start
           else binding.loc_start
         in
@@ -386,7 +397,7 @@ let rec process_signature_item ~config ~decls ~file ~do_types ~do_values
       in
       if (not is_primitive) || !Config.analyze_externals then
         let optional_args =
-          val_type |> Dead_optional_args.from_type_expr
+          val_type |> Dead_optional_args.from_type_expr_with_declared_arity
           |> Optional_args.from_list
         in
         let reports_optional_args =

--- a/analysis/reanalyze/src/decl.ml
+++ b/analysis/reanalyze/src/decl.ml
@@ -7,6 +7,7 @@ module Kind = struct
     | VariantCase
     | Value of {
         is_toplevel: bool;
+        mutable reports_optional_args: bool;
         mutable optional_args: Optional_args.t;
         side_effects: bool;
       }

--- a/analysis/reanalyze/src/decl.ml
+++ b/analysis/reanalyze/src/decl.ml
@@ -1,18 +1,13 @@
 (** Declaration types for dead code analysis. *)
 
 module Kind = struct
-  type optional_args_report =
-    | NoOptionalArgReport
-    | ReportOptionalArgs
-    | ReportOptionalArgsIfDirectCall
-
   type t =
     | Exception
     | RecordLabel
     | VariantCase
     | Value of {
         is_toplevel: bool;
-        mutable optional_args_report: optional_args_report;
+        mutable reports_optional_args: bool;
         mutable optional_args: Optional_args.t;
         side_effects: bool;
       }

--- a/analysis/reanalyze/src/decl.ml
+++ b/analysis/reanalyze/src/decl.ml
@@ -1,13 +1,18 @@
 (** Declaration types for dead code analysis. *)
 
 module Kind = struct
+  type optional_args_report =
+    | NoOptionalArgReport
+    | ReportOptionalArgs
+    | ReportOptionalArgsIfDirectCall
+
   type t =
     | Exception
     | RecordLabel
     | VariantCase
     | Value of {
         is_toplevel: bool;
-        mutable reports_optional_args: bool;
+        mutable optional_args_report: optional_args_report;
         mutable optional_args: Optional_args.t;
         side_effects: bool;
       }

--- a/analysis/reanalyze/src/reactive_merge.ml
+++ b/analysis/reanalyze/src/reactive_merge.ml
@@ -88,6 +88,8 @@ let create (source : (string, Dce_file_processing.file_data option) Reactive.t)
             exception_refs = a.exception_refs @ b.exception_refs;
             optional_arg_calls = a.optional_arg_calls @ b.optional_arg_calls;
             function_refs = a.function_refs @ b.function_refs;
+            optional_arg_value_escapes =
+              a.optional_arg_value_escapes @ b.optional_arg_value_escapes;
           })
       ()
   in
@@ -225,17 +227,22 @@ let collect_cross_file_items (t : t) : Cross_file_items.t =
   let exception_refs = ref [] in
   let optional_arg_calls = ref [] in
   let function_refs = ref [] in
+  let optional_arg_value_escapes = ref [] in
   Reactive.iter
     (fun _path items ->
       exception_refs := items.Cross_file_items.exception_refs @ !exception_refs;
       optional_arg_calls :=
         items.Cross_file_items.optional_arg_calls @ !optional_arg_calls;
-      function_refs := items.Cross_file_items.function_refs @ !function_refs)
+      function_refs := items.Cross_file_items.function_refs @ !function_refs;
+      optional_arg_value_escapes :=
+        items.Cross_file_items.optional_arg_value_escapes
+        @ !optional_arg_value_escapes)
     t.cross_file_items;
   {
     Cross_file_items.exception_refs = !exception_refs;
     optional_arg_calls = !optional_arg_calls;
     function_refs = !function_refs;
+    optional_arg_value_escapes = !optional_arg_value_escapes;
   }
 
 (** Convert reactive file deps to FileDeps.t for solver.

--- a/analysis/reanalyze/src/reanalyze.ml
+++ b/analysis/reanalyze/src/reanalyze.ml
@@ -347,11 +347,16 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                   Cross_file_items_store.compute_optional_args_state
                     cross_file_store ~find_decl ~is_live
                 in
+                let optional_arg_value_escapes =
+                  Cross_file_items_store.compute_live_optional_arg_value_escapes
+                    cross_file_store ~is_live
+                in
                 (* Iterate live declarations and check for optional args issues *)
                 let issues = ref [] in
                 Reactive_solver.iter_live_decls ~t:solver (fun decl ->
                     let decl_issues =
-                      Dead_optional_args.check ~optional_args_state ~ann_store
+                      Dead_optional_args.check ~optional_args_state
+                        ~optional_arg_value_escapes ~ann_store
                         ~config:dce_config decl
                     in
                     issues := List.rev_append decl_issues !issues);
@@ -399,13 +404,18 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                 ~find_decl:(Declaration_store.find_opt decl_store)
                 ~is_live
             in
+            let optional_arg_value_escapes =
+              Cross_file_items_store.compute_live_optional_arg_value_escapes
+                cross_file_store ~is_live
+            in
             (* Collect optional args issues only for live declarations *)
             let optional_args_issues =
               Declaration_store.fold
                 (fun _pos decl acc ->
                   if Decl.is_live decl then
                     let issues =
-                      Dead_optional_args.check ~optional_args_state ~ann_store
+                      Dead_optional_args.check ~optional_args_state
+                        ~optional_arg_value_escapes ~ann_store
                         ~config:dce_config decl
                     in
                     List.rev_append issues acc

--- a/analysis/reanalyze/src/reanalyze.ml
+++ b/analysis/reanalyze/src/reanalyze.ml
@@ -347,12 +347,17 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                   Cross_file_items_store.compute_optional_args_state
                     cross_file_store ~find_decl ~is_live
                 in
+                let direct_optional_arg_calls =
+                  Cross_file_items_store.compute_live_direct_optional_arg_calls
+                    cross_file_store ~find_decl ~is_live
+                in
                 (* Iterate live declarations and check for optional args issues *)
                 let issues = ref [] in
                 Reactive_solver.iter_live_decls ~t:solver (fun decl ->
                     let decl_issues =
-                      Dead_optional_args.check ~optional_args_state ~ann_store
-                        ~config:dce_config decl
+                      Dead_optional_args.check ~optional_args_state
+                        ~direct_optional_arg_calls ~ann_store ~config:dce_config
+                        decl
                     in
                     issues := List.rev_append decl_issues !issues);
                 List.rev !issues
@@ -399,14 +404,21 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                 ~find_decl:(Declaration_store.find_opt decl_store)
                 ~is_live
             in
+            let direct_optional_arg_calls =
+              Cross_file_items_store.compute_live_direct_optional_arg_calls
+                cross_file_store
+                ~find_decl:(Declaration_store.find_opt decl_store)
+                ~is_live
+            in
             (* Collect optional args issues only for live declarations *)
             let optional_args_issues =
               Declaration_store.fold
                 (fun _pos decl acc ->
                   if Decl.is_live decl then
                     let issues =
-                      Dead_optional_args.check ~optional_args_state ~ann_store
-                        ~config:dce_config decl
+                      Dead_optional_args.check ~optional_args_state
+                        ~direct_optional_arg_calls ~ann_store ~config:dce_config
+                        decl
                     in
                     List.rev_append issues acc
                   else acc)

--- a/analysis/reanalyze/src/reanalyze.ml
+++ b/analysis/reanalyze/src/reanalyze.ml
@@ -347,17 +347,12 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                   Cross_file_items_store.compute_optional_args_state
                     cross_file_store ~find_decl ~is_live
                 in
-                let direct_optional_arg_calls =
-                  Cross_file_items_store.compute_live_direct_optional_arg_calls
-                    cross_file_store ~find_decl ~is_live
-                in
                 (* Iterate live declarations and check for optional args issues *)
                 let issues = ref [] in
                 Reactive_solver.iter_live_decls ~t:solver (fun decl ->
                     let decl_issues =
-                      Dead_optional_args.check ~optional_args_state
-                        ~direct_optional_arg_calls ~ann_store ~config:dce_config
-                        decl
+                      Dead_optional_args.check ~optional_args_state ~ann_store
+                        ~config:dce_config decl
                     in
                     issues := List.rev_append decl_issues !issues);
                 List.rev !issues
@@ -404,21 +399,14 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                 ~find_decl:(Declaration_store.find_opt decl_store)
                 ~is_live
             in
-            let direct_optional_arg_calls =
-              Cross_file_items_store.compute_live_direct_optional_arg_calls
-                cross_file_store
-                ~find_decl:(Declaration_store.find_opt decl_store)
-                ~is_live
-            in
             (* Collect optional args issues only for live declarations *)
             let optional_args_issues =
               Declaration_store.fold
                 (fun _pos decl acc ->
                   if Decl.is_live decl then
                     let issues =
-                      Dead_optional_args.check ~optional_args_state
-                        ~direct_optional_arg_calls ~ann_store ~config:dce_config
-                        decl
+                      Dead_optional_args.check ~optional_args_state ~ann_store
+                        ~config:dce_config decl
                     in
                     List.rev_append issues acc
                   else acc)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -32,6 +32,52 @@
   addTypeReference _none_:1:-1 --> ComponentAsProp.res:6:20
   addTypeReference _none_:1:-1 --> ComponentAsProp.res:6:34
   addValueReference ComponentAsProp.res:6:4 --> React.res:16:0
+  Scanning ContextOptionalArgs.cmt Source:ContextOptionalArgs.res
+  addValueDeclaration +dispatchNotificationContext ContextOptionalArgs.res:2:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +make ContextOptionalArgs.res:8:8 path:+ContextOptionalArgs.NotificationProvider.Provider
+  addValueDeclaration +make ContextOptionalArgs.res:12:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +useNotification ContextOptionalArgs.res:22:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +make ContextOptionalArgs.res:27:6 path:+ContextOptionalArgs.ComponentUsingAction
+  addValueDeclaration +make ContextOptionalArgs.res:41:6 path:+ContextOptionalArgs.ComponentNotUsingAction
+  addValueDeclaration +make ContextOptionalArgs.res:55:4 path:+ContextOptionalArgs
+  addRecordLabelDeclaration children ContextOptionalArgs.res:12:14 path:+ContextOptionalArgs.NotificationProvider.props
+  addValueReference ContextOptionalArgs.res:2:6 --> React.res:81:0
+  addValueReference ContextOptionalArgs.res:8:8 --> ContextOptionalArgs.res:2:6
+  addValueReference ContextOptionalArgs.res:8:8 --> React.res:77:2
+  addRecordLabelDeclaration children ContextOptionalArgs.res:12:14 path:+ContextOptionalArgs.NotificationProvider.props
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:13:8 path:+ContextOptionalArgs.NotificationProvider
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:43
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:15:13
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:43
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:32
+  addValueReference ContextOptionalArgs.res:19:5 --> ContextOptionalArgs.res:8:8
+  addValueReference ContextOptionalArgs.res:19:20 --> ContextOptionalArgs.res:13:8
+  addValueReference ContextOptionalArgs.res:19:43 --> ContextOptionalArgs.res:12:14
+  addTypeReference _none_:1:-1 --> ContextOptionalArgs.res:12:14
+  addValueReference ContextOptionalArgs.res:12:6 --> React.res:16:0
+  DeadOptionalArgs.addReferences React.useContext called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:22:30
+  addValueReference ContextOptionalArgs.res:22:6 --> ContextOptionalArgs.res:2:6
+  addValueReference ContextOptionalArgs.res:22:6 --> React.res:250:0
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:28:8 path:+ContextOptionalArgs.ComponentUsingAction
+  DeadOptionalArgs.addReferences NotificationProvider.useNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:28:31
+  addValueReference ContextOptionalArgs.res:28:8 --> ContextOptionalArgs.res:22:6
+  addValueReference ContextOptionalArgs.res:35:4 --> React.res:3:0
+  DeadOptionalArgs.addReferences dispatchNotification called with optional argNames:action argNamesMaybe: ContextOptionalArgs.res:31:6
+  addValueReference ContextOptionalArgs.res:31:6 --> ContextOptionalArgs.res:28:8
+  addValueReference ContextOptionalArgs.res:30:4 --> React.res:150:0
+  addValueReference ContextOptionalArgs.res:27:6 --> React.res:16:0
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:42:8 path:+ContextOptionalArgs.ComponentNotUsingAction
+  DeadOptionalArgs.addReferences NotificationProvider.useNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:42:31
+  addValueReference ContextOptionalArgs.res:42:8 --> ContextOptionalArgs.res:22:6
+  addValueReference ContextOptionalArgs.res:49:4 --> React.res:3:0
+  DeadOptionalArgs.addReferences dispatchNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:45:6
+  addValueReference ContextOptionalArgs.res:45:6 --> ContextOptionalArgs.res:42:8
+  addValueReference ContextOptionalArgs.res:44:4 --> React.res:150:0
+  addValueReference ContextOptionalArgs.res:41:6 --> React.res:16:0
+  addValueReference ContextOptionalArgs.res:56:3 --> ContextOptionalArgs.res:12:6
+  addValueReference ContextOptionalArgs.res:57:5 --> ContextOptionalArgs.res:27:6
+  addValueReference ContextOptionalArgs.res:58:5 --> ContextOptionalArgs.res:41:6
+  addValueReference ContextOptionalArgs.res:55:4 --> React.res:16:0
   Scanning CreateErrorHandler1.cmt Source:CreateErrorHandler1.res
   addValueDeclaration +notification CreateErrorHandler1.res:3:6 path:+CreateErrorHandler1.Error1
   addValueReference CreateErrorHandler1.res:3:6 --> CreateErrorHandler1.res:3:21
@@ -1455,6 +1501,16 @@
   addTypeReference TestPromise.res:14:32 --> TestPromise.res:7:2
   Scanning ToSuppress.cmt Source:ToSuppress.res
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
+  Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
+  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:26
+  addValueReference TopLevelOptionalArgValueUse.res:9:8 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:0 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:8 --> TopLevelOptionalArgValueUse.res:11:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -1958,9 +2014,9 @@
   
 Forward Liveness Analysis
 
-    decls: 702
-    roots(external targets): 137
-    decl-deps: decls_with_out=411 edges_to_decls=289
+    decls: 712
+    roots(external targets): 147
+    decl-deps: decls_with_out=422 edges_to_decls=302
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -1997,7 +2053,9 @@ Forward Liveness Analysis
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
+    Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
+    Root (external ref): RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
     Root (annotated): Value +Variants.+testConvert2
     Root (annotated): Value +Tuples.+coord2d
     Root (external ref): Value +CreateErrorHandler1.Error1.+notification
@@ -2034,6 +2092,7 @@ Forward Liveness Analysis
     Root (external ref): RecordLabel +DeadTest.props.s
     Root (annotated): Value +Hooks.+default
     Root (external ref): VariantCase +Unison.break_.Never
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+make
     Root (annotated): Value +TestEmitInnerModules.Inner.+y
     Root (external ref): VariantCase InnerModuleTypes.I.t.Foo
     Root (annotated): Value +Types.+selfRecursiveConverter
@@ -2047,12 +2106,14 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+restResult3
     Root (external ref): RecordLabel +Tuples.person.name
     Root (external ref): Value +FirstClassModules.M.InnerModule3.+k3
+    Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): RecordLabel +Records.coord.x
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+setMatch
     Root (external ref): Value +DeadTest.+deadIncorrect
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (external ref): RecordLabel +TypeReexport.UseReexported.reexportedType.usedField
     Root (annotated): Value +Docstrings.+signMessage
     Root (external ref): RecordLabel +Hooks.Inner.Inner2.props.vehicle
@@ -2077,6 +2138,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unitArgWithConversionU
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +ModuleAliases.+testNested
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
     Root (annotated): Value +Hooks.Inner.Inner2.+make
@@ -2101,12 +2163,14 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+id2
     Root (annotated): Value +Uncurried.+sumU
     Root (external ref): Value +TestOptArg.+bar
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +DeadTest.record.yyy
     Root (annotated): Value +Docstrings.+one
     Root (external ref): Value +OptArg.+twoArgs
     Root (annotated): Value +OcamlWarningSuppressToplevel.+suppressed1
     Root (external ref): RecordLabel +Records.business2.address2
     Root (annotated): Value +Tuples.+testTuple
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
     Root (annotated): Value +Records.+testMyObj2
     Root (annotated): Value +Uncurried.+callback2
     Root (external ref): Value +DeadTest.VariantUsedOnlyInImplementation.+a
@@ -2117,6 +2181,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TestEmitInnerModules.Inner.+x
     Root (external ref): Value +OptArg.+wrapOneArg
     Root (external ref): RecordLabel +ComponentAsProp.props.title
+    Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
     Root (annotated): Value +Records.+findAddress
     Root (annotated): Value +Uncurried.+callback
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayload
@@ -2125,6 +2190,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unnamed2
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive1
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
@@ -2166,8 +2232,10 @@ Forward Liveness Analysis
     Root (annotated): RecordLabel +DeadTypeTest.record.x
     Root (external ref): RecordLabel +Records.myRec.type_
     Root (annotated): Value +TestOptArg.+liveSuppressesOptArgs
+    Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+make
     Root (annotated): Value NestedModulesInSignature.Universe.+theAnswer
     Root (annotated): Value +Docstrings.+unitArgWithoutConversion
+    Root (annotated): Value +ContextOptionalArgs.+make
     Root (annotated): Value +References.+create
     Root (annotated): Value +Types.+currentTime
     Root (annotated): Value +Records.+someBusiness2
@@ -2288,7 +2356,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  325 roots found
+  334 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2298,6 +2366,7 @@ Forward Liveness Analysis
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
+    Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
     Propagate: +Hooks.+default -> +Hooks.+make
@@ -2315,6 +2384,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
+    Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
@@ -2344,7 +2414,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  53 declarations marked live via propagation
+  55 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -2373,6 +2443,56 @@ Forward Liveness Analysis
   Live (external ref) RecordLabel +ComponentAsProp.props.button
       deps: in=1 (live=1 dead=0) out=0
         <- +ComponentAsProp.+make (live)
+  Live (propagated) Value +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+      deps: in=2 (live=2 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.Provider.+make (live)
+        <- +ContextOptionalArgs.NotificationProvider.+useNotification (live)
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.Provider.+make
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.+make
+      deps: in=1 (live=1 dead=0) out=3
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.Provider.+make
+        -> +ContextOptionalArgs.NotificationProvider.props.children
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotification
+  Live (external ref) RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
+      deps: in=1 (live=1 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+  Live (propagated) Value +ContextOptionalArgs.NotificationProvider.+useNotification
+      deps: in=4 (live=4 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentUsingAction.+make (live)
+        <- +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification (live)
+        <- +ContextOptionalArgs.ComponentNotUsingAction.+make (live)
+        <- ... (1 more)
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+  Live (external ref) Value +ContextOptionalArgs.ComponentUsingAction.+make
+      deps: in=1 (live=1 dead=0) out=2
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+        -> +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentUsingAction.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentNotUsingAction.+make
+      deps: in=1 (live=1 dead=0) out=2
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+        -> +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentNotUsingAction.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+  Live (annotated) Value +ContextOptionalArgs.+make
+      deps: in=0 (live=0 dead=0) out=3
+        -> +ContextOptionalArgs.NotificationProvider.+make
+        -> +ContextOptionalArgs.ComponentUsingAction.+make
+        -> +ContextOptionalArgs.ComponentNotUsingAction.+make
   Live (external ref) Value +CreateErrorHandler1.Error1.+notification
   Live (external ref) Value +CreateErrorHandler2.Error2.+notification
   Live (external ref) Value +DeadCodeImplementation.M.+x
@@ -3669,6 +3789,13 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=1
         -> +TestPromise.fromPayload.s
   Dead Value +ToSuppress.+toSuppress
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDate
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveCaller (live)
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDate
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5250,6 +5377,10 @@ Forward Liveness Analysis
   optional argument fmt of function formatDate is never used
 
   Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:5:1-33
+  optional argument fmt of function formatDate is never used
+
+  Warning Unused Argument
   OptArg.res:14:1-42
   optional argument a of function twoArgs is never used
 
@@ -5273,4 +5404,4 @@ Forward Liveness Analysis
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
   
-  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)
+  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1514,31 +1514,39 @@
   addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:15:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:24:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateForwarded TopLevelOptionalArgValueUse.res:8:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:14:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:21:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
   addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
   addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:9:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:13:23
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:17:2
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:9:4
-  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:6:4
-  addValueReference TopLevelOptionalArgValueUse.res:24:4 --> TopLevelOptionalArgValueUse.res:7:4
-  addValueReference TopLevelOptionalArgValueUse.res:28:8 --> TopLevelOptionalArgValueUse.res:13:4
-  addValueReference TopLevelOptionalArgValueUse.res:29:8 --> TopLevelOptionalArgValueUse.res:15:4
-  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:30:8
-  addValueReference TopLevelOptionalArgValueUse.res:30:8 --> TopLevelOptionalArgValueUse.res:20:4
-  addValueReference TopLevelOptionalArgValueUse.res:31:8 --> TopLevelOptionalArgValueUse.res:24:4
+  addValueReference TopLevelOptionalArgValueUse.res:8:4 --> TopLevelOptionalArgValueUse.res:8:35
+  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:10:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:14:23
+  addValueReference TopLevelOptionalArgValueUse.res:14:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:2
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:10:4
+  addValueReference TopLevelOptionalArgValueUse.res:21:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:30:2
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:29:28
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:8:4
+  addValueReference TopLevelOptionalArgValueUse.res:33:8 --> TopLevelOptionalArgValueUse.res:14:4
+  addValueReference TopLevelOptionalArgValueUse.res:34:8 --> TopLevelOptionalArgValueUse.res:16:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:35:8
+  addValueReference TopLevelOptionalArgValueUse.res:35:8 --> TopLevelOptionalArgValueUse.res:21:4
+  addValueReference TopLevelOptionalArgValueUse.res:36:8 --> TopLevelOptionalArgValueUse.res:25:4
+  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:37:8
+  addValueReference TopLevelOptionalArgValueUse.res:37:8 --> TopLevelOptionalArgValueUse.res:29:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2042,9 +2050,9 @@
   
 Forward Liveness Analysis
 
-    decls: 721
-    roots(external targets): 149
-    decl-deps: decls_with_out=431 edges_to_decls=309
+    decls: 727
+    roots(external targets): 152
+    decl-deps: decls_with_out=434 edges_to_decls=312
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2057,6 +2065,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+twoU
     Root (external ref): RecordLabel +TypeReexportCrossFileB.reexportedRecord.usedField
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (annotated): Value +Tuples.+marry
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
     Root (annotated): Value +Types.+i64Const
@@ -2103,6 +2112,7 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+foo
     Root (annotated): RecordLabel +ImportIndex.props.method
     Root (annotated): Value +Docstrings.+unnamed2U
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +RecordRest.config.name
     Root (external ref): Value +FirstClassModules.M.Z.+u
     Root (annotated): Value +Uncurried.+callback2U
@@ -2136,7 +2146,6 @@ Forward Liveness Analysis
     Root (external ref): Value +FirstClassModules.M.InnerModule3.+k3
     Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): RecordLabel +Records.coord.x
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
     Root (external ref): Value +OptArg.+threeArgs
@@ -2157,7 +2166,6 @@ Forward Liveness Analysis
     Root (external ref): Value +DeadTest.+make
     Root (annotated): Value +Records.+testMyRecBsAs
     Root (external ref): RecordLabel +DeadTest.inlineRecord.IR.c
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Records.+origin
     Root (annotated): Value +Variants.+onlySunday
     Root (annotated): Value +Docstrings.+treeU
@@ -2169,6 +2177,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
     Root (annotated): Value +ModuleAliases.+testNested
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
     Root (annotated): Value +Hooks.Inner.Inner2.+make
     Root (annotated): Value +ImportJsValue.+area
@@ -2219,6 +2228,7 @@ Forward Liveness Analysis
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive1
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
@@ -2324,6 +2334,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Shadow.M.+test
     Root (annotated): Value +ComponentAsProp.+make
     Root (annotated): Value +Records.+testMyRec2
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +VariantsWithPayload.+printManyPayloads
     Root (annotated): Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations
     Root (annotated): Value +TransitiveType1.+convertAlias
@@ -2335,12 +2346,10 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayloads
     Root (annotated): Value +Unboxed.+r2Test
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.y
     Root (external ref): RecordLabel +DeadTest.record.xxx
     Root (annotated): Value +FirstClassModules.+firstClassModule
     Root (external ref): RecordLabel +Hooks.props.vehicle
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportJsValue.+useGetAbs
     Root (external ref): Value +JsxV4.C.+make
     Root (external ref): RecordLabel +Types.selfRecursive.self
@@ -2386,10 +2395,11 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  336 roots found
+  340 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
+    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
     Propagate: +Newton.+f -> +Newton.+-
@@ -2399,15 +2409,14 @@ Forward Liveness Analysis
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
     Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +References.+get -> +References.R.+get
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
     Propagate: +ScopedAnnotationsLiveVsDead.LiveScope.+root -> +ScopedAnnotationsLiveVsDead.+middleLive
@@ -2419,6 +2428,8 @@ Forward Liveness Analysis
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
     Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
@@ -2429,7 +2440,6 @@ Forward Liveness Analysis
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
-    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
@@ -2450,7 +2460,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  61 declarations marked live via propagation
+  62 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3844,6 +3854,9 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateTuple
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveTupleCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateForwarded
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveForwardingCaller (live)
   Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
@@ -3865,6 +3878,9 @@ Forward Liveness Analysis
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveTupleCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDateTuple
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateForwarded
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5226,7 +5242,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:11:1-42
+  TopLevelOptionalArgValueUse.res:12:1-42
   deadEscape is never used
 
   Warning Dead Module
@@ -5406,6 +5422,10 @@ Forward Liveness Analysis
   optional argument d of function fourArgs is never used
 
   Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:29:1-85
+  optional argument fmt of function liveForwardingCaller is never used
+
+  Warning Unused Argument
   TestOptArg.res:9:1-65
   optional argument x of function notSuppressesOptArgs is never used
 
@@ -5477,4 +5497,4 @@ Forward Liveness Analysis
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
   
-  Analysis reported 320 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)
+  Analysis reported 322 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:14)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1016,6 +1016,21 @@
   addVariantCaseDeclaration Foo InnerModuleTypes.res:2:11 path:+InnerModuleTypes.I.t
   Scanning InnerModuleTypes.cmti Source:InnerModuleTypes.resi
   addVariantCaseDeclaration Foo InnerModuleTypes.resi:2:11 path:InnerModuleTypes.I.t
+  Scanning InterfaceOptionalArgEscape.cmt Source:InterfaceOptionalArgEscape.res
+  addValueDeclaration +escaped InterfaceOptionalArgEscape.res:1:4 path:+InterfaceOptionalArgEscape
+  addValueDeclaration +takesFn InterfaceOptionalArgEscape.res:3:4 path:+InterfaceOptionalArgEscape
+  addValueReference InterfaceOptionalArgEscape.res:1:4 --> InterfaceOptionalArgEscape.res:1:23
+  addValueReference InterfaceOptionalArgEscape.res:5:8 --> InterfaceOptionalArgEscape.res:1:4
+  addValueReference InterfaceOptionalArgEscape.res:5:0 --> InterfaceOptionalArgEscape.res:3:4
+  addValueReference InterfaceOptionalArgEscape.resi:1:0 --> InterfaceOptionalArgEscape.res:1:4
+  OptionalArgs.addFunctionReference InterfaceOptionalArgEscape.resi:1:0 InterfaceOptionalArgEscape.res:1:4
+  Scanning InterfaceOptionalArgEscape.cmti Source:InterfaceOptionalArgEscape.resi
+  addValueDeclaration +escaped InterfaceOptionalArgEscape.resi:1:0 path:InterfaceOptionalArgEscape
+  Scanning InterfaceOptionalArgEscapeUse.cmt Source:InterfaceOptionalArgEscapeUse.res
+  addValueDeclaration +use InterfaceOptionalArgEscapeUse.res:1:4 path:+InterfaceOptionalArgEscapeUse
+  DeadOptionalArgs.addReferences InterfaceOptionalArgEscape.escaped called with optional argNames: argNamesMaybe: InterfaceOptionalArgEscapeUse.res:1:16
+  addValueReference InterfaceOptionalArgEscapeUse.res:1:4 --> InterfaceOptionalArgEscape.resi:1:0
+  addValueReference InterfaceOptionalArgEscapeUse.res:3:8 --> InterfaceOptionalArgEscapeUse.res:1:4
   Scanning JSResource.cmt Source:JSResource.res
   Scanning JsxV4.cmt Source:JsxV4.res
   addValueDeclaration +make JsxV4.res:4:23 path:+JsxV4.C
@@ -2077,9 +2092,9 @@
   
 Forward Liveness Analysis
 
-    decls: 736
-    roots(external targets): 157
-    decl-deps: decls_with_out=443 edges_to_decls=317
+    decls: 740
+    roots(external targets): 160
+    decl-deps: decls_with_out=446 edges_to_decls=319
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2094,6 +2109,7 @@ Forward Liveness Analysis
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
     Root (annotated): Value +Tuples.+marry
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
+    Root (external ref): Value +InterfaceOptionalArgEscape.+escaped
     Root (annotated): Value +Types.+i64Const
     Root (external ref): VariantCase +DeadTypeTest.deadType.OnlyInImplementation
     Root (annotated): Value +TestImport.+valueStartingWithUpperCaseLetter
@@ -2304,6 +2320,7 @@ Forward Liveness Analysis
     Root (annotated): Value +ContextOptionalArgs.+make
     Root (annotated): Value +References.+create
     Root (annotated): Value +Types.+currentTime
+    Root (external ref): Value +InterfaceOptionalArgEscapeUse.+use
     Root (annotated): Value +Records.+someBusiness2
     Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): Value +DeadTest.+ira
@@ -2391,6 +2408,7 @@ Forward Liveness Analysis
     Root (external ref): Value +FirstClassModules.M.+x
     Root (external ref): Value +TypeReexportCrossFileB.+recordValue
     Root (annotated): Value +Records.+computeArea4
+    Root (external ref): Value +InterfaceOptionalArgEscape.+takesFn
     Root (annotated): Value +TestModuleAliases.+testInner1Expanded
     Root (external ref): Value +TypeReexport.OnlyReexportedDead.+value
     Root (annotated): Value +ImportIndex.+make
@@ -2427,7 +2445,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  345 roots found
+  348 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2466,6 +2484,7 @@ Forward Liveness Analysis
     Propagate: +References.+set -> +References.R.+set
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
     Propagate: NestedModulesInSignature.Universe.+theAnswer -> +NestedModulesInSignature.Universe.+theAnswer
+    Propagate: +InterfaceOptionalArgEscapeUse.+use -> InterfaceOptionalArgEscape.+escaped
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
     Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTypeTest.t.A -> DeadTypeTest.t.A
@@ -2496,7 +2515,7 @@ Forward Liveness Analysis
     Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  66 declarations marked live via propagation
+  67 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3459,6 +3478,17 @@ Forward Liveness Analysis
         <- +InnerModuleTypes.I.t.Foo (live)
         <- +TestInnedModuleTypes.+_ (dead)
         -> +InnerModuleTypes.I.t.Foo
+  Live (external ref) Value +InterfaceOptionalArgEscape.+escaped
+      deps: in=1 (live=1 dead=0) out=0
+        <- InterfaceOptionalArgEscape.+escaped (live)
+  Live (external ref) Value +InterfaceOptionalArgEscape.+takesFn
+  Live (propagated) Value InterfaceOptionalArgEscape.+escaped
+      deps: in=1 (live=1 dead=0) out=1
+        <- +InterfaceOptionalArgEscapeUse.+use (live)
+        -> +InterfaceOptionalArgEscape.+escaped
+  Live (external ref) Value +InterfaceOptionalArgEscapeUse.+use
+      deps: in=0 (live=0 dead=0) out=1
+        -> InterfaceOptionalArgEscape.+escaped
   Live (external ref) Value +JsxV4.C.+make
   Live (annotated) Value +LetPrivate.local_1.+x
       deps: in=1 (live=1 dead=0) out=0

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1515,38 +1515,65 @@
   addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateForwarded TopLevelOptionalArgValueUse.res:8:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:14:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:21:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateTopLevelEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateAlias TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:18:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:33:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateAlias2 TopLevelOptionalArgValueUse.res:37:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveAliasCaller TopLevelOptionalArgValueUse.res:38:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +mutuallyRecursiveCaller TopLevelOptionalArgValueUse.res:40:8 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +mutuallyRecursiveTarget TopLevelOptionalArgValueUse.res:41:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +returnsFunction TopLevelOptionalArgValueUse.res:43:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +returnedFunction TopLevelOptionalArgValueUse.res:44:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnedFunctionCaller TopLevelOptionalArgValueUse.res:45:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
   addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
   addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
   addValueReference TopLevelOptionalArgValueUse.res:8:4 --> TopLevelOptionalArgValueUse.res:8:35
-  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:10:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:14:23
-  addValueReference TopLevelOptionalArgValueUse.res:14:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:2
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:10:4
-  addValueReference TopLevelOptionalArgValueUse.res:21:4 --> TopLevelOptionalArgValueUse.res:6:4
-  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:30:2
-  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:29:28
-  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:8:4
-  addValueReference TopLevelOptionalArgValueUse.res:33:8 --> TopLevelOptionalArgValueUse.res:14:4
-  addValueReference TopLevelOptionalArgValueUse.res:34:8 --> TopLevelOptionalArgValueUse.res:16:4
-  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:35:8
-  addValueReference TopLevelOptionalArgValueUse.res:35:8 --> TopLevelOptionalArgValueUse.res:21:4
-  addValueReference TopLevelOptionalArgValueUse.res:36:8 --> TopLevelOptionalArgValueUse.res:25:4
-  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:37:8
-  addValueReference TopLevelOptionalArgValueUse.res:37:8 --> TopLevelOptionalArgValueUse.res:29:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:9:40
+  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:10:31
+  addValueReference TopLevelOptionalArgValueUse.res:14:8 --> TopLevelOptionalArgValueUse.res:9:4
+  addValueReference TopLevelOptionalArgValueUse.res:14:0 --> TopLevelOptionalArgValueUse.res:12:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:12:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:23
+  addValueReference TopLevelOptionalArgValueUse.res:18:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:22:2
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:12:4
+  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:34:2
+  addValueReference TopLevelOptionalArgValueUse.res:33:4 --> TopLevelOptionalArgValueUse.res:33:28
+  addValueReference TopLevelOptionalArgValueUse.res:33:4 --> TopLevelOptionalArgValueUse.res:8:4
+  addValueReference TopLevelOptionalArgValueUse.res:37:4 --> TopLevelOptionalArgValueUse.res:10:4
+  DeadOptionalArgs.addReferences formatDateAlias2 called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:38:28
+  addValueReference TopLevelOptionalArgValueUse.res:38:4 --> TopLevelOptionalArgValueUse.res:37:4
+  DeadOptionalArgs.addReferences mutuallyRecursiveTarget called with optional argNames:fmt argNamesMaybe: TopLevelOptionalArgValueUse.res:40:40
+  addValueReference TopLevelOptionalArgValueUse.res:40:8 --> TopLevelOptionalArgValueUse.res:41:4
+  addValueReference TopLevelOptionalArgValueUse.res:41:4 --> TopLevelOptionalArgValueUse.res:41:39
+  addValueReference TopLevelOptionalArgValueUse.res:43:4 --> TopLevelOptionalArgValueUse.res:43:22
+  DeadOptionalArgs.addReferences returnsFunction called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:44:23
+  addValueReference TopLevelOptionalArgValueUse.res:44:4 --> TopLevelOptionalArgValueUse.res:43:4
+  DeadOptionalArgs.addReferences returnedFunction called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:45:39
+  addValueReference TopLevelOptionalArgValueUse.res:45:4 --> TopLevelOptionalArgValueUse.res:44:4
+  addValueReference TopLevelOptionalArgValueUse.res:47:8 --> TopLevelOptionalArgValueUse.res:18:4
+  addValueReference TopLevelOptionalArgValueUse.res:48:8 --> TopLevelOptionalArgValueUse.res:20:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:49:8
+  addValueReference TopLevelOptionalArgValueUse.res:49:8 --> TopLevelOptionalArgValueUse.res:25:4
+  addValueReference TopLevelOptionalArgValueUse.res:50:8 --> TopLevelOptionalArgValueUse.res:29:4
+  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:51:8
+  addValueReference TopLevelOptionalArgValueUse.res:51:8 --> TopLevelOptionalArgValueUse.res:33:4
+  addValueReference TopLevelOptionalArgValueUse.res:52:8 --> TopLevelOptionalArgValueUse.res:38:4
+  addValueReference TopLevelOptionalArgValueUse.res:53:8 --> TopLevelOptionalArgValueUse.res:40:8
+  addValueReference TopLevelOptionalArgValueUse.res:54:8 --> TopLevelOptionalArgValueUse.res:45:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2050,9 +2077,9 @@
   
 Forward Liveness Analysis
 
-    decls: 727
-    roots(external targets): 152
-    decl-deps: decls_with_out=434 edges_to_decls=312
+    decls: 736
+    roots(external targets): 157
+    decl-deps: decls_with_out=443 edges_to_decls=317
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2065,7 +2092,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+twoU
     Root (external ref): RecordLabel +TypeReexportCrossFileB.reexportedRecord.usedField
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (annotated): Value +Tuples.+marry
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
     Root (annotated): Value +Types.+i64Const
@@ -2078,6 +2104,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TypeParams3.+test
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (external ref): RecordLabel +Unison.t.doc
     Root (annotated): Value +Tuples.+computeAreaWithIdent
     Root (annotated): Value +LetPrivate.+y
@@ -2112,7 +2139,6 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+foo
     Root (annotated): RecordLabel +ImportIndex.props.method
     Root (annotated): Value +Docstrings.+unnamed2U
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +RecordRest.config.name
     Root (external ref): Value +FirstClassModules.M.Z.+u
     Root (annotated): Value +Uncurried.+callback2U
@@ -2126,6 +2152,7 @@ Forward Liveness Analysis
     Root (external ref): Value +OptArg.+foo
     Root (annotated): Value +Variants.+fortytwoOK
     Root (external ref): Value OptArg.+bar
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveAliasCaller
     Root (annotated): Value +Records.+payloadValue
     Root (external ref): RecordLabel +DeadTest.props.s
     Root (annotated): Value +Hooks.+default
@@ -2177,11 +2204,11 @@ Forward Liveness Analysis
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
     Root (annotated): Value +ModuleAliases.+testNested
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
     Root (annotated): Value +Hooks.Inner.Inner2.+make
     Root (annotated): Value +ImportJsValue.+area
     Root (annotated): Value +Records.+testMyRec
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive3
     Root (external ref): RecordLabel +Uncurried.auth.login
     Root (annotated): Value +ImportJsValue.+roundedNumber
@@ -2206,6 +2233,7 @@ Forward Liveness Analysis
     Root (external ref): Value +OptArg.+twoArgs
     Root (annotated): Value +OcamlWarningSuppressToplevel.+suppressed1
     Root (external ref): RecordLabel +Records.business2.address2
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Tuples.+testTuple
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
     Root (annotated): Value +Records.+testMyObj2
@@ -2223,12 +2251,12 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+callback
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayload
     Root (annotated): Value +TestImmutableArray.+testImmutableArrayGet
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDateTopLevelEscape
     Root (external ref): Value +TypeReexport.UseOriginal.+value
     Root (annotated): Value +Docstrings.+unnamed2
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive1
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
@@ -2277,8 +2305,10 @@ Forward Liveness Analysis
     Root (annotated): Value +References.+create
     Root (annotated): Value +Types.+currentTime
     Root (annotated): Value +Records.+someBusiness2
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): Value +DeadTest.+ira
     Root (annotated): Value +FirstClassModules.+testConvert
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.z
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+jsString2T
@@ -2324,6 +2354,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+restResult2
     Root (annotated): Value +Docstrings.+useParam
     Root (annotated): Value +Records.+getPayload
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller
     Root (annotated): Value +ScopedAnnotationsOverride.M.NestedInLive.+nestedLive
     Root (external ref): Value +FirstClassModules.M.+y
     Root (external ref): RecordLabel +Uncurried.authU.loginU
@@ -2334,7 +2365,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Shadow.M.+test
     Root (annotated): Value +ComponentAsProp.+make
     Root (annotated): Value +Records.+testMyRec2
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +VariantsWithPayload.+printManyPayloads
     Root (annotated): Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations
     Root (annotated): Value +TransitiveType1.+convertAlias
@@ -2342,6 +2372,7 @@ Forward Liveness Analysis
     Root (external ref): VariantCase +Unison.stack.Cons
     Root (external ref): Exception +DeadExn.Inside.Einside
     Root (annotated): Value +TestImport.+defaultValue2
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (external ref): Exception +DeadExn.Etoplevel
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayloads
@@ -2378,6 +2409,7 @@ Forward Liveness Analysis
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive2
     Root (external ref): RecordLabel +TypeReexport.OnlyReexportedDead.reexportedType.usedField
     Root (annotated): Value +Docstrings.+unitArgWithConversion
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (external ref): RecordLabel +Records.business.owner
     Root (external ref): VariantCase +DeadTest.WithInclude.t.A
     Root (external ref): VariantCase +DeadTypeTest.deadType.InBoth
@@ -2395,13 +2427,13 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  340 roots found
+  345 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
-    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
@@ -2409,14 +2441,14 @@ Forward Liveness Analysis
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveAliasCaller -> +TopLevelOptionalArgValueUse.+formatDateAlias2
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
     Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +References.+get -> +References.R.+get
-    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
+    Propagate: +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
     Propagate: +ScopedAnnotationsLiveVsDead.LiveScope.+root -> +ScopedAnnotationsLiveVsDead.+middleLive
@@ -2424,27 +2456,30 @@ Forward Liveness Analysis
     Propagate: +Newton.+result -> +Newton.+fPrimed
     Propagate: +Records.+findAllAddresses -> +Records.+getOpt
     Propagate: +TestOptArg.+bar -> +TestOptArg.+foo
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
     Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
     Propagate: NestedModulesInSignature.Universe.+theAnswer -> +NestedModulesInSignature.Universe.+theAnswer
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTypeTest.t.A -> DeadTypeTest.t.A
     Propagate: ImmutableArray.+fromArray -> +ImmutableArray.+fromArray
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller -> +TopLevelOptionalArgValueUse.+returnedFunction
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
-    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
+    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
+    Propagate: +TopLevelOptionalArgValueUse.+formatDateAlias2 -> +TopLevelOptionalArgValueUse.+formatDateAlias
     Propagate: +References.R.+get -> +References.R.+get
     Propagate: +References.R.+make -> +References.R.+make
     Propagate: +ScopedAnnotationsLiveVsDead.+middleLive -> +ScopedAnnotationsLiveVsDead.+leafLive
@@ -2458,9 +2493,10 @@ Forward Liveness Analysis
     Propagate: ImmutableArray.Array.+get -> +ImmutableArray.+get
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
+    Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  62 declarations marked live via propagation
+  66 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3857,7 +3893,11 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateForwarded
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveForwardingCaller (live)
-  Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDateTopLevelEscape
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateAlias
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+formatDateAlias2 (live)
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
         <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
@@ -3881,6 +3921,29 @@ Forward Liveness Analysis
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDateForwarded
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateAlias2
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TopLevelOptionalArgValueUse.+liveAliasCaller (live)
+        -> +TopLevelOptionalArgValueUse.+formatDateAlias
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveAliasCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateAlias2
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+returnsFunction
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+returnedFunction (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+returnedFunction
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller (live)
+        -> +TopLevelOptionalArgValueUse.+returnsFunction
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+returnedFunction
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5242,7 +5305,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:12:1-42
+  TopLevelOptionalArgValueUse.res:16:1-42
   deadEscape is never used
 
   Warning Dead Module
@@ -5422,10 +5485,6 @@ Forward Liveness Analysis
   optional argument d of function fourArgs is never used
 
   Warning Unused Argument
-  TopLevelOptionalArgValueUse.res:29:1-85
-  optional argument fmt of function liveForwardingCaller is never used
-
-  Warning Unused Argument
   TestOptArg.res:9:1-65
   optional argument x of function notSuppressesOptArgs is never used
 
@@ -5489,6 +5548,10 @@ Forward Liveness Analysis
   Unison.res:17:1-55
   optional argument break_ of function group is always supplied (2 calls)
 
+  Warning Redundant Optional Argument
+  TopLevelOptionalArgValueUse.res:41:1-46
+  optional argument fmt of function mutuallyRecursiveTarget is always supplied (1 calls)
+
   Warning Unused Argument
   TopLevelOptionalArgValueUse.res:4:1-33
   optional argument fmt of function formatDate is never used
@@ -5496,5 +5559,9 @@ Forward Liveness Analysis
   Warning Redundant Optional Argument
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
+
+  Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:33:1-85
+  optional argument fmt of function liveForwardingCaller is never used
   
-  Analysis reported 322 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:14)
+  Analysis reported 323 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:7, Warning Unused Argument:14)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1502,15 +1502,15 @@
   Scanning ToSuppress.cmt Source:ToSuppress.res
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
-  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:26
-  addValueReference TopLevelOptionalArgValueUse.res:9:8 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:9:0 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:8 --> TopLevelOptionalArgValueUse.res:11:4
+  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
+  addValueReference TopLevelOptionalArgValueUse.res:8:8 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:8:0 --> TopLevelOptionalArgValueUse.res:6:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:10:23
+  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:12:8 --> TopLevelOptionalArgValueUse.res:10:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2086,6 +2086,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useTypeImportedInOtherModule
     Root (annotated): Value +Hooks.Inner.+make
     Root (external ref): Value +OptArg.+foo
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +Variants.+fortytwoOK
     Root (external ref): Value OptArg.+bar
     Root (annotated): Value +Records.+payloadValue
@@ -2113,7 +2114,6 @@ Forward Liveness Analysis
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+setMatch
     Root (external ref): Value +DeadTest.+deadIncorrect
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (external ref): RecordLabel +TypeReexport.UseReexported.reexportedType.usedField
     Root (annotated): Value +Docstrings.+signMessage
     Root (external ref): RecordLabel +Hooks.Inner.Inner2.props.vehicle
@@ -2138,7 +2138,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unitArgWithConversionU
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +ModuleAliases.+testNested
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
     Root (annotated): Value +Hooks.Inner.Inner2.+make
@@ -2163,7 +2162,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+id2
     Root (annotated): Value +Uncurried.+sumU
     Root (external ref): Value +TestOptArg.+bar
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +DeadTest.record.yyy
     Root (annotated): Value +Docstrings.+one
     Root (external ref): Value +OptArg.+twoArgs
@@ -2242,6 +2240,7 @@ Forward Liveness Analysis
     Root (external ref): Value +DeadTest.+ira
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): RecordLabel +Records.coord.z
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+jsString2T
     Root (external ref): VariantCase +Unison.stack.Empty
@@ -2289,6 +2288,7 @@ Forward Liveness Analysis
     Root (annotated): Value +ScopedAnnotationsOverride.M.NestedInLive.+nestedLive
     Root (external ref): Value +FirstClassModules.M.+y
     Root (external ref): RecordLabel +Uncurried.authU.loginU
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +ModuleAliases.+testInner2
     Root (annotated): RecordLabel +ImportHooks.props.person
     Root (external ref): Value DeadValueTest.+valueAlive
@@ -5377,10 +5377,6 @@ Forward Liveness Analysis
   optional argument fmt of function formatDate is never used
 
   Warning Unused Argument
-  TopLevelOptionalArgValueUse.res:5:1-33
-  optional argument fmt of function formatDate is never used
-
-  Warning Unused Argument
   OptArg.res:14:1-42
   optional argument a of function twoArgs is never used
 
@@ -5404,4 +5400,4 @@ Forward Liveness Analysis
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
   
-  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)
+  Analysis reported 318 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1503,14 +1503,23 @@
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
   addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
-  addValueReference TopLevelOptionalArgValueUse.res:8:8 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:8:0 --> TopLevelOptionalArgValueUse.res:6:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:10:23
-  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:12:8 --> TopLevelOptionalArgValueUse.res:10:4
+  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:15:2
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:7:4
+  addValueReference TopLevelOptionalArgValueUse.res:18:8 --> TopLevelOptionalArgValueUse.res:11:4
+  addValueReference TopLevelOptionalArgValueUse.res:19:8 --> TopLevelOptionalArgValueUse.res:13:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2014,9 +2023,9 @@
   
 Forward Liveness Analysis
 
-    decls: 712
-    roots(external targets): 147
-    decl-deps: decls_with_out=422 edges_to_decls=302
+    decls: 715
+    roots(external targets): 146
+    decl-deps: decls_with_out=425 edges_to_decls=306
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2039,6 +2048,7 @@ Forward Liveness Analysis
     Root (external ref): Value +OptionalArgsLiveDead.+liveCaller
     Root (annotated): RecordLabel +ImportHookDefault.props.renderMe
     Root (annotated): Value +TypeParams3.+test
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
     Root (external ref): RecordLabel +Unison.t.doc
@@ -2052,6 +2062,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+uncurried3
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
     Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
@@ -2086,7 +2097,6 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useTypeImportedInOtherModule
     Root (annotated): Value +Hooks.Inner.+make
     Root (external ref): Value +OptArg.+foo
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +Variants.+fortytwoOK
     Root (external ref): Value OptArg.+bar
     Root (annotated): Value +Records.+payloadValue
@@ -2240,7 +2250,6 @@ Forward Liveness Analysis
     Root (external ref): Value +DeadTest.+ira
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): RecordLabel +Records.coord.z
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+jsString2T
     Root (external ref): VariantCase +Unison.stack.Empty
@@ -2288,7 +2297,6 @@ Forward Liveness Analysis
     Root (annotated): Value +ScopedAnnotationsOverride.M.NestedInLive.+nestedLive
     Root (external ref): Value +FirstClassModules.M.+y
     Root (external ref): RecordLabel +Uncurried.authU.loginU
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +ModuleAliases.+testInner2
     Root (annotated): RecordLabel +ImportHooks.props.person
     Root (external ref): Value DeadValueTest.+valueAlive
@@ -2356,15 +2364,18 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  334 roots found
+  333 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
@@ -2414,7 +2425,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  55 declarations marked live via propagation
+  58 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3789,13 +3800,28 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=1
         -> +TestPromise.fromPayload.s
   Dead Value +ToSuppress.+toSuppress
-  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDate
-      deps: in=1 (live=1 dead=0) out=0
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDate
+      deps: in=2 (live=1 dead=1) out=0
+        <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
         <- +TopLevelOptionalArgValueUse.+liveCaller (live)
-  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateEscapes
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
+      deps: in=2 (live=1 dead=1) out=0
+        <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
+        <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Dead Value +TopLevelOptionalArgValueUse.+deadEscape
+      deps: in=0 (live=0 dead=0) out=2
+        -> +TopLevelOptionalArgValueUse.+formatDate
+        -> +TopLevelOptionalArgValueUse.+takesFn
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDate
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
+      deps: in=0 (live=0 dead=0) out=2
+        -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+        -> +TopLevelOptionalArgValueUse.+takesFn
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5156,6 +5182,10 @@ Forward Liveness Analysis
   TestPromise.res:11:19-32
   toPayload.result is a record label never used to read a value
 
+  Warning Dead Value
+  TopLevelOptionalArgValueUse.res:9:1-42
+  deadEscape is never used
+
   Warning Dead Module
   TransitiveType2.res:0:1
   TransitiveType2 is a dead module as all its items are dead.
@@ -5396,8 +5426,12 @@ Forward Liveness Analysis
   Unison.res:17:1-55
   optional argument break_ of function group is always supplied (2 calls)
 
+  Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:4:1-33
+  optional argument fmt of function formatDate is never used
+
   Warning Redundant Optional Argument
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
   
-  Analysis reported 318 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)
+  Analysis reported 320 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:93, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1504,22 +1504,33 @@
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
   addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:15:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:24:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
-  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
+  addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
   addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:15:2
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:7:4
-  addValueReference TopLevelOptionalArgValueUse.res:18:8 --> TopLevelOptionalArgValueUse.res:11:4
-  addValueReference TopLevelOptionalArgValueUse.res:19:8 --> TopLevelOptionalArgValueUse.res:13:4
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:9:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:13:23
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:17:2
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:9:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:24:4 --> TopLevelOptionalArgValueUse.res:7:4
+  addValueReference TopLevelOptionalArgValueUse.res:28:8 --> TopLevelOptionalArgValueUse.res:13:4
+  addValueReference TopLevelOptionalArgValueUse.res:29:8 --> TopLevelOptionalArgValueUse.res:15:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:30:8
+  addValueReference TopLevelOptionalArgValueUse.res:30:8 --> TopLevelOptionalArgValueUse.res:20:4
+  addValueReference TopLevelOptionalArgValueUse.res:31:8 --> TopLevelOptionalArgValueUse.res:24:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2023,9 +2034,9 @@
   
 Forward Liveness Analysis
 
-    decls: 715
-    roots(external targets): 146
-    decl-deps: decls_with_out=425 edges_to_decls=306
+    decls: 719
+    roots(external targets): 148
+    decl-deps: decls_with_out=429 edges_to_decls=308
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2048,7 +2059,6 @@ Forward Liveness Analysis
     Root (external ref): Value +OptionalArgsLiveDead.+liveCaller
     Root (annotated): RecordLabel +ImportHookDefault.props.renderMe
     Root (annotated): Value +TypeParams3.+test
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
     Root (external ref): RecordLabel +Unison.t.doc
@@ -2062,7 +2072,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+uncurried3
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
     Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
@@ -2119,6 +2128,7 @@ Forward Liveness Analysis
     Root (external ref): Value +FirstClassModules.M.InnerModule3.+k3
     Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): RecordLabel +Records.coord.x
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
     Root (external ref): Value +OptArg.+threeArgs
@@ -2138,6 +2148,7 @@ Forward Liveness Analysis
     Root (external ref): Value +DeadTest.+make
     Root (annotated): Value +Records.+testMyRecBsAs
     Root (external ref): RecordLabel +DeadTest.inlineRecord.IR.c
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Records.+origin
     Root (annotated): Value +Variants.+onlySunday
     Root (annotated): Value +Docstrings.+treeU
@@ -2315,10 +2326,12 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayloads
     Root (annotated): Value +Unboxed.+r2Test
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.y
     Root (external ref): RecordLabel +DeadTest.record.xxx
     Root (annotated): Value +FirstClassModules.+firstClassModule
     Root (external ref): RecordLabel +Hooks.props.vehicle
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportJsValue.+useGetAbs
     Root (external ref): Value +JsxV4.C.+make
     Root (external ref): RecordLabel +Types.selfRecursive.self
@@ -2364,18 +2377,15 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  333 roots found
+  335 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
@@ -2383,7 +2393,10 @@ Forward Liveness Analysis
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +References.+get -> +References.R.+get
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
@@ -2406,6 +2419,8 @@ Forward Liveness Analysis
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
@@ -2425,7 +2440,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  58 declarations marked live via propagation
+  60 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3807,6 +3822,12 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateEscapes
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateReturn
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveReturnCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateTuple
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveTupleCaller (live)
   Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
@@ -3822,6 +3843,12 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=2
         -> +TopLevelOptionalArgValueUse.+formatDateEscapes
         -> +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveReturnCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateReturn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveTupleCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateTuple
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5183,7 +5210,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:9:1-42
+  TopLevelOptionalArgValueUse.res:11:1-42
   deadEscape is never used
 
   Warning Dead Module

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -88,6 +88,14 @@
   addValueDeclaration +notification CreateErrorHandler2.res:3:6 path:+CreateErrorHandler2.Error2
   addValueReference CreateErrorHandler2.res:3:6 --> CreateErrorHandler2.res:3:21
   addValueReference ErrorHandler.resi:3:2 --> CreateErrorHandler2.res:3:6
+  Scanning CrossFileOptionalArgProvider.cmt Source:CrossFileOptionalArgProvider.res
+  addValueDeclaration +formatDate CrossFileOptionalArgProvider.res:1:4 path:+CrossFileOptionalArgProvider
+  addValueReference CrossFileOptionalArgProvider.res:1:4 --> CrossFileOptionalArgProvider.res:1:26
+  Scanning CrossFileOptionalArgValueUse.cmt Source:CrossFileOptionalArgValueUse.res
+  addValueDeclaration +liveReturnCaller CrossFileOptionalArgValueUse.res:1:4 path:+CrossFileOptionalArgValueUse
+  addValueReference CrossFileOptionalArgValueUse.res:1:4 --> CrossFileOptionalArgProvider.res:1:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: CrossFileOptionalArgValueUse.res:5:8
+  addValueReference CrossFileOptionalArgValueUse.res:5:8 --> CrossFileOptionalArgValueUse.res:1:4
   Scanning DeadCodeImplementation.cmt Source:DeadCodeImplementation.res
   addValueDeclaration +x DeadCodeImplementation.res:2:6 path:+DeadCodeImplementation.M
   addValueReference DeadCodeInterface.res:2:2 --> DeadCodeImplementation.res:2:6
@@ -2034,9 +2042,9 @@
   
 Forward Liveness Analysis
 
-    decls: 719
-    roots(external targets): 148
-    decl-deps: decls_with_out=429 edges_to_decls=308
+    decls: 721
+    roots(external targets): 149
+    decl-deps: decls_with_out=431 edges_to_decls=309
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2143,6 +2151,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TestImport.+innerStuffContents
     Root (external ref): Value +ModuleExceptionBug.+ddjdj
     Root (annotated): Value +TransitiveType1.+convert
+    Root (external ref): Value +CrossFileOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportHooks.+make
     Root (external ref): VariantCase +Unison.break_.IfNeed
     Root (external ref): Value +DeadTest.+make
@@ -2377,7 +2386,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  335 roots found
+  336 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2395,6 +2404,7 @@ Forward Liveness Analysis
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
     Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
+    Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +References.+get -> +References.R.+get
@@ -2440,7 +2450,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  60 declarations marked live via propagation
+  61 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -2521,6 +2531,12 @@ Forward Liveness Analysis
         -> +ContextOptionalArgs.ComponentNotUsingAction.+make
   Live (external ref) Value +CreateErrorHandler1.Error1.+notification
   Live (external ref) Value +CreateErrorHandler2.Error2.+notification
+  Live (propagated) Value +CrossFileOptionalArgProvider.+formatDate
+      deps: in=1 (live=1 dead=0) out=0
+        <- +CrossFileOptionalArgValueUse.+liveReturnCaller (live)
+  Live (external ref) Value +CrossFileOptionalArgValueUse.+liveReturnCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +CrossFileOptionalArgProvider.+formatDate
   Live (external ref) Value +DeadCodeImplementation.M.+x
   Live (external ref) Exception +DeadExn.Etoplevel
       deps: in=1 (live=0 dead=1) out=0

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -32,6 +32,52 @@
   addTypeReference _none_:1:-1 --> ComponentAsProp.res:6:20
   addTypeReference _none_:1:-1 --> ComponentAsProp.res:6:34
   addValueReference ComponentAsProp.res:6:4 --> React.res:16:0
+  Scanning ContextOptionalArgs.cmt Source:ContextOptionalArgs.res
+  addValueDeclaration +dispatchNotificationContext ContextOptionalArgs.res:2:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +make ContextOptionalArgs.res:8:8 path:+ContextOptionalArgs.NotificationProvider.Provider
+  addValueDeclaration +make ContextOptionalArgs.res:12:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +useNotification ContextOptionalArgs.res:22:6 path:+ContextOptionalArgs.NotificationProvider
+  addValueDeclaration +make ContextOptionalArgs.res:27:6 path:+ContextOptionalArgs.ComponentUsingAction
+  addValueDeclaration +make ContextOptionalArgs.res:41:6 path:+ContextOptionalArgs.ComponentNotUsingAction
+  addValueDeclaration +make ContextOptionalArgs.res:55:4 path:+ContextOptionalArgs
+  addRecordLabelDeclaration children ContextOptionalArgs.res:12:14 path:+ContextOptionalArgs.NotificationProvider.props
+  addValueReference ContextOptionalArgs.res:2:6 --> React.res:81:0
+  addValueReference ContextOptionalArgs.res:8:8 --> ContextOptionalArgs.res:2:6
+  addValueReference ContextOptionalArgs.res:8:8 --> React.res:77:2
+  addRecordLabelDeclaration children ContextOptionalArgs.res:12:14 path:+ContextOptionalArgs.NotificationProvider.props
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:13:8 path:+ContextOptionalArgs.NotificationProvider
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:43
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:15:13
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:43
+  addValueReference ContextOptionalArgs.res:13:8 --> ContextOptionalArgs.res:13:32
+  addValueReference ContextOptionalArgs.res:19:5 --> ContextOptionalArgs.res:8:8
+  addValueReference ContextOptionalArgs.res:19:20 --> ContextOptionalArgs.res:13:8
+  addValueReference ContextOptionalArgs.res:19:43 --> ContextOptionalArgs.res:12:14
+  addTypeReference _none_:1:-1 --> ContextOptionalArgs.res:12:14
+  addValueReference ContextOptionalArgs.res:12:6 --> React.res:16:0
+  DeadOptionalArgs.addReferences React.useContext called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:22:30
+  addValueReference ContextOptionalArgs.res:22:6 --> ContextOptionalArgs.res:2:6
+  addValueReference ContextOptionalArgs.res:22:6 --> React.res:250:0
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:28:8 path:+ContextOptionalArgs.ComponentUsingAction
+  DeadOptionalArgs.addReferences NotificationProvider.useNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:28:31
+  addValueReference ContextOptionalArgs.res:28:8 --> ContextOptionalArgs.res:22:6
+  addValueReference ContextOptionalArgs.res:35:4 --> React.res:3:0
+  DeadOptionalArgs.addReferences dispatchNotification called with optional argNames:action argNamesMaybe: ContextOptionalArgs.res:31:6
+  addValueReference ContextOptionalArgs.res:31:6 --> ContextOptionalArgs.res:28:8
+  addValueReference ContextOptionalArgs.res:30:4 --> React.res:150:0
+  addValueReference ContextOptionalArgs.res:27:6 --> React.res:16:0
+  addValueDeclaration +dispatchNotification ContextOptionalArgs.res:42:8 path:+ContextOptionalArgs.ComponentNotUsingAction
+  DeadOptionalArgs.addReferences NotificationProvider.useNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:42:31
+  addValueReference ContextOptionalArgs.res:42:8 --> ContextOptionalArgs.res:22:6
+  addValueReference ContextOptionalArgs.res:49:4 --> React.res:3:0
+  DeadOptionalArgs.addReferences dispatchNotification called with optional argNames: argNamesMaybe: ContextOptionalArgs.res:45:6
+  addValueReference ContextOptionalArgs.res:45:6 --> ContextOptionalArgs.res:42:8
+  addValueReference ContextOptionalArgs.res:44:4 --> React.res:150:0
+  addValueReference ContextOptionalArgs.res:41:6 --> React.res:16:0
+  addValueReference ContextOptionalArgs.res:56:3 --> ContextOptionalArgs.res:12:6
+  addValueReference ContextOptionalArgs.res:57:5 --> ContextOptionalArgs.res:27:6
+  addValueReference ContextOptionalArgs.res:58:5 --> ContextOptionalArgs.res:41:6
+  addValueReference ContextOptionalArgs.res:55:4 --> React.res:16:0
   Scanning CreateErrorHandler1.cmt Source:CreateErrorHandler1.res
   addValueDeclaration +notification CreateErrorHandler1.res:3:6 path:+CreateErrorHandler1.Error1
   addValueReference CreateErrorHandler1.res:3:6 --> CreateErrorHandler1.res:3:21
@@ -1456,6 +1502,16 @@
   addTypeReference TestPromise.res:14:48 --> TestPromise.res:7:2
   Scanning ToSuppress.cmt Source:ToSuppress.res
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
+  Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
+  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:26
+  addValueReference TopLevelOptionalArgValueUse.res:9:8 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:0 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:8 --> TopLevelOptionalArgValueUse.res:11:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -1957,9 +2013,9 @@
   
 Forward Liveness Analysis
 
-    decls: 700
-    roots(external targets): 137
-    decl-deps: decls_with_out=411 edges_to_decls=289
+    decls: 714
+    roots(external targets): 149
+    decl-deps: decls_with_out=423 edges_to_decls=304
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -1997,7 +2053,9 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+uncurried3
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
+    Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
+    Root (external ref): RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
     Root (annotated): Value +Variants.+testConvert2
     Root (annotated): Value +Tuples.+coord2d
     Root (external ref): Value +CreateErrorHandler1.Error1.+notification
@@ -2036,6 +2094,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Types.+currentTime
     Root (annotated): Value +VariantsWithPayload.+testVariant1Object
     Root (external ref): VariantCase +Unison.break_.Never
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+make
     Root (annotated): Value +Records.+computeArea3
     Root (annotated): Value +TestEmitInnerModules.Inner.+y
     Root (external ref): VariantCase InnerModuleTypes.I.t.Foo
@@ -2050,10 +2109,12 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+restResult3
     Root (external ref): Value +FirstClassModules.M.InnerModule3.+k3
     Root (annotated): Value +DeadTest.+fortyTwoButExported
+    Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
     Root (external ref): RecordLabel +Records.coord.x
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive2
     Root (external ref): RecordLabel +TypeReexport.UseReexported.reexportedType.usedField
     Root (annotated): Value +Docstrings.+signMessage
@@ -2077,6 +2138,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Records.+computeArea4
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +ModuleAliases.+testNested
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+jsonStringify
@@ -2101,10 +2163,12 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportJsValue.+useGetProp
     Root (annotated): Value +Variants.+id2
     Root (annotated): Value +Uncurried.+sumU
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +DeadTest.+thisIsMarkedLive
     Root (annotated): Value +Docstrings.+one
     Root (annotated): Value +OcamlWarningSuppressToplevel.+suppressed1
     Root (annotated): Value +Tuples.+testTuple
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
     Root (external ref): Value +OptArg.+wrapOneArg
     Root (annotated): Value +Uncurried.+callback2
     Root (annotated): Value +ImportMyBanner.+make
@@ -2116,6 +2180,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TestEmitInnerModules.Inner.+x
     Root (annotated): Value +Tuples.+changeSecondAge
     Root (external ref): RecordLabel +ComponentAsProp.props.title
+    Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
     Root (annotated): Value +Records.+findAddress
     Root (annotated): Value +Uncurried.+callback
     Root (external ref): Value +DeadTest.+thisIsUsedTwice
@@ -2126,6 +2191,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unnamed2
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
+    Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
     Root (external ref): VariantCase +DeadTest.inlineRecord.IR
@@ -2161,10 +2227,12 @@ Forward Liveness Analysis
     Root (annotated): Value +Types.+map
     Root (annotated): RecordLabel +DeadTypeTest.record.x
     Root (external ref): Value +TestOptArg.+bar
+    Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+make
     Root (external ref): RecordLabel +Records.myRec.type_
     Root (external ref): Value +DeadTest.+make
     Root (annotated): Value NestedModulesInSignature.Universe.+theAnswer
     Root (annotated): Value +Docstrings.+unitArgWithoutConversion
+    Root (annotated): Value +ContextOptionalArgs.+make
     Root (annotated): Value +References.+create
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): RecordLabel +Records.coord.z
@@ -2285,7 +2353,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  323 roots found
+  335 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2295,6 +2363,7 @@ Forward Liveness Analysis
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
+    Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
@@ -2313,6 +2382,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
+    Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
@@ -2341,7 +2411,7 @@ Forward Liveness Analysis
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  53 declarations marked live via propagation
+  55 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -2370,6 +2440,56 @@ Forward Liveness Analysis
   Live (external ref) RecordLabel +ComponentAsProp.props.button
       deps: in=1 (live=1 dead=0) out=0
         <- +ComponentAsProp.+make (live)
+  Live (propagated) Value +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+      deps: in=2 (live=2 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.Provider.+make (live)
+        <- +ContextOptionalArgs.NotificationProvider.+useNotification (live)
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.Provider.+make
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.+make
+      deps: in=1 (live=1 dead=0) out=3
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.Provider.+make
+        -> +ContextOptionalArgs.NotificationProvider.props.children
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotification
+  Live (external ref) RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
+      deps: in=1 (live=1 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+  Live (external ref) Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=0
+        <- +ContextOptionalArgs.NotificationProvider.+make (live)
+  Live (propagated) Value +ContextOptionalArgs.NotificationProvider.+useNotification
+      deps: in=4 (live=4 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentUsingAction.+make (live)
+        <- +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification (live)
+        <- +ContextOptionalArgs.ComponentNotUsingAction.+make (live)
+        <- ... (1 more)
+        -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+  Live (external ref) Value +ContextOptionalArgs.ComponentUsingAction.+make
+      deps: in=1 (live=1 dead=0) out=2
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+        -> +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentUsingAction.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentUsingAction.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentNotUsingAction.+make
+      deps: in=1 (live=1 dead=0) out=2
+        <- +ContextOptionalArgs.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+        -> +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
+  Live (external ref) Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ContextOptionalArgs.ComponentNotUsingAction.+make (live)
+        -> +ContextOptionalArgs.NotificationProvider.+useNotification
+  Live (annotated) Value +ContextOptionalArgs.+make
+      deps: in=0 (live=0 dead=0) out=3
+        -> +ContextOptionalArgs.NotificationProvider.+make
+        -> +ContextOptionalArgs.ComponentUsingAction.+make
+        -> +ContextOptionalArgs.ComponentNotUsingAction.+make
   Live (external ref) Value +CreateErrorHandler1.Error1.+notification
   Live (external ref) Value +CreateErrorHandler2.Error2.+notification
   Live (external ref) Value +DeadCodeImplementation.M.+x
@@ -3666,6 +3786,13 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=1
         -> +TestPromise.fromPayload.s
   Dead Value +ToSuppress.+toSuppress
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDate
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveCaller (live)
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDate
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5233,6 +5360,10 @@ Forward Liveness Analysis
   optional argument fmt of function formatDate is never used
 
   Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:5:1-33
+  optional argument fmt of function formatDate is never used
+
+  Warning Unused Argument
   OptArg.res:9:1-54
   optional argument b of function threeArgs is never used
 
@@ -5268,4 +5399,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)
+  Analysis reported 320 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1505,22 +1505,33 @@
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
   addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:15:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:24:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
-  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
+  addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
   addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:15:2
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:7:4
-  addValueReference TopLevelOptionalArgValueUse.res:18:8 --> TopLevelOptionalArgValueUse.res:11:4
-  addValueReference TopLevelOptionalArgValueUse.res:19:8 --> TopLevelOptionalArgValueUse.res:13:4
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:9:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:13:23
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:17:2
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:9:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:24:4 --> TopLevelOptionalArgValueUse.res:7:4
+  addValueReference TopLevelOptionalArgValueUse.res:28:8 --> TopLevelOptionalArgValueUse.res:13:4
+  addValueReference TopLevelOptionalArgValueUse.res:29:8 --> TopLevelOptionalArgValueUse.res:15:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:30:8
+  addValueReference TopLevelOptionalArgValueUse.res:30:8 --> TopLevelOptionalArgValueUse.res:20:4
+  addValueReference TopLevelOptionalArgValueUse.res:31:8 --> TopLevelOptionalArgValueUse.res:24:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2022,9 +2033,9 @@
   
 Forward Liveness Analysis
 
-    decls: 717
-    roots(external targets): 148
-    decl-deps: decls_with_out=426 edges_to_decls=308
+    decls: 721
+    roots(external targets): 150
+    decl-deps: decls_with_out=430 edges_to_decls=310
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2051,7 +2062,6 @@ Forward Liveness Analysis
     Root (annotated): RecordLabel +ImportHookDefault.props.renderMe
     Root (annotated): Value +TypeParams3.+test
     Root (annotated): Value +Types.+optFunction
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
     Root (external ref): RecordLabel +Unison.t.doc
@@ -2063,7 +2073,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+uncurried3
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
     Root (external ref): RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
@@ -2123,6 +2132,7 @@ Forward Liveness Analysis
     Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
     Root (external ref): RecordLabel +Records.coord.x
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive2
@@ -2138,6 +2148,7 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+make
     Root (external ref): VariantCase +Unison.break_.IfNeed
     Root (external ref): VariantCase +DeadTest.WithInclude.t.A
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Records.+origin
     Root (annotated): Value +Variants.+onlySunday
     Root (annotated): Value +Docstrings.+treeU
@@ -2310,12 +2321,14 @@ Forward Liveness Analysis
     Root (external ref): Exception +DeadExn.Etoplevel
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +Unboxed.+r2Test
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.y
     Root (annotated): Value +Records.+testMyObj
     Root (annotated): Value +TestPromise.+convert
     Root (annotated): Value +FirstClassModules.+firstClassModule
     Root (external ref): RecordLabel +Hooks.props.vehicle
     Root (external ref): Value +DeadTest.VariantUsedOnlyInImplementation.+a
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportJsValue.+useGetAbs
     Root (external ref): Value +JsxV4.C.+make
     Root (external ref): RecordLabel +Types.selfRecursive.self
@@ -2361,27 +2374,27 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  334 roots found
+  336 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +References.+get -> +References.R.+get
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
@@ -2403,7 +2416,9 @@ Forward Liveness Analysis
     Propagate: ImmutableArray.+fromArray -> +ImmutableArray.+fromArray
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
@@ -2422,7 +2437,7 @@ Forward Liveness Analysis
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  58 declarations marked live via propagation
+  60 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3804,6 +3819,12 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateEscapes
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateReturn
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveReturnCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateTuple
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveTupleCaller (live)
   Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
@@ -3819,6 +3840,12 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=2
         -> +TopLevelOptionalArgValueUse.+formatDateEscapes
         -> +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveReturnCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateReturn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveTupleCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateTuple
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5178,7 +5205,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:9:1-42
+  TopLevelOptionalArgValueUse.res:11:1-42
   deadEscape is never used
 
   Warning Dead Module

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -88,6 +88,14 @@
   addValueDeclaration +notification CreateErrorHandler2.res:3:6 path:+CreateErrorHandler2.Error2
   addValueReference CreateErrorHandler2.res:3:6 --> CreateErrorHandler2.res:3:21
   addValueReference ErrorHandler.resi:3:2 --> CreateErrorHandler2.res:3:6
+  Scanning CrossFileOptionalArgProvider.cmt Source:CrossFileOptionalArgProvider.res
+  addValueDeclaration +formatDate CrossFileOptionalArgProvider.res:1:4 path:+CrossFileOptionalArgProvider
+  addValueReference CrossFileOptionalArgProvider.res:1:4 --> CrossFileOptionalArgProvider.res:1:26
+  Scanning CrossFileOptionalArgValueUse.cmt Source:CrossFileOptionalArgValueUse.res
+  addValueDeclaration +liveReturnCaller CrossFileOptionalArgValueUse.res:1:4 path:+CrossFileOptionalArgValueUse
+  addValueReference CrossFileOptionalArgValueUse.res:1:4 --> CrossFileOptionalArgProvider.res:1:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: CrossFileOptionalArgValueUse.res:5:8
+  addValueReference CrossFileOptionalArgValueUse.res:5:8 --> CrossFileOptionalArgValueUse.res:1:4
   Scanning DeadCodeImplementation.cmt Source:DeadCodeImplementation.res
   addValueDeclaration +x DeadCodeImplementation.res:2:6 path:+DeadCodeImplementation.M
   addValueReference DeadCodeInterface.res:2:2 --> DeadCodeImplementation.res:2:6
@@ -2033,9 +2041,9 @@
   
 Forward Liveness Analysis
 
-    decls: 721
-    roots(external targets): 150
-    decl-deps: decls_with_out=430 edges_to_decls=310
+    decls: 723
+    roots(external targets): 151
+    decl-deps: decls_with_out=432 edges_to_decls=311
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2145,6 +2153,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TestImport.+innerStuffContents
     Root (external ref): Value +ModuleExceptionBug.+ddjdj
     Root (annotated): Value +TransitiveType1.+convert
+    Root (external ref): Value +CrossFileOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportHooks.+make
     Root (external ref): VariantCase +Unison.break_.IfNeed
     Root (external ref): VariantCase +DeadTest.WithInclude.t.A
@@ -2374,7 +2383,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  336 roots found
+  337 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2392,6 +2401,7 @@ Forward Liveness Analysis
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
     Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
+    Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
@@ -2437,7 +2447,7 @@ Forward Liveness Analysis
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  60 declarations marked live via propagation
+  61 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -2518,6 +2528,12 @@ Forward Liveness Analysis
         -> +ContextOptionalArgs.ComponentNotUsingAction.+make
   Live (external ref) Value +CreateErrorHandler1.Error1.+notification
   Live (external ref) Value +CreateErrorHandler2.Error2.+notification
+  Live (propagated) Value +CrossFileOptionalArgProvider.+formatDate
+      deps: in=1 (live=1 dead=0) out=0
+        <- +CrossFileOptionalArgValueUse.+liveReturnCaller (live)
+  Live (external ref) Value +CrossFileOptionalArgValueUse.+liveReturnCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +CrossFileOptionalArgProvider.+formatDate
   Live (external ref) Value +DeadCodeImplementation.M.+x
   Live (external ref) Exception +DeadExn.Etoplevel
       deps: in=1 (live=0 dead=1) out=0

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1516,38 +1516,65 @@
   addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateForwarded TopLevelOptionalArgValueUse.res:8:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:14:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:21:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateTopLevelEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateAlias TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:18:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:33:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateAlias2 TopLevelOptionalArgValueUse.res:37:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveAliasCaller TopLevelOptionalArgValueUse.res:38:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +mutuallyRecursiveCaller TopLevelOptionalArgValueUse.res:40:8 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +mutuallyRecursiveTarget TopLevelOptionalArgValueUse.res:41:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +returnsFunction TopLevelOptionalArgValueUse.res:43:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +returnedFunction TopLevelOptionalArgValueUse.res:44:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnedFunctionCaller TopLevelOptionalArgValueUse.res:45:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
   addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
   addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
   addValueReference TopLevelOptionalArgValueUse.res:8:4 --> TopLevelOptionalArgValueUse.res:8:35
-  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:10:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:14:23
-  addValueReference TopLevelOptionalArgValueUse.res:14:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:2
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:10:4
-  addValueReference TopLevelOptionalArgValueUse.res:21:4 --> TopLevelOptionalArgValueUse.res:6:4
-  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:30:2
-  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:29:28
-  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:8:4
-  addValueReference TopLevelOptionalArgValueUse.res:33:8 --> TopLevelOptionalArgValueUse.res:14:4
-  addValueReference TopLevelOptionalArgValueUse.res:34:8 --> TopLevelOptionalArgValueUse.res:16:4
-  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:35:8
-  addValueReference TopLevelOptionalArgValueUse.res:35:8 --> TopLevelOptionalArgValueUse.res:21:4
-  addValueReference TopLevelOptionalArgValueUse.res:36:8 --> TopLevelOptionalArgValueUse.res:25:4
-  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:37:8
-  addValueReference TopLevelOptionalArgValueUse.res:37:8 --> TopLevelOptionalArgValueUse.res:29:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:9:40
+  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:10:31
+  addValueReference TopLevelOptionalArgValueUse.res:14:8 --> TopLevelOptionalArgValueUse.res:9:4
+  addValueReference TopLevelOptionalArgValueUse.res:14:0 --> TopLevelOptionalArgValueUse.res:12:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:12:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:23
+  addValueReference TopLevelOptionalArgValueUse.res:18:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:22:2
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:12:4
+  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:34:2
+  addValueReference TopLevelOptionalArgValueUse.res:33:4 --> TopLevelOptionalArgValueUse.res:33:28
+  addValueReference TopLevelOptionalArgValueUse.res:33:4 --> TopLevelOptionalArgValueUse.res:8:4
+  addValueReference TopLevelOptionalArgValueUse.res:37:4 --> TopLevelOptionalArgValueUse.res:10:4
+  DeadOptionalArgs.addReferences formatDateAlias2 called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:38:28
+  addValueReference TopLevelOptionalArgValueUse.res:38:4 --> TopLevelOptionalArgValueUse.res:37:4
+  DeadOptionalArgs.addReferences mutuallyRecursiveTarget called with optional argNames:fmt argNamesMaybe: TopLevelOptionalArgValueUse.res:40:40
+  addValueReference TopLevelOptionalArgValueUse.res:40:8 --> TopLevelOptionalArgValueUse.res:41:4
+  addValueReference TopLevelOptionalArgValueUse.res:41:4 --> TopLevelOptionalArgValueUse.res:41:39
+  addValueReference TopLevelOptionalArgValueUse.res:43:4 --> TopLevelOptionalArgValueUse.res:43:22
+  DeadOptionalArgs.addReferences returnsFunction called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:44:23
+  addValueReference TopLevelOptionalArgValueUse.res:44:4 --> TopLevelOptionalArgValueUse.res:43:4
+  DeadOptionalArgs.addReferences returnedFunction called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:45:39
+  addValueReference TopLevelOptionalArgValueUse.res:45:4 --> TopLevelOptionalArgValueUse.res:44:4
+  addValueReference TopLevelOptionalArgValueUse.res:47:8 --> TopLevelOptionalArgValueUse.res:18:4
+  addValueReference TopLevelOptionalArgValueUse.res:48:8 --> TopLevelOptionalArgValueUse.res:20:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:49:8
+  addValueReference TopLevelOptionalArgValueUse.res:49:8 --> TopLevelOptionalArgValueUse.res:25:4
+  addValueReference TopLevelOptionalArgValueUse.res:50:8 --> TopLevelOptionalArgValueUse.res:29:4
+  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:51:8
+  addValueReference TopLevelOptionalArgValueUse.res:51:8 --> TopLevelOptionalArgValueUse.res:33:4
+  addValueReference TopLevelOptionalArgValueUse.res:52:8 --> TopLevelOptionalArgValueUse.res:38:4
+  addValueReference TopLevelOptionalArgValueUse.res:53:8 --> TopLevelOptionalArgValueUse.res:40:8
+  addValueReference TopLevelOptionalArgValueUse.res:54:8 --> TopLevelOptionalArgValueUse.res:45:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2049,9 +2076,9 @@
   
 Forward Liveness Analysis
 
-    decls: 725
-    roots(external targets): 152
-    decl-deps: decls_with_out=434 edges_to_decls=312
+    decls: 734
+    roots(external targets): 157
+    decl-deps: decls_with_out=443 edges_to_decls=317
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2068,7 +2095,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+twoU
     Root (external ref): RecordLabel +TypeReexportCrossFileB.reexportedRecord.usedField
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (external ref): Value +OptArg.+wrapfourArgs
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
     Root (external ref): VariantCase +DeadTypeTest.deadType.OnlyInImplementation
@@ -2081,6 +2107,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Types.+optFunction
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (external ref): RecordLabel +Unison.t.doc
     Root (annotated): Value +Tuples.+computeAreaWithIdent
     Root (annotated): Value +LetPrivate.+y
@@ -2110,7 +2137,6 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+foo
     Root (annotated): RecordLabel +ImportIndex.props.method
     Root (annotated): Value +Docstrings.+unnamed2U
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +RecordRest.config.name
     Root (annotated): Value +Records.+testMyRecBsAs
     Root (external ref): Value +FirstClassModules.M.Z.+u
@@ -2127,6 +2153,7 @@ Forward Liveness Analysis
     Root (annotated): Value +TestOptArg.+liveSuppressesOptArgs
     Root (annotated): Value +Uncurried.+sumU2
     Root (external ref): Value OptArg.+bar
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveAliasCaller
     Root (annotated): Value +Records.+payloadValue
     Root (annotated): Value +Hooks.+default
     Root (annotated): Value +Types.+currentTime
@@ -2177,13 +2204,13 @@ Forward Liveness Analysis
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
     Root (annotated): Value +ModuleAliases.+testNested
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+jsonStringify
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
     Root (annotated): Value +Types.+testMarshalFields
     Root (annotated): Value +Hooks.Inner.Inner2.+make
     Root (annotated): Value +ImportJsValue.+area
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller
     Root (external ref): Value +DeadTest.MM.+x
     Root (external ref): RecordLabel +Uncurried.auth.login
     Root (annotated): Value +ImportJsValue.+roundedNumber
@@ -2204,6 +2231,7 @@ Forward Liveness Analysis
     Root (annotated): Value +DeadTest.+thisIsMarkedLive
     Root (annotated): Value +Docstrings.+one
     Root (annotated): Value +OcamlWarningSuppressToplevel.+suppressed1
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Tuples.+testTuple
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.+dispatchNotification
     Root (external ref): Value +OptArg.+wrapOneArg
@@ -2224,12 +2252,12 @@ Forward Liveness Analysis
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayload
     Root (annotated): Value +TestImmutableArray.+testImmutableArrayGet
     Root (annotated): Value +VariantsWithPayload.+printManyPayloads
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDateTopLevelEscape
     Root (external ref): Value +TypeReexport.UseOriginal.+value
     Root (annotated): Value +Docstrings.+unnamed2
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
     Root (external ref): VariantCase +DeadTest.inlineRecord.IR
@@ -2272,7 +2300,9 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unitArgWithoutConversion
     Root (annotated): Value +ContextOptionalArgs.+make
     Root (annotated): Value +References.+create
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +FirstClassModules.+testConvert
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.z
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+i64Const
@@ -2317,6 +2347,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Variants.+restResult2
     Root (annotated): Value +Docstrings.+useParam
     Root (annotated): Value +Records.+getPayload
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller
     Root (annotated): Value +VariantsWithPayload.+printVariantWithPayloads
     Root (annotated): Value +ScopedAnnotationsOverride.M.NestedInLive.+nestedLive
     Root (external ref): Value +FirstClassModules.M.+y
@@ -2331,13 +2362,13 @@ Forward Liveness Analysis
     Root (annotated): Value +Shadow.M.+test
     Root (annotated): Value +Uncurried.+sumLblCurried
     Root (annotated): Value +ComponentAsProp.+make
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations
     Root (annotated): Value +TransitiveType1.+convertAlias
     Root (annotated): Value +ForOf.+keep
     Root (external ref): VariantCase +Unison.stack.Cons
     Root (external ref): Exception +DeadExn.Inside.Einside
     Root (annotated): Value +TestImport.+defaultValue2
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (external ref): Exception +DeadExn.Etoplevel
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +Unboxed.+r2Test
@@ -2376,6 +2407,7 @@ Forward Liveness Analysis
     Root (annotated): Value +VariantsWithPayload.+testManyPayloads
     Root (external ref): RecordLabel +TypeReexport.OnlyReexportedDead.reexportedType.usedField
     Root (annotated): Value +Docstrings.+unitArgWithConversion
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (external ref): RecordLabel +Records.business.owner
     Root (external ref): VariantCase +DeadTypeTest.deadType.InBoth
     Root (external ref): RecordLabel +Records.business.address
@@ -2392,20 +2424,20 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  338 roots found
+  343 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
-    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveAliasCaller -> +TopLevelOptionalArgValueUse.+formatDateAlias2
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
@@ -2414,7 +2446,7 @@ Forward Liveness Analysis
     Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
     Propagate: +References.+get -> +References.R.+get
-    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
+    Propagate: +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
@@ -2423,25 +2455,28 @@ Forward Liveness Analysis
     Propagate: +Newton.+result -> +Newton.+fPrimed
     Propagate: +Records.+findAllAddresses -> +Records.+getOpt
     Propagate: +DeadTest.+thisIsMarkedLive -> +DeadTest.+thisIsKeptAlive
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
     Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
     Propagate: +TestOptArg.+bar -> +TestOptArg.+foo
     Propagate: NestedModulesInSignature.Universe.+theAnswer -> +NestedModulesInSignature.Universe.+theAnswer
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTypeTest.t.A -> DeadTypeTest.t.A
     Propagate: ImmutableArray.+fromArray -> +ImmutableArray.+fromArray
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
+    Propagate: +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller -> +TopLevelOptionalArgValueUse.+returnedFunction
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
-    Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
+    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
+    Propagate: +TopLevelOptionalArgValueUse.+formatDateAlias2 -> +TopLevelOptionalArgValueUse.+formatDateAlias
     Propagate: +References.R.+get -> +References.R.+get
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
     Propagate: +References.R.+make -> +References.R.+make
@@ -2455,9 +2490,10 @@ Forward Liveness Analysis
     Propagate: +Newton.+newton -> +Newton.+next
     Propagate: ImmutableArray.Array.+get -> +ImmutableArray.+get
     Propagate: +References.R.+set -> +References.R.+set
+    Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  62 declarations marked live via propagation
+  66 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3854,7 +3890,11 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateForwarded
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveForwardingCaller (live)
-  Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDateTopLevelEscape
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateAlias
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+formatDateAlias2 (live)
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
         <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
@@ -3878,6 +3918,29 @@ Forward Liveness Analysis
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDateForwarded
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateAlias2
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TopLevelOptionalArgValueUse.+liveAliasCaller (live)
+        -> +TopLevelOptionalArgValueUse.+formatDateAlias
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveAliasCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateAlias2
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+returnsFunction
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+returnedFunction (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+returnedFunction
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller (live)
+        -> +TopLevelOptionalArgValueUse.+returnsFunction
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+returnedFunction
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5237,7 +5300,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:12:1-42
+  TopLevelOptionalArgValueUse.res:16:1-42
   deadEscape is never used
 
   Warning Dead Module
@@ -5412,10 +5475,6 @@ Forward Liveness Analysis
   VariantsWithPayload.res:96:23-32
   variant1Object.R is a variant case which is never constructed
 
-  Warning Unused Argument
-  TopLevelOptionalArgValueUse.res:29:1-85
-  optional argument fmt of function liveForwardingCaller is never used
-
   Warning Redundant Optional Argument
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
@@ -5480,9 +5539,17 @@ Forward Liveness Analysis
   Unison.res:17:1-55
   optional argument break_ of function group is always supplied (2 calls)
 
+  Warning Redundant Optional Argument
+  TopLevelOptionalArgValueUse.res:41:1-46
+  optional argument fmt of function mutuallyRecursiveTarget is always supplied (1 calls)
+
   Warning Unused Argument
   TopLevelOptionalArgValueUse.res:4:1-33
   optional argument fmt of function formatDate is never used
+
+  Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:33:1-85
+  optional argument fmt of function liveForwardingCaller is never used
 
   Warning Unused Argument
   OptArg.res:14:1-42
@@ -5492,4 +5559,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 322 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:14)
+  Analysis reported 323 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:7, Warning Unused Argument:14)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1515,31 +1515,39 @@
   addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateReturn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
   addValueDeclaration +formatDateTuple TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:15:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:20:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:24:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateForwarded TopLevelOptionalArgValueUse.res:8:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:12:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:14:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:16:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveReturnCaller TopLevelOptionalArgValueUse.res:21:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveTupleCaller TopLevelOptionalArgValueUse.res:25:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveForwardingCaller TopLevelOptionalArgValueUse.res:29:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
   addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
   addValueReference TopLevelOptionalArgValueUse.res:6:4 --> TopLevelOptionalArgValueUse.res:6:32
   addValueReference TopLevelOptionalArgValueUse.res:7:4 --> TopLevelOptionalArgValueUse.res:7:31
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:9:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:13:23
-  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:4:4
-  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:17:2
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:15:4 --> TopLevelOptionalArgValueUse.res:9:4
-  addValueReference TopLevelOptionalArgValueUse.res:20:4 --> TopLevelOptionalArgValueUse.res:6:4
-  addValueReference TopLevelOptionalArgValueUse.res:24:4 --> TopLevelOptionalArgValueUse.res:7:4
-  addValueReference TopLevelOptionalArgValueUse.res:28:8 --> TopLevelOptionalArgValueUse.res:13:4
-  addValueReference TopLevelOptionalArgValueUse.res:29:8 --> TopLevelOptionalArgValueUse.res:15:4
-  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:30:8
-  addValueReference TopLevelOptionalArgValueUse.res:30:8 --> TopLevelOptionalArgValueUse.res:20:4
-  addValueReference TopLevelOptionalArgValueUse.res:31:8 --> TopLevelOptionalArgValueUse.res:24:4
+  addValueReference TopLevelOptionalArgValueUse.res:8:4 --> TopLevelOptionalArgValueUse.res:8:35
+  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:12:4 --> TopLevelOptionalArgValueUse.res:10:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:14:23
+  addValueReference TopLevelOptionalArgValueUse.res:14:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:18:2
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:16:4 --> TopLevelOptionalArgValueUse.res:10:4
+  addValueReference TopLevelOptionalArgValueUse.res:21:4 --> TopLevelOptionalArgValueUse.res:6:4
+  addValueReference TopLevelOptionalArgValueUse.res:25:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDateForwarded called with optional argNames:fmt argNamesMaybe:fmt TopLevelOptionalArgValueUse.res:30:2
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:29:28
+  addValueReference TopLevelOptionalArgValueUse.res:29:4 --> TopLevelOptionalArgValueUse.res:8:4
+  addValueReference TopLevelOptionalArgValueUse.res:33:8 --> TopLevelOptionalArgValueUse.res:14:4
+  addValueReference TopLevelOptionalArgValueUse.res:34:8 --> TopLevelOptionalArgValueUse.res:16:4
+  DeadOptionalArgs.addReferences liveReturnCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:35:8
+  addValueReference TopLevelOptionalArgValueUse.res:35:8 --> TopLevelOptionalArgValueUse.res:21:4
+  addValueReference TopLevelOptionalArgValueUse.res:36:8 --> TopLevelOptionalArgValueUse.res:25:4
+  DeadOptionalArgs.addReferences liveForwardingCaller called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:37:8
+  addValueReference TopLevelOptionalArgValueUse.res:37:8 --> TopLevelOptionalArgValueUse.res:29:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2041,9 +2049,9 @@
   
 Forward Liveness Analysis
 
-    decls: 723
-    roots(external targets): 151
-    decl-deps: decls_with_out=432 edges_to_decls=311
+    decls: 725
+    roots(external targets): 152
+    decl-deps: decls_with_out=434 edges_to_decls=312
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2060,6 +2068,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+twoU
     Root (external ref): RecordLabel +TypeReexportCrossFileB.reexportedRecord.usedField
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
     Root (external ref): Value +OptArg.+wrapfourArgs
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
     Root (external ref): VariantCase +DeadTypeTest.deadType.OnlyInImplementation
@@ -2101,6 +2110,7 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+foo
     Root (annotated): RecordLabel +ImportIndex.props.method
     Root (annotated): Value +Docstrings.+unnamed2U
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (external ref): RecordLabel +RecordRest.config.name
     Root (annotated): Value +Records.+testMyRecBsAs
     Root (external ref): Value +FirstClassModules.M.Z.+u
@@ -2140,7 +2150,6 @@ Forward Liveness Analysis
     Root (external ref): Value +ContextOptionalArgs.ComponentNotUsingAction.+dispatchNotification
     Root (external ref): VariantCase +DeadTest.VariantUsedOnlyInImplementation.t.A
     Root (external ref): RecordLabel +Records.coord.x
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive2
@@ -2157,7 +2166,6 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportHooks.+make
     Root (external ref): VariantCase +Unison.break_.IfNeed
     Root (external ref): VariantCase +DeadTest.WithInclude.t.A
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Records.+origin
     Root (annotated): Value +Variants.+onlySunday
     Root (annotated): Value +Docstrings.+treeU
@@ -2169,6 +2177,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
     Root (annotated): Value +ModuleAliases.+testNested
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+jsonStringify
     Root (external ref): Value +FirstClassModules.SomeFunctor.+ww
@@ -2220,6 +2229,7 @@ Forward Liveness Analysis
     Root (annotated): Value +LetPrivate.local_1.+x
     Root (annotated): Value +TestImport.+make
     Root (external ref): Value +ContextOptionalArgs.NotificationProvider.Provider.+make
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed4
     Root (external ref): VariantCase +DeadTest.inlineRecord.IR
@@ -2321,6 +2331,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Shadow.M.+test
     Root (annotated): Value +Uncurried.+sumLblCurried
     Root (annotated): Value +ComponentAsProp.+make
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations
     Root (annotated): Value +TransitiveType1.+convertAlias
     Root (annotated): Value +ForOf.+keep
@@ -2330,14 +2341,12 @@ Forward Liveness Analysis
     Root (external ref): Exception +DeadExn.Etoplevel
     Root (annotated): Value +Variants.+monday
     Root (annotated): Value +Unboxed.+r2Test
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
     Root (external ref): RecordLabel +Records.coord.y
     Root (annotated): Value +Records.+testMyObj
     Root (annotated): Value +TestPromise.+convert
     Root (annotated): Value +FirstClassModules.+firstClassModule
     Root (external ref): RecordLabel +Hooks.props.vehicle
     Root (external ref): Value +DeadTest.VariantUsedOnlyInImplementation.+a
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveReturnCaller
     Root (annotated): Value +ImportJsValue.+useGetAbs
     Root (external ref): Value +JsxV4.C.+make
     Root (external ref): RecordLabel +Types.selfRecursive.self
@@ -2383,10 +2392,11 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  337 roots found
+  338 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
+    Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
@@ -2395,17 +2405,16 @@ Forward Liveness Analysis
     Propagate: +Newton.+f -> +Newton.+*
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
-    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
     Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
-    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +References.+get -> +References.R.+get
+    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
@@ -2417,6 +2426,8 @@ Forward Liveness Analysis
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
     Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
@@ -2426,9 +2437,8 @@ Forward Liveness Analysis
     Propagate: ImmutableArray.+fromArray -> +ImmutableArray.+fromArray
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
-    Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
-    Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +TopLevelOptionalArgValueUse.+liveReturnCaller -> +TopLevelOptionalArgValueUse.+formatDateReturn
+    Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
@@ -2447,7 +2457,7 @@ Forward Liveness Analysis
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  61 declarations marked live via propagation
+  62 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3841,6 +3851,9 @@ Forward Liveness Analysis
   Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateTuple
       deps: in=1 (live=1 dead=0) out=0
         <- +TopLevelOptionalArgValueUse.+liveTupleCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateForwarded
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveForwardingCaller (live)
   Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
       deps: in=2 (live=1 dead=1) out=0
         <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
@@ -3862,6 +3875,9 @@ Forward Liveness Analysis
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveTupleCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDateTuple
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveForwardingCaller
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TopLevelOptionalArgValueUse.+formatDateForwarded
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5221,7 +5237,7 @@ Forward Liveness Analysis
   toPayload.result is a record label never used to read a value
 
   Warning Dead Value
-  TopLevelOptionalArgValueUse.res:11:1-42
+  TopLevelOptionalArgValueUse.res:12:1-42
   deadEscape is never used
 
   Warning Dead Module
@@ -5396,6 +5412,10 @@ Forward Liveness Analysis
   VariantsWithPayload.res:96:23-32
   variant1Object.R is a variant case which is never constructed
 
+  Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:29:1-85
+  optional argument fmt of function liveForwardingCaller is never used
+
   Warning Redundant Optional Argument
   OptArg.res:26:1-70
   optional argument c of function wrapfourArgs is always supplied (2 calls)
@@ -5472,4 +5492,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 321 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)
+  Analysis reported 322 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:14)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1503,15 +1503,15 @@
   Scanning ToSuppress.cmt Source:ToSuppress.res
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
-  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
-  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:26
-  addValueReference TopLevelOptionalArgValueUse.res:9:8 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:9:0 --> TopLevelOptionalArgValueUse.res:7:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
-  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:5:4
-  addValueReference TopLevelOptionalArgValueUse.res:13:8 --> TopLevelOptionalArgValueUse.res:11:4
+  addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
+  addValueReference TopLevelOptionalArgValueUse.res:8:8 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:8:0 --> TopLevelOptionalArgValueUse.res:6:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:10:23
+  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:12:8 --> TopLevelOptionalArgValueUse.res:10:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2085,6 +2085,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Hooks.Inner.+make
     Root (external ref): RecordLabel +DeadTest.inlineRecord.IR.c
     Root (external ref): Value +OptArg.+foo
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +Variants.+fortytwoOK
     Root (annotated): Value +TestOptArg.+liveSuppressesOptArgs
     Root (annotated): Value +Uncurried.+sumU2
@@ -2114,7 +2115,6 @@ Forward Liveness Analysis
     Root (external ref): RecordLabel +Records.coord.x
     Root (annotated): RecordLabel +DeadTypeTest.record.y
     Root (annotated): Value +TestImport.+defaultValue
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive2
     Root (external ref): RecordLabel +TypeReexport.UseReexported.reexportedType.usedField
     Root (annotated): Value +Docstrings.+signMessage
@@ -2138,7 +2138,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Records.+computeArea4
     Root (annotated): Value +Tuples.+computeArea
     Root (annotated): Value +References.+get
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +ModuleAliases.+testNested
     Root (external ref): Value +OptArg.+threeArgs
     Root (annotated): Value +Types.+jsonStringify
@@ -2163,7 +2162,6 @@ Forward Liveness Analysis
     Root (annotated): Value +ImportJsValue.+useGetProp
     Root (annotated): Value +Variants.+id2
     Root (annotated): Value +Uncurried.+sumU
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +DeadTest.+thisIsMarkedLive
     Root (annotated): Value +Docstrings.+one
     Root (annotated): Value +OcamlWarningSuppressToplevel.+suppressed1
@@ -2236,6 +2234,7 @@ Forward Liveness Analysis
     Root (annotated): Value +References.+create
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): RecordLabel +Records.coord.z
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+i64Const
     Root (external ref): VariantCase +Unison.stack.Empty
@@ -2285,6 +2284,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Records.+findAddress2
     Root (external ref): RecordLabel +Uncurried.authU.loginU
     Root (external ref): RecordLabel +Tuples.person.name
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +ModuleAliases.+testInner2
     Root (annotated): RecordLabel +ImportHooks.props.person
     Root (external ref): Value DeadValueTest.+valueAlive
@@ -5360,10 +5360,6 @@ Forward Liveness Analysis
   optional argument fmt of function formatDate is never used
 
   Warning Unused Argument
-  TopLevelOptionalArgValueUse.res:5:1-33
-  optional argument fmt of function formatDate is never used
-
-  Warning Unused Argument
   OptArg.res:9:1-54
   optional argument b of function threeArgs is never used
 
@@ -5399,4 +5395,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 320 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)
+  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1504,14 +1504,23 @@
   addValueDeclaration +toSuppress ToSuppress.res:1:4 path:+ToSuppress
   Scanning TopLevelOptionalArgValueUse.cmt Source:TopLevelOptionalArgValueUse.res
   addValueDeclaration +formatDate TopLevelOptionalArgValueUse.res:4:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:6:4 path:+TopLevelOptionalArgValueUse
-  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:10:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +formatDateEscapes TopLevelOptionalArgValueUse.res:5:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +takesFn TopLevelOptionalArgValueUse.res:7:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +deadEscape TopLevelOptionalArgValueUse.res:9:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveCaller TopLevelOptionalArgValueUse.res:11:4 path:+TopLevelOptionalArgValueUse
+  addValueDeclaration +liveEscapeCaller TopLevelOptionalArgValueUse.res:13:4 path:+TopLevelOptionalArgValueUse
   addValueReference TopLevelOptionalArgValueUse.res:4:4 --> TopLevelOptionalArgValueUse.res:4:26
-  addValueReference TopLevelOptionalArgValueUse.res:8:8 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:8:0 --> TopLevelOptionalArgValueUse.res:6:4
-  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:10:23
-  addValueReference TopLevelOptionalArgValueUse.res:10:4 --> TopLevelOptionalArgValueUse.res:4:4
-  addValueReference TopLevelOptionalArgValueUse.res:12:8 --> TopLevelOptionalArgValueUse.res:10:4
+  addValueReference TopLevelOptionalArgValueUse.res:5:4 --> TopLevelOptionalArgValueUse.res:5:33
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:4:4
+  addValueReference TopLevelOptionalArgValueUse.res:9:4 --> TopLevelOptionalArgValueUse.res:7:4
+  DeadOptionalArgs.addReferences formatDate called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:11:23
+  addValueReference TopLevelOptionalArgValueUse.res:11:4 --> TopLevelOptionalArgValueUse.res:4:4
+  DeadOptionalArgs.addReferences formatDateEscapes called with optional argNames: argNamesMaybe: TopLevelOptionalArgValueUse.res:15:2
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:5:4
+  addValueReference TopLevelOptionalArgValueUse.res:13:4 --> TopLevelOptionalArgValueUse.res:7:4
+  addValueReference TopLevelOptionalArgValueUse.res:18:8 --> TopLevelOptionalArgValueUse.res:11:4
+  addValueReference TopLevelOptionalArgValueUse.res:19:8 --> TopLevelOptionalArgValueUse.res:13:4
   Scanning TransitiveType1.cmt Source:TransitiveType1.res
   addValueDeclaration +convert TransitiveType1.res:2:4 path:+TransitiveType1
   addValueDeclaration +convertAlias TransitiveType1.res:5:4 path:+TransitiveType1
@@ -2013,9 +2022,9 @@
   
 Forward Liveness Analysis
 
-    decls: 714
-    roots(external targets): 149
-    decl-deps: decls_with_out=423 edges_to_decls=304
+    decls: 717
+    roots(external targets): 148
+    decl-deps: decls_with_out=426 edges_to_decls=308
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2042,6 +2051,7 @@ Forward Liveness Analysis
     Root (annotated): RecordLabel +ImportHookDefault.props.renderMe
     Root (annotated): Value +TypeParams3.+test
     Root (annotated): Value +Types.+optFunction
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Variants.+sunday
     Root (annotated): Value +NestedModules.Universe.Nested2.Nested3.+nested3Value
     Root (external ref): RecordLabel +Unison.t.doc
@@ -2053,6 +2063,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Uncurried.+uncurried3
     Root (external ref): Value +Newton.+f
     Root (external ref): RecordLabel +Records.record.v
+    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (external ref): Value +ContextOptionalArgs.ComponentUsingAction.+make
     Root (external ref): RecordLabel +Records.person.address
     Root (external ref): RecordLabel +ContextOptionalArgs.NotificationProvider.props.children
@@ -2085,7 +2096,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Hooks.Inner.+make
     Root (external ref): RecordLabel +DeadTest.inlineRecord.IR.c
     Root (external ref): Value +OptArg.+foo
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+formatDate
     Root (annotated): Value +Variants.+fortytwoOK
     Root (annotated): Value +TestOptArg.+liveSuppressesOptArgs
     Root (annotated): Value +Uncurried.+sumU2
@@ -2234,7 +2244,6 @@ Forward Liveness Analysis
     Root (annotated): Value +References.+create
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): RecordLabel +Records.coord.z
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+liveCaller
     Root (annotated): Value +Types.+someIntList
     Root (annotated): Value +Types.+i64Const
     Root (external ref): VariantCase +Unison.stack.Empty
@@ -2284,7 +2293,6 @@ Forward Liveness Analysis
     Root (annotated): Value +Records.+findAddress2
     Root (external ref): RecordLabel +Uncurried.authU.loginU
     Root (external ref): RecordLabel +Tuples.person.name
-    Root (external ref): Value +TopLevelOptionalArgValueUse.+takesFn
     Root (annotated): Value +ModuleAliases.+testInner2
     Root (annotated): RecordLabel +ImportHooks.props.person
     Root (external ref): Value DeadValueTest.+valueAlive
@@ -2353,16 +2361,19 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  335 roots found
+  334 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
     Propagate: +DeadTypeTest.deadType.OnlyInImplementation -> DeadTypeTest.deadType.OnlyInImplementation
     Propagate: +OptionalArgsLiveDead.+liveCaller -> +OptionalArgsLiveDead.+formatDate
+    Propagate: +TopLevelOptionalArgValueUse.+liveCaller -> +TopLevelOptionalArgValueUse.+formatDate
     Propagate: +Newton.+f -> +Newton.+-
     Propagate: +Newton.+f -> +Newton.++
     Propagate: +Newton.+f -> +Newton.+*
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+    Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+takesFn
     Propagate: +ContextOptionalArgs.ComponentUsingAction.+make -> +ContextOptionalArgs.NotificationProvider.+useNotification
     Propagate: +TypeReexport.UseOriginal.reexportedType.directlyUsed -> +TypeReexport.UseOriginal.originalType.directlyUsed
     Propagate: +Hooks.+default -> +Hooks.+make
@@ -2411,7 +2422,7 @@ Forward Liveness Analysis
     Propagate: +References.R.+set -> +References.R.+set
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  55 declarations marked live via propagation
+  58 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3786,13 +3797,28 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=1
         -> +TestPromise.fromPayload.s
   Dead Value +ToSuppress.+toSuppress
-  Live (external ref) Value +TopLevelOptionalArgValueUse.+formatDate
-      deps: in=1 (live=1 dead=0) out=0
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDate
+      deps: in=2 (live=1 dead=1) out=0
+        <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
         <- +TopLevelOptionalArgValueUse.+liveCaller (live)
-  Live (external ref) Value +TopLevelOptionalArgValueUse.+takesFn
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+formatDateEscapes
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Live (propagated) Value +TopLevelOptionalArgValueUse.+takesFn
+      deps: in=2 (live=1 dead=1) out=0
+        <- +TopLevelOptionalArgValueUse.+deadEscape (dead)
+        <- +TopLevelOptionalArgValueUse.+liveEscapeCaller (live)
+  Dead Value +TopLevelOptionalArgValueUse.+deadEscape
+      deps: in=0 (live=0 dead=0) out=2
+        -> +TopLevelOptionalArgValueUse.+formatDate
+        -> +TopLevelOptionalArgValueUse.+takesFn
   Live (external ref) Value +TopLevelOptionalArgValueUse.+liveCaller
       deps: in=0 (live=0 dead=0) out=1
         -> +TopLevelOptionalArgValueUse.+formatDate
+  Live (external ref) Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
+      deps: in=0 (live=0 dead=0) out=2
+        -> +TopLevelOptionalArgValueUse.+formatDateEscapes
+        -> +TopLevelOptionalArgValueUse.+takesFn
   Live (annotated) Value +TransitiveType1.+convert
   Live (annotated) Value +TransitiveType1.+convertAlias
   Dead Value +TransitiveType2.+convertT2
@@ -5151,6 +5177,10 @@ Forward Liveness Analysis
   TestPromise.res:11:19-32
   toPayload.result is a record label never used to read a value
 
+  Warning Dead Value
+  TopLevelOptionalArgValueUse.res:9:1-42
+  deadEscape is never used
+
   Warning Dead Module
   TransitiveType2.res:0:1
   TransitiveType2 is a dead module as all its items are dead.
@@ -5388,6 +5418,10 @@ Forward Liveness Analysis
   optional argument break_ of function group is always supplied (2 calls)
 
   Warning Unused Argument
+  TopLevelOptionalArgValueUse.res:4:1-33
+  optional argument fmt of function formatDate is never used
+
+  Warning Unused Argument
   OptArg.res:14:1-42
   optional argument a of function twoArgs is never used
 
@@ -5395,4 +5429,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 319 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:177, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:12)
+  Analysis reported 321 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:6, Warning Unused Argument:13)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1413,6 +1413,27 @@
   addTypeReference RepeatedLabel.res:12:16 --> RepeatedLabel.res:8:2
   addValueReference RepeatedLabel.res:14:12 --> RepeatedLabel.res:12:4
   Scanning RequireCond.cmt Source:RequireCond.res
+  Scanning ReturnedOptionalSignature.cmt Source:ReturnedOptionalSignature.res
+  addValueDeclaration +returnedOptional ReturnedOptionalSignature.res:1:4 path:+ReturnedOptionalSignature
+  addValueReference ReturnedOptionalSignature.res:1:4 --> ReturnedOptionalSignature.res:1:34
+  addValueReference ReturnedOptionalSignature.resi:1:0 --> ReturnedOptionalSignature.res:1:4
+  OptionalArgs.addFunctionReference ReturnedOptionalSignature.resi:1:0 ReturnedOptionalSignature.res:1:4
+  Scanning ReturnedOptionalSignature.cmti Source:ReturnedOptionalSignature.resi
+  addValueDeclaration +returnedOptional ReturnedOptionalSignature.resi:1:0 path:ReturnedOptionalSignature
+  Scanning ReturnedOptionalSignatureUse.cmt Source:ReturnedOptionalSignatureUse.res
+  addValueDeclaration +useInterfaceDeclaration ReturnedOptionalSignatureUse.res:1:4 path:+ReturnedOptionalSignatureUse
+  addValueDeclaration +returnedOptional ReturnedOptionalSignatureUse.res:5:2 path:+ReturnedOptionalSignatureUse.InlineSignature
+  addValueDeclaration +useInlineSignature ReturnedOptionalSignatureUse.res:10:4 path:+ReturnedOptionalSignatureUse
+  DeadOptionalArgs.addReferences ReturnedOptionalSignature.returnedOptional called with optional argNames: argNamesMaybe: ReturnedOptionalSignatureUse.res:2:2
+  addValueReference ReturnedOptionalSignatureUse.res:1:4 --> ReturnedOptionalSignature.resi:1:0
+  addValueDeclaration +returnedOptional ReturnedOptionalSignatureUse.res:7:6 path:+ReturnedOptionalSignatureUse.InlineSignature
+  addValueReference ReturnedOptionalSignatureUse.res:7:6 --> ReturnedOptionalSignatureUse.res:7:36
+  DeadOptionalArgs.addReferences InlineSignature.returnedOptional called with optional argNames: argNamesMaybe: ReturnedOptionalSignatureUse.res:11:2
+  addValueReference ReturnedOptionalSignatureUse.res:10:4 --> ReturnedOptionalSignatureUse.res:5:2
+  addValueReference ReturnedOptionalSignatureUse.res:13:8 --> ReturnedOptionalSignatureUse.res:1:4
+  addValueReference ReturnedOptionalSignatureUse.res:14:8 --> ReturnedOptionalSignatureUse.res:10:4
+  addValueReference ReturnedOptionalSignatureUse.res:5:2 --> ReturnedOptionalSignatureUse.res:7:6
+  OptionalArgs.addFunctionReference ReturnedOptionalSignatureUse.res:5:2 ReturnedOptionalSignatureUse.res:7:6
   Scanning ScopedAnnotationsLiveVsDead.cmt Source:ScopedAnnotationsLiveVsDead.res
   addValueDeclaration +leafLive ScopedAnnotationsLiveVsDead.res:1:4 path:+ScopedAnnotationsLiveVsDead
   addValueDeclaration +middleLive ScopedAnnotationsLiveVsDead.res:2:4 path:+ScopedAnnotationsLiveVsDead
@@ -2091,9 +2112,9 @@
   
 Forward Liveness Analysis
 
-    decls: 738
-    roots(external targets): 160
-    decl-deps: decls_with_out=446 edges_to_decls=319
+    decls: 744
+    roots(external targets): 162
+    decl-deps: decls_with_out=452 edges_to_decls=323
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2181,6 +2202,7 @@ Forward Liveness Analysis
     Root (external ref): VariantCase InnerModuleTypes.I.t.Foo
     Root (annotated): Value +Types.+selfRecursiveConverter
     Root (annotated): Value +Opaque.+testConvertNestedRecordFromOtherFile
+    Root (external ref): Value +ReturnedOptionalSignatureUse.+useInterfaceDeclaration
     Root (external ref): RecordLabel +DeadTest.inlineRecord.IR.b
     Root (external ref): Value +OptArg.+bar
     Root (annotated): Value +TestFirstClassModules.+convertRecord
@@ -2231,6 +2253,7 @@ Forward Liveness Analysis
     Root (external ref): RecordLabel +Uncurried.auth.login
     Root (annotated): Value +ImportJsValue.+roundedNumber
     Root (external ref): RecordLabel +RepeatedLabel.tabState.a
+    Root (external ref): Value +ReturnedOptionalSignatureUse.+useInlineSignature
     Root (external ref): Value ErrorHandler.Make.+notify
     Root (annotated): Value +References.+make
     Root (annotated): Value +Shadow.+test
@@ -2442,7 +2465,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  346 roots found
+  348 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2458,6 +2481,7 @@ Forward Liveness Analysis
     Propagate: +TopLevelOptionalArgValueUse.+liveAliasCaller -> +TopLevelOptionalArgValueUse.+formatDateAlias2
     Propagate: +Hooks.+default -> +Hooks.+make
     Propagate: InnerModuleTypes.I.t.Foo -> +InnerModuleTypes.I.t.Foo
+    Propagate: +ReturnedOptionalSignatureUse.+useInterfaceDeclaration -> ReturnedOptionalSignature.+returnedOptional
     Propagate: DeadTypeTest.deadType.OnlyInInterface -> +DeadTypeTest.deadType.OnlyInInterface
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.t.A -> +DeadTest.VariantUsedOnlyInImplementation.t.A
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
@@ -2466,6 +2490,7 @@ Forward Liveness Analysis
     Propagate: +References.+get -> +References.R.+get
     Propagate: +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
+    Propagate: +ReturnedOptionalSignatureUse.+useInlineSignature -> +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
     Propagate: ErrorHandler.Make.+notify -> +ErrorHandler.Make.+notify
     Propagate: +References.+make -> +References.R.+make
     Propagate: +ScopedAnnotationsLiveVsDead.LiveScope.+root -> +ScopedAnnotationsLiveVsDead.+middleLive
@@ -2496,8 +2521,10 @@ Forward Liveness Analysis
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
     Propagate: +TopLevelOptionalArgValueUse.+formatDateAlias2 -> +TopLevelOptionalArgValueUse.+formatDateAlias
+    Propagate: ReturnedOptionalSignature.+returnedOptional -> +ReturnedOptionalSignature.+returnedOptional
     Propagate: +References.R.+get -> +References.R.+get
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+y
+    Propagate: +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional -> +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
     Propagate: +References.R.+make -> +References.R.+make
     Propagate: +ScopedAnnotationsLiveVsDead.+middleLive -> +ScopedAnnotationsLiveVsDead.+leafLive
     Propagate: +Newton.+newton -> +Newton.+/
@@ -2512,7 +2539,7 @@ Forward Liveness Analysis
     Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  67 declarations marked live via propagation
+  71 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3819,6 +3846,26 @@ Forward Liveness Analysis
       deps: in=0 (live=0 dead=0) out=2
         -> +RepeatedLabel.tabState.a
         -> +RepeatedLabel.tabState.b
+  Live (propagated) Value +ReturnedOptionalSignature.+returnedOptional
+      deps: in=1 (live=1 dead=0) out=0
+        <- ReturnedOptionalSignature.+returnedOptional (live)
+  Live (propagated) Value ReturnedOptionalSignature.+returnedOptional
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ReturnedOptionalSignatureUse.+useInterfaceDeclaration (live)
+        -> +ReturnedOptionalSignature.+returnedOptional
+  Live (external ref) Value +ReturnedOptionalSignatureUse.+useInterfaceDeclaration
+      deps: in=0 (live=0 dead=0) out=1
+        -> ReturnedOptionalSignature.+returnedOptional
+  Live (propagated) Value +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
+      deps: in=1 (live=1 dead=0) out=1
+        <- +ReturnedOptionalSignatureUse.+useInlineSignature (live)
+        -> +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
+  Live (propagated) Value +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
+      deps: in=1 (live=1 dead=0) out=0
+        <- +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional (live)
+  Live (external ref) Value +ReturnedOptionalSignatureUse.+useInlineSignature
+      deps: in=0 (live=0 dead=0) out=1
+        -> +ReturnedOptionalSignatureUse.InlineSignature.+returnedOptional
   Live (propagated) Value +ScopedAnnotationsLiveVsDead.+leafLive
       deps: in=1 (live=1 dead=0) out=0
         <- +ScopedAnnotationsLiveVsDead.+middleLive (live)
@@ -5538,6 +5585,10 @@ Forward Liveness Analysis
   optional argument x of function bar is never used
 
   Warning Unused Argument
+  ReturnedOptionalSignature.resi:1:1-80
+  optional argument outer of function returnedOptional is never used
+
+  Warning Unused Argument
   OptionalArgsLiveDead.res:1:1-33
   optional argument fmt of function formatDate is never used
 
@@ -5548,6 +5599,14 @@ Forward Liveness Analysis
   Warning Redundant Optional Argument
   OptArg.res:9:1-54
   optional argument a of function threeArgs is always supplied (2 calls)
+
+  Warning Unused Argument
+  ReturnedOptionalSignatureUse.res:5:3-82
+  optional argument outer of function InlineSignature.returnedOptional is never used
+
+  Warning Unused Argument
+  ReturnedOptionalSignature.res:1:1-63
+  optional argument outer of function returnedOptional is never used
 
   Warning Redundant Optional Argument
   OptArg.res:20:1-51
@@ -5582,6 +5641,10 @@ Forward Liveness Analysis
   optional argument fmt of function liveForwardingCaller is never used
 
   Warning Unused Argument
+  ReturnedOptionalSignatureUse.res:7:3-65
+  optional argument outer of function InlineSignature.returnedOptional is never used
+
+  Warning Unused Argument
   OptArg.res:14:1-42
   optional argument a of function twoArgs is never used
 
@@ -5589,4 +5652,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 323 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:7, Warning Unused Argument:14)
+  Analysis reported 327 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:22, Warning Dead Type:94, Warning Dead Value:178, Warning Dead Value With Side Effects:5, Warning Redundant Optional Argument:7, Warning Unused Argument:18)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1016,6 +1016,21 @@
   addVariantCaseDeclaration Foo InnerModuleTypes.res:2:11 path:+InnerModuleTypes.I.t
   Scanning InnerModuleTypes.cmti Source:InnerModuleTypes.resi
   addVariantCaseDeclaration Foo InnerModuleTypes.resi:2:11 path:InnerModuleTypes.I.t
+  Scanning InterfaceOptionalArgEscape.cmt Source:InterfaceOptionalArgEscape.res
+  addValueDeclaration +escaped InterfaceOptionalArgEscape.res:1:4 path:+InterfaceOptionalArgEscape
+  addValueDeclaration +takesFn InterfaceOptionalArgEscape.res:3:4 path:+InterfaceOptionalArgEscape
+  addValueReference InterfaceOptionalArgEscape.res:1:4 --> InterfaceOptionalArgEscape.res:1:23
+  addValueReference InterfaceOptionalArgEscape.res:5:8 --> InterfaceOptionalArgEscape.res:1:4
+  addValueReference InterfaceOptionalArgEscape.res:5:0 --> InterfaceOptionalArgEscape.res:3:4
+  addValueReference InterfaceOptionalArgEscape.resi:1:0 --> InterfaceOptionalArgEscape.res:1:4
+  OptionalArgs.addFunctionReference InterfaceOptionalArgEscape.resi:1:0 InterfaceOptionalArgEscape.res:1:4
+  Scanning InterfaceOptionalArgEscape.cmti Source:InterfaceOptionalArgEscape.resi
+  addValueDeclaration +escaped InterfaceOptionalArgEscape.resi:1:0 path:InterfaceOptionalArgEscape
+  Scanning InterfaceOptionalArgEscapeUse.cmt Source:InterfaceOptionalArgEscapeUse.res
+  addValueDeclaration +use InterfaceOptionalArgEscapeUse.res:1:4 path:+InterfaceOptionalArgEscapeUse
+  DeadOptionalArgs.addReferences InterfaceOptionalArgEscape.escaped called with optional argNames: argNamesMaybe: InterfaceOptionalArgEscapeUse.res:1:16
+  addValueReference InterfaceOptionalArgEscapeUse.res:1:4 --> InterfaceOptionalArgEscape.resi:1:0
+  addValueReference InterfaceOptionalArgEscapeUse.res:3:8 --> InterfaceOptionalArgEscapeUse.res:1:4
   Scanning JSResource.cmt Source:JSResource.res
   Scanning JsxV4.cmt Source:JsxV4.res
   addValueDeclaration +make JsxV4.res:4:23 path:+JsxV4.C
@@ -2076,9 +2091,9 @@
   
 Forward Liveness Analysis
 
-    decls: 734
-    roots(external targets): 157
-    decl-deps: decls_with_out=443 edges_to_decls=317
+    decls: 738
+    roots(external targets): 160
+    decl-deps: decls_with_out=446 edges_to_decls=319
 
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
@@ -2097,6 +2112,7 @@ Forward Liveness Analysis
     Root (annotated): Value +NestedModules.Universe.Nested2.+nested2Function
     Root (external ref): Value +OptArg.+wrapfourArgs
     Root (annotated): Value +Docstrings.+unitArgWithoutConversionU
+    Root (external ref): Value +InterfaceOptionalArgEscape.+escaped
     Root (external ref): VariantCase +DeadTypeTest.deadType.OnlyInImplementation
     Root (annotated): Value +TestImport.+valueStartingWithUpperCaseLetter
     Root (external ref): Value +TypeReexport.VariantUseReexported.+value
@@ -2300,6 +2316,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+unitArgWithoutConversion
     Root (annotated): Value +ContextOptionalArgs.+make
     Root (annotated): Value +References.+create
+    Root (external ref): Value +InterfaceOptionalArgEscapeUse.+use
     Root (external ref): Value +TopLevelOptionalArgValueUse.+liveEscapeCaller
     Root (annotated): Value +FirstClassModules.+testConvert
     Root (external ref): Value +TopLevelOptionalArgValueUse.+liveTupleCaller
@@ -2388,6 +2405,7 @@ Forward Liveness Analysis
     Root (external ref): Value +OptArg.+twoArgs
     Root (external ref): Value +FirstClassModules.M.+x
     Root (external ref): Value +TypeReexportCrossFileB.+recordValue
+    Root (external ref): Value +InterfaceOptionalArgEscape.+takesFn
     Root (annotated): Value +TestModuleAliases.+testInner1Expanded
     Root (external ref): Value +TypeReexport.OnlyReexportedDead.+value
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive3
@@ -2424,7 +2442,7 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  343 roots found
+  346 roots found
 
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
@@ -2464,6 +2482,7 @@ Forward Liveness Analysis
     Propagate: +References.+set -> +References.R.+set
     Propagate: +TestOptArg.+bar -> +TestOptArg.+foo
     Propagate: NestedModulesInSignature.Universe.+theAnswer -> +NestedModulesInSignature.Universe.+theAnswer
+    Propagate: +InterfaceOptionalArgEscapeUse.+use -> InterfaceOptionalArgEscape.+escaped
     Propagate: +TopLevelOptionalArgValueUse.+liveEscapeCaller -> +TopLevelOptionalArgValueUse.+formatDateEscapes
     Propagate: +TopLevelOptionalArgValueUse.+liveTupleCaller -> +TopLevelOptionalArgValueUse.+formatDateTuple
     Propagate: +DeadTypeTest.t.A -> DeadTypeTest.t.A
@@ -2493,7 +2512,7 @@ Forward Liveness Analysis
     Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  66 declarations marked live via propagation
+  67 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -3456,6 +3475,17 @@ Forward Liveness Analysis
         <- +InnerModuleTypes.I.t.Foo (live)
         <- +TestInnedModuleTypes.+_ (dead)
         -> +InnerModuleTypes.I.t.Foo
+  Live (external ref) Value +InterfaceOptionalArgEscape.+escaped
+      deps: in=1 (live=1 dead=0) out=0
+        <- InterfaceOptionalArgEscape.+escaped (live)
+  Live (external ref) Value +InterfaceOptionalArgEscape.+takesFn
+  Live (propagated) Value InterfaceOptionalArgEscape.+escaped
+      deps: in=1 (live=1 dead=0) out=1
+        <- +InterfaceOptionalArgEscapeUse.+use (live)
+        -> +InterfaceOptionalArgEscape.+escaped
+  Live (external ref) Value +InterfaceOptionalArgEscapeUse.+use
+      deps: in=0 (live=0 dead=0) out=1
+        -> InterfaceOptionalArgEscape.+escaped
   Live (external ref) Value +JsxV4.C.+make
   Live (annotated) Value +LetPrivate.local_1.+x
       deps: in=1 (live=1 dead=0) out=0

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/ContextOptionalArgs.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/ContextOptionalArgs.res
@@ -1,0 +1,60 @@
+module NotificationProvider = {
+  let dispatchNotificationContext = React.createContext((
+    ~action as _: option<string>=?,
+    _message: string,
+  ) => ())
+
+  module Provider = {
+    let make = React.Context.provider(dispatchNotificationContext)
+  }
+
+  @react.component
+  let make = (~children) => {
+    let dispatchNotification = (~action=?, message) =>
+      switch action {
+      | Some(action) => Console.log2(message, action)
+      | None => Console.log(message)
+      }
+
+    <Provider value=dispatchNotification> {children} </Provider>
+  }
+
+  let useNotification = () => React.useContext(dispatchNotificationContext)
+}
+
+module ComponentUsingAction = {
+  @react.component
+  let make = () => {
+    let dispatchNotification = NotificationProvider.useNotification()
+
+    React.useEffect(() => {
+      dispatchNotification(~action="Some action", "This is a notification message")
+      None
+    }, [])
+
+    React.null
+  }
+}
+
+module ComponentNotUsingAction = {
+  @react.component
+  let make = () => {
+    let dispatchNotification = NotificationProvider.useNotification()
+
+    React.useEffect(() => {
+      dispatchNotification("This is a notification message")
+      None
+    }, [])
+
+    React.null
+  }
+}
+
+@live
+@react.component
+let make = () => {
+  <NotificationProvider>
+    <ComponentUsingAction />
+    <ComponentNotUsingAction />
+  </NotificationProvider>
+}

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/CrossFileOptionalArgProvider.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/CrossFileOptionalArgProvider.res
@@ -1,0 +1,1 @@
+let formatDate = (~fmt=?, s) => s

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/CrossFileOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/CrossFileOptionalArgValueUse.res
@@ -1,0 +1,5 @@
+let liveReturnCaller = () => {
+  CrossFileOptionalArgProvider.formatDate
+}
+
+let _ = liveReturnCaller()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscape.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscape.res
@@ -1,0 +1,5 @@
+let escaped = (~fmt=?, value) => value
+
+let takesFn = _ => ()
+
+takesFn(escaped)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscape.resi
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscape.resi
@@ -1,0 +1,1 @@
+let escaped: (~fmt: string=?, string) => string

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscapeUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/InterfaceOptionalArgEscapeUse.res
@@ -1,0 +1,3 @@
+let use = () => InterfaceOptionalArgEscape.escaped("value")
+
+let _ = use()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignature.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignature.res
@@ -1,0 +1,1 @@
+let returnedOptional = (~outer=?, value) => (~inner=?) => value

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignature.resi
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignature.resi
@@ -1,0 +1,1 @@
+let returnedOptional: (~outer: string=?, string) => (~inner: string=?) => string

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignatureUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/ReturnedOptionalSignatureUse.res
@@ -1,0 +1,14 @@
+let useInterfaceDeclaration = () =>
+  ReturnedOptionalSignature.returnedOptional("value")(~inner="used")
+
+module InlineSignature: {
+  let returnedOptional: (~outer: string=?, string) => (~inner: string=?) => string
+} = {
+  let returnedOptional = (~outer=?, value) => (~inner=?) => value
+}
+
+let useInlineSignature = () =>
+  InlineSignature.returnedOptional("value")(~inner="used")
+
+let _ = useInterfaceDeclaration()
+let _ = useInlineSignature()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -1,6 +1,5 @@
-/* Repro for the optional-arg ownership regression on fix-reanalyze.
-   Passing a function with optional args as a first-class value in a top-level
-   eval should not suppress warnings on the function declaration itself. */
+/* Passing a function with optional args as a first-class value must suppress
+   optional-arg warnings even when the function also has a direct call. */
 
 let formatDate = (~fmt=?, s) => s
 
@@ -11,4 +10,3 @@ takesFn(formatDate)
 let liveCaller = () => formatDate("2024-01-01")
 
 let _ = liveCaller()
-

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -6,8 +6,12 @@ let formatDateEscapes = (~fmt=?, s) => s
 let formatDateReturn = (~fmt=?, s) => s
 let formatDateTuple = (~fmt=?, s) => s
 let formatDateForwarded = (~fmt=?, s) => s
+let formatDateTopLevelEscape = (~fmt=?, s) => s
+let formatDateAlias = (~fmt=?, s) => s
 
 let takesFn = _ => ()
+
+takesFn(formatDateTopLevelEscape)
 
 let deadEscape = () => takesFn(formatDate)
 
@@ -30,8 +34,21 @@ let liveForwardingCaller = (~fmt=?) => {
   formatDateForwarded(~fmt?, "2024-01-01")
 }
 
+let formatDateAlias2 = formatDateAlias
+let liveAliasCaller = () => formatDateAlias2("2024-01-01")
+
+let rec mutuallyRecursiveCaller = () => mutuallyRecursiveTarget(~fmt="ISO", "2024-01-01")
+and mutuallyRecursiveTarget = (~fmt=?, s) => s
+
+let returnsFunction = value => (~inner: option<string>=?) => value
+let returnedFunction = returnsFunction("value")
+let liveReturnedFunctionCaller = () => returnedFunction()
+
 let _ = liveCaller()
 let _ = liveEscapeCaller()
 let _ = liveReturnCaller()
 let _ = liveTupleCaller()
 let _ = liveForwardingCaller()
+let _ = liveAliasCaller()
+let _ = mutuallyRecursiveCaller()
+let _ = liveReturnedFunctionCaller()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -3,6 +3,8 @@
 
 let formatDate = (~fmt=?, s) => s
 let formatDateEscapes = (~fmt=?, s) => s
+let formatDateReturn = (~fmt=?, s) => s
+let formatDateTuple = (~fmt=?, s) => s
 
 let takesFn = _ => ()
 
@@ -15,5 +17,15 @@ let liveEscapeCaller = () => {
   formatDateEscapes("2024-01-01")
 }
 
+let liveReturnCaller = () => {
+  formatDateReturn
+}
+
+let liveTupleCaller = () => {
+  (formatDateTuple, "tuple")
+}
+
 let _ = liveCaller()
 let _ = liveEscapeCaller()
+let _ = liveReturnCaller()
+let _ = liveTupleCaller()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -1,0 +1,14 @@
+/* Repro for the optional-arg ownership regression on fix-reanalyze.
+   Passing a function with optional args as a first-class value in a top-level
+   eval should not suppress warnings on the function declaration itself. */
+
+let formatDate = (~fmt=?, s) => s
+
+let takesFn = _ => ()
+
+takesFn(formatDate)
+
+let liveCaller = () => formatDate("2024-01-01")
+
+let _ = liveCaller()
+

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -1,12 +1,19 @@
-/* Passing a function with optional args as a first-class value must suppress
-   optional-arg warnings even when the function also has a direct call. */
+/* Dead first-class escapes should not suppress optional-arg warnings, but live
+   first-class escapes should suppress them even when there is also a direct call. */
 
 let formatDate = (~fmt=?, s) => s
+let formatDateEscapes = (~fmt=?, s) => s
 
 let takesFn = _ => ()
 
-takesFn(formatDate)
+let deadEscape = () => takesFn(formatDate)
 
 let liveCaller = () => formatDate("2024-01-01")
 
+let liveEscapeCaller = () => {
+  takesFn(formatDateEscapes)
+  formatDateEscapes("2024-01-01")
+}
+
 let _ = liveCaller()
+let _ = liveEscapeCaller()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TopLevelOptionalArgValueUse.res
@@ -5,6 +5,7 @@ let formatDate = (~fmt=?, s) => s
 let formatDateEscapes = (~fmt=?, s) => s
 let formatDateReturn = (~fmt=?, s) => s
 let formatDateTuple = (~fmt=?, s) => s
+let formatDateForwarded = (~fmt=?, s) => s
 
 let takesFn = _ => ()
 
@@ -25,7 +26,12 @@ let liveTupleCaller = () => {
   (formatDateTuple, "tuple")
 }
 
+let liveForwardingCaller = (~fmt=?) => {
+  formatDateForwarded(~fmt?, "2024-01-01")
+}
+
 let _ = liveCaller()
 let _ = liveEscapeCaller()
 let _ = liveReturnCaller()
 let _ = liveTupleCaller()
+let _ = liveForwardingCaller()


### PR DESCRIPTION
Fixes #8302

## Summary

Reanalyze now treats optional-argument diagnostics as sound only while it has a closed set of possible calls to a function.

Only syntactic function definitions own and report optional-argument diagnostics. Aliases and functions produced by other expressions do not independently own the optional arguments present in their inferred types.

When an optional-argument function is passed, returned, stored, or otherwise used as a first-class value, the analysis records an escape:

- A live escape suppresses both “never used” and “always supplied” diagnostics. Unseen callers may either omit or supply the argument, so both conclusions become unknown.
- An escape in dead code does not suppress diagnostics because it cannot produce a runtime call.
- Escapes propagate through aliases and paired interface/implementation declarations.

Direct calls are distinguished from first-class uses by tracking the callee expression node. Optional arguments are limited to the declared arity of the outer function, so optional arguments belonging to a returned function are not attributed to the outer declaration. This applies to implementations, `.resi` declarations, and inline module signatures.

Function-reference collection deliberately uses type information instead of declaration-table lookup. That makes it independent of declaration visitation order, including `let rec ... and ...` groups.

## Trade-off

The escape model is intentionally conservative and favors false negatives over unsound false positives once the call set is open. For example, the `formatDateAlias` fixture contains a genuine optional-argument issue that is intentionally not reported when the function is reachable only through an alias.

## Tests

Regression coverage includes live and dead escapes, direct calls mixed with escapes, returned and forwarded functions, aliases, mutual recursion, interface/implementation pairs, top-level expressions, returned functions, `.resi` declarations, and inline module signatures.