### PR TITLE
Remove outdated Node.js version guards from docstring tests

### DIFF
--- a/tests/docstring_tests/DocTest.res
+++ b/tests/docstring_tests/DocTest.res
@@ -15,31 +15,12 @@ let nodeVersion =
 
 let ignoreRuntimeTests = [
   (
-    // Ignore tests that require Node.js v20+
-    20,
-    ["Stdlib_Array.toReversed", "Stdlib_Array.toSorted"],
-  ),
-  (
-    // Ignore tests that require Node.js v22+
-    22,
-    [
-      "Stdlib_Promise.withResolvers",
-      "Stdlib_Set.union",
-      "Stdlib_Set.isSupersetOf",
-      "Stdlib_Set.isSubsetOf",
-      "Stdlib_Set.isDisjointFrom",
-      "Stdlib_Set.intersection",
-      "Stdlib_Set.symmetricDifference",
-      "Stdlib_Set.difference",
-    ],
-  ),
-  (
     // Ignore tests that require Node.js v24+
     24,
     ["Stdlib_RegExp.escape"],
   ),
   (
-    // Not available in Node.js yet
+    // Require Node.js 24 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat16#browser_compatibility)
     1000,
     ["Stdlib_DataView.getFloat16", "Stdlib_DataView.setFloat16"],
   ),

--- a/tests/docstring_tests/DocTest.res
+++ b/tests/docstring_tests/DocTest.res
@@ -15,13 +15,13 @@ let nodeVersion =
 
 let ignoreRuntimeTests = [
   (
-    // Ignore tests that require Node.js v24+
+    // Ignore tests that require Node.js v24+ (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape#browser_compatibility)
     24,
     ["Stdlib_RegExp.escape"],
   ),
   (
-    // Require Node.js 24 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat16#browser_compatibility)
-    1000,
+    // Require Node.js v24+ (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat16#browser_compatibility)
+    24,
     ["Stdlib_DataView.getFloat16", "Stdlib_DataView.setFloat16"],
   ),
 ]

--- a/tests/docstring_tests/DocTest.res.js
+++ b/tests/docstring_tests/DocTest.res.js
@@ -22,26 +22,6 @@ let nodeVersion = Stdlib_Option.getOrThrow(Stdlib_Int.fromString(Stdlib_Option.g
 
 let ignoreRuntimeTests = [
   [
-    20,
-    [
-      "Stdlib_Array.toReversed",
-      "Stdlib_Array.toSorted"
-    ]
-  ],
-  [
-    22,
-    [
-      "Stdlib_Promise.withResolvers",
-      "Stdlib_Set.union",
-      "Stdlib_Set.isSupersetOf",
-      "Stdlib_Set.isSubsetOf",
-      "Stdlib_Set.isDisjointFrom",
-      "Stdlib_Set.intersection",
-      "Stdlib_Set.symmetricDifference",
-      "Stdlib_Set.difference"
-    ]
-  ],
-  [
     24,
     ["Stdlib_RegExp.escape"]
   ],

--- a/tests/docstring_tests/DocTest.res.js
+++ b/tests/docstring_tests/DocTest.res.js
@@ -26,7 +26,7 @@ let ignoreRuntimeTests = [
     ["Stdlib_RegExp.escape"]
   ],
   [
-    1000,
+    24,
     [
       "Stdlib_DataView.getFloat16",
       "Stdlib_DataView.setFloat16"


### PR DESCRIPTION
Node.js 20 has been dropped and the minimum is now v22, so the version guards for Node.js 20+ and 22+ features are no longer needed.