### PR TITLE
Sync dune-project with opam dependencies

### DIFF
--- a/analysis.opam
+++ b/analysis.opam
@@ -7,9 +7,9 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
+  "dune" {>= "3.17"}
   "ocaml" {>= "5.0.0"}
   "cppo" {= "1.8.0"}
-  "dune" {>= "3.17"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
  (depends
   (ocaml
    (>= 5.0.0))
+  dune
   (cppo
    (= 1.8.0))
   (flow_parser

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,30 @@
  (synopsis "ReScript compiler")
  (depends
   (ocaml
-   (>= 5.0.0))))
+   (>= 5.0.0))
+  (cppo
+   (= 1.8.0))
+  (flow_parser
+   (= 0.267.0))
+  (ocamlformat
+   (and :with-test (= 0.27.0)))
+  (yojson
+   (and :with-test (= 2.2.2)))
+  (ounit2
+   (and :with-test (= 2.2.7)))
+  (odoc :with-doc)
+  (ocaml-lsp-server
+   (and :with-dev-setup (= 1.22.0)))
+  (js_of_ocaml
+   (and
+    (<> :os "win32")
+    :with-test
+    (= 6.0.1)))
+  (wasm_of_ocaml-compiler
+   (and
+    (<> :os "win32")
+    :with-test
+    (= 6.0.1)))))
 
 (package
  (name analysis)
@@ -29,7 +52,7 @@
    (>= 5.0.0))
   (cppo
    (= 1.8.0))
-  dune))
+  (odoc :with-doc)))
 
 (package
  (name tools)
@@ -42,4 +65,4 @@
   (cppo
    (= 1.8.0))
   analysis
-  dune))
+  (odoc :with-doc)))

--- a/rescript.opam
+++ b/rescript.opam
@@ -6,6 +6,19 @@ authors: ["Hongbo Zhang <bobzhang1988@gmail.com>"]
 license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.0.0"}
+  "cppo" {= "1.8.0"}
+  "flow_parser" {= "0.267.0"}
+  "ocamlformat" {with-test & = "0.27.0"}
+  "yojson" {with-test & = "2.2.2"}
+  "ounit2" {with-test & = "2.2.7"}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup & = "1.22.0"}
+  "js_of_ocaml" {os != "win32" & with-test & = "6.0.1"}
+  "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.0.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -19,21 +32,6 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-]
-depends: [
-  "ocaml" {>= "5.0.0"}
-  "cppo" {= "1.8.0"}
-  "dune" {>= "3.17"}
-  "flow_parser" {= "0.267.0"}
-  "ocamlformat" {with-test & = "0.27.0"}
-  "yojson" {with-test & = "2.2.2"}
-  "ounit2" {with-test & = "2.2.7"}
-  "odoc" {with-doc}
-  "ocaml-lsp-server" {with-dev-setup & = "1.22.0"}
-
-  # Test dependencies that would be broken on Windows runners
-  "js_of_ocaml" {os != "win32" & with-test & = "6.0.1"}
-  "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.0.1"}
 ]
 pin-depends: [
   ["flow_parser.0.267.0" "git+https://github.com/rescript-lang/flow.git#9ea4062c0b7e037415c4413a7634c459ebd5c31b"]

--- a/rescript.opam
+++ b/rescript.opam
@@ -7,8 +7,8 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
-  "dune" {>= "3.17"}
   "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.17"}
   "cppo" {= "1.8.0"}
   "flow_parser" {= "0.267.0"}
   "ocamlformat" {with-test & = "0.27.0"}

--- a/rescript.opam.template
+++ b/rescript.opam.template
@@ -1,18 +1,3 @@
-depends: [
-  "ocaml" {>= "5.0.0"}
-  "cppo" {= "1.8.0"}
-  "dune" {>= "3.17"}
-  "flow_parser" {= "0.267.0"}
-  "ocamlformat" {with-test & = "0.27.0"}
-  "yojson" {with-test & = "2.2.2"}
-  "ounit2" {with-test & = "2.2.7"}
-  "odoc" {with-doc}
-  "ocaml-lsp-server" {with-dev-setup & = "1.22.0"}
-
-  # Test dependencies that would be broken on Windows runners
-  "js_of_ocaml" {os != "win32" & with-test & = "6.0.1"}
-  "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.0.1"}
-]
 pin-depends: [
   ["flow_parser.0.267.0" "git+https://github.com/rescript-lang/flow.git#9ea4062c0b7e037415c4413a7634c459ebd5c31b"]
 ]

--- a/tools.opam
+++ b/tools.opam
@@ -7,11 +7,11 @@ license: "LGPL-3.0-or-later"
 homepage: "https://github.com/rescript-lang/rescript-compiler"
 bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
+  "dune" {>= "3.17"}
   "ocaml" {>= "5.0.0"}
   "cmarkit" {>= "0.3.0"}
   "cppo" {= "1.8.0"}
   "analysis"
-  "dune" {>= "3.17"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
The .opam files declared dependencies (cppo, flow_parser, ocamlformat, yojson, ounit2, odoc, ocaml-lsp-server, js_of_ocaml, wasm_of_ocaml-compiler) that were not present in dune-project. For the rescript package those deps were sourced from rescript.opam.template, which fully overrode what dune-project would have generated. For analysis and tools, the odoc {with-doc} entry was missing entirely.

Move all dependencies into dune-project so it is the single source of truth, and shrink rescript.opam.template to only the pin-depends: block for the flow_parser fork — the one field dune-project cannot express. The regenerated .opam files are equivalent to the previous ones.