### PR TITLE
Update lsp and yojson dependencies

### DIFF
--- a/analysis.opam
+++ b/analysis.opam
@@ -11,8 +11,8 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "cppo" {= "1.8.0"}
   "odoc" {with-doc}
-  "lsp" {= "1.22.0"}
-  "yojson" {= "2.2.2"}
+  "lsp" {>= "1.23.0"}
+  "yojson" {= "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -44,7 +44,7 @@
   (wasm_of_ocaml-compiler
    (and
     (<> :os "win32")
-    :with-test`
+    :with-test
     (= 6.0.1)))))
 
 (package

--- a/dune-project
+++ b/dune-project
@@ -28,12 +28,12 @@
   (ocamlformat
    (and :with-test (= 0.27.0)))
   (yojson
-   (and :with-test (= 2.2.2)))
+   (and :with-test (= 3.0.0)))
   (ounit2
    (and :with-test (= 2.2.7)))
   (odoc :with-doc)
   (ocaml-lsp-server
-   (and :with-dev-setup (= 1.22.0)))
+   (and :with-dev-setup (>= 1.23.0)))
   (bisect_ppx
    (and :with-dev-setup (>= 2.8.0)))
   (js_of_ocaml
@@ -44,7 +44,7 @@
   (wasm_of_ocaml-compiler
    (and
     (<> :os "win32")
-    :with-test
+    :with-test`
     (= 6.0.1)))))
 
 (package
@@ -57,9 +57,9 @@
    (= 1.8.0))
   (odoc :with-doc)
   (lsp
-   (= 1.22.0))
+   (>= 1.23.0))
   (yojson
-    (= 2.2.2))))
+    (= 3.0.0))))
 
 (package
  (name tools)
@@ -73,5 +73,5 @@
    (= 1.8.0))
   analysis
   (yojson
-    (= 2.2.2))
+    (= 3.0.0))
   (odoc :with-doc)))

--- a/rescript.opam
+++ b/rescript.opam
@@ -12,10 +12,10 @@ depends: [
   "cppo" {= "1.8.0"}
   "flow_parser" {= "0.267.0"}
   "ocamlformat" {with-test & = "0.27.0"}
-  "yojson" {with-test & = "2.2.2"}
+  "yojson" {with-test & = "3.0.0"}
   "ounit2" {with-test & = "2.2.7"}
   "odoc" {with-doc}
-  "ocaml-lsp-server" {with-dev-setup & = "1.22.0"}
+  "ocaml-lsp-server" {with-dev-setup & >= "1.23.0"}
   "bisect_ppx" {with-dev-setup & >= "2.8.0"}
   "js_of_ocaml" {os != "win32" & with-test & = "6.0.1"}
   "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.0.1"}

--- a/tools.opam
+++ b/tools.opam
@@ -12,7 +12,7 @@ depends: [
   "cmarkit" {>= "0.3.0"}
   "cppo" {= "1.8.0"}
   "analysis"
-  "yojson" {= "2.2.2"}
+  "yojson" {= "3.0.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Relax LSP-related dependencies to allow 1.23.0+ and update yojson pins to 3.0.0 across dune-project and opam package files.