### PR TITLE
analysis refactor: remove global state `Shared_types.state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Catalog every named compiler error variant in `tests/ERROR_VARIANTS.md` and add fixtures for the remaining reachable ones. https://github.com/rescript-lang/rescript/pull/8446
 - Remove dead and unreachable compiler error and warning variants; add fixtures for the ones found to be reachable. https://github.com/rescript-lang/rescript/pull/8459
 - Convert OCaml codebase to snake case format. https://github.com/rescript-lang/rescript/pull/8456
+- Analysis refactor: remove global state `Shared_types.state`. https://github.com/rescript-lang/rescript/pull/8465
 
 
 # 13.0.0-alpha.4

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -217,7 +217,7 @@ let main () =
     `String (Create_interface.command ~state ~path ~cmi_file)
     |> Yojson.Safe.pretty_to_string ~std:true
     |> print_endline
-  | [_; "format"; path] -> Cli.format ~state ~path
+  | [_; "format"; path] -> Cli.format ~path
   | [_; "test"; path] -> Cli.test ~state ~path
   | [_; "cmt"; rescript_json; cmt_path] ->
     Cmt_viewer.dump ~state rescript_json cmt_path

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -92,6 +92,7 @@ Options:
 |}
 
 let main () =
+  let state = Shared_types.create_state () in
   let args = Array.to_list Sys.argv in
   let debug_level, args =
     match args with
@@ -118,7 +119,7 @@ let main () =
   | [_; "cache-project"; root_path] -> (
     Cfg.read_project_config_cache := false;
     let uri = Uri.from_path root_path in
-    match Packages.get_package ~uri with
+    match Packages.get_package ~state ~uri with
     | Some package -> Cache.cache_project package
     | None -> print_endline "\"ERR\"")
   | [_; "cache-delete"; root_path] -> (
@@ -136,18 +137,20 @@ let main () =
     print_header_info path line col;
     Cli.completion ~debug ~path
       ~pos:(int_of_string line, int_of_string col)
-      ~current_file
+      ~current_file ~state
   | [_; "completionResolve"; path; module_path] ->
-    Cli.completion_resolve ~path ~module_path
+    Cli.completion_resolve ~state ~path ~module_path
   | [_; "definition"; path; line; col] ->
-    Cli.definition ~path ~pos:(int_of_string line, int_of_string col) ~debug
+    Cli.definition ~state ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug
   | [_; "typeDefinition"; path; line; col] ->
-    Cli.type_definition ~path
+    Cli.type_definition ~state ~path
       ~pos:(int_of_string line, int_of_string col)
       ~debug
   | [_; "documentSymbol"; path] -> Document_symbol.command ~path
   | [_; "hover"; path; line; col; current_file; supports_markdown_links] ->
-    Cli.hover ~path
+    Cli.hover ~state ~path
       ~pos:(int_of_string line, int_of_string col)
       ~current_file ~debug
       ~supports_markdown_links:
@@ -163,7 +166,7 @@ let main () =
    current_file;
    allow_for_constructor_payloads;
   ] ->
-    Cli.signature_help ~path
+    Cli.signature_help ~state ~path
       ~pos:(int_of_string line, int_of_string col)
       ~current_file ~debug
       ~allow_for_constructor_payloads:
@@ -171,14 +174,14 @@ let main () =
         | "true" -> true
         | _ -> false)
   | [_; "inlayHint"; path; line_start; line_end; max_length] ->
-    Cli.inlayhint ~path
+    Cli.inlayhint ~state ~path
       ~pos:(int_of_string line_start, int_of_string line_end)
       ~max_length ~debug
-  | [_; "codeLens"; path] -> Cli.code_lens ~path ~debug
+  | [_; "codeLens"; path] -> Cli.code_lens ~state ~path ~debug
   | [
    _; "codeAction"; path; start_line; start_col; end_line; end_col; current_file;
   ] ->
-    Cli.code_action ~path
+    Cli.code_action ~state ~path
       ~start_pos:(int_of_string start_line, int_of_string start_col)
       ~end_pos:(int_of_string end_line, int_of_string end_col)
       ~current_file ~debug
@@ -197,23 +200,27 @@ let main () =
     |> print_endline
   | [_; "diagnosticSyntax"; path] -> Cli.diagnostic_syntax ~path
   | [_; "references"; path; line; col] ->
-    Cli.references ~path ~pos:(int_of_string line, int_of_string col) ~debug
+    Cli.references ~state ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug
   | [_; "prepareRename"; path; line; col] ->
-    Cli.prepare_rename ~path ~pos:(int_of_string line, int_of_string col) ~debug
+    Cli.prepare_rename ~state ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug
   | [_; "rename"; path; line; col; new_name] ->
-    Cli.rename ~path
+    Cli.rename ~state ~path
       ~pos:(int_of_string line, int_of_string col)
       ~new_name ~debug
   | [_; "semanticTokens"; current_file] ->
     Cli.semantic_tokens ~path:current_file
   | [_; "createInterface"; path; cmi_file] ->
-    `String (Create_interface.command ~path ~cmi_file)
+    `String (Create_interface.command ~state ~path ~cmi_file)
     |> Yojson.Safe.pretty_to_string ~std:true
     |> print_endline
-  | [_; "format"; path] -> Cli.format ~path
-  | [_; "test"; path] -> Cli.test ~path
+  | [_; "format"; path] -> Cli.format ~state ~path
+  | [_; "test"; path] -> Cli.test ~state ~path
   | [_; "cmt"; rescript_json; cmt_path] ->
-    Cmt_viewer.dump rescript_json cmt_path
+    Cmt_viewer.dump ~state rescript_json cmt_path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->
     prerr_endline help;

--- a/analysis/reanalyze/src/paths.ml
+++ b/analysis/reanalyze/src/paths.ml
@@ -35,7 +35,7 @@ let set_project_root_from_cwd () =
     | None -> run_config.project_root
     | Some s -> s)
 
-let set_re_script_project_root = lazy (set_project_root_from_cwd ())
+let set_rescript_project_root = lazy (set_project_root_from_cwd ())
 
 module Config = struct
   let read_suppress conf =

--- a/analysis/reanalyze/src/reanalyze.ml
+++ b/analysis/reanalyze/src/reanalyze.ml
@@ -102,7 +102,7 @@ let collect_cmt_file_paths ~cmt_root : string list =
     in
     walk_sub_dirs ""
   | None ->
-    Lazy.force Paths.set_re_script_project_root;
+    Lazy.force Paths.set_rescript_project_root;
     (* Prefer explicit scan plan emitted by rewatch (v2 `.sourcedirs.json`).
        This supports monorepos without reanalyze-side package resolution. *)
     let scan_plan = Paths.read_cmt_scan () in

--- a/analysis/src/cli.ml
+++ b/analysis/src/cli.ml
@@ -25,7 +25,9 @@ let inlayhint ~state ~path ~pos ~max_length ~debug =
   match Files.read_file path with
   | None -> print_null ()
   | Some source -> (
-    match Hint.inlay ~source ~kind_file ~pos ~max_length ~full ~debug with
+    match
+      Hint.inlay ~source ~kind_file ~pos ~max_length ~full ~state ~debug
+    with
     | Some hints ->
       hints
       |> List.map (fun h -> Lsp.Types.InlayHint.yojson_of_t h)
@@ -65,7 +67,7 @@ let signature_help ~state ~path ~pos ~current_file ~debug
   | Some source -> (
     match
       Commands.signature_help ~state ~source ~kind_file ~pos
-        ~allow_for_constructor_payloads ~full ~debug
+        ~allow_for_constructor_payloads ~full ~state ~debug
     with
     | None -> print_null ()
     | Some s -> Lsp.Types.SignatureHelp.yojson_of_t s |> print_string)

--- a/analysis/src/cli.ml
+++ b/analysis/src/cli.ml
@@ -3,24 +3,24 @@ let print_string json =
 let print_null () = `Null |> print_string
 let print_list l = `List l |> print_string
 
-let completion ~debug ~path ~pos ~current_file =
-  let full = Cmt.load_full_cmt_from_path ~path in
+let completion ~state ~debug ~path ~pos ~current_file =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
   let kind_file = Files.classify_source_file current_file in
   match Files.read_file current_file with
   | None | Some "" -> print_null ()
   | Some source ->
-    Commands.completion ~debug ~source ~kind_file ~pos ~full
+    Commands.completion ~state ~debug ~source ~kind_file ~pos ~full
     |> List.map (fun c -> Lsp.Types.CompletionItem.yojson_of_t c)
     |> print_list
 
-let completion_resolve ~path ~module_path =
-  let full = Cmt.load_full_cmt_from_path ~path in
-  match Commands.completion_resolve ~full ~module_path with
+let completion_resolve ~state ~path ~module_path =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
+  match Commands.completion_resolve ~state ~full ~module_path with
   | None -> print_null ()
   | Some (`MarkupContent {value}) -> `String value |> print_string
 
-let inlayhint ~path ~pos ~max_length ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
+let inlayhint ~state ~path ~pos ~max_length ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
   let kind_file = Files.classify_source_file path in
   match Files.read_file path with
   | None -> print_null ()
@@ -32,8 +32,8 @@ let inlayhint ~path ~pos ~max_length ~debug =
       |> print_list
     | None -> print_null ())
 
-let code_lens ~path ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
+let code_lens ~state ~path ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
   let kind_file = Files.classify_source_file path in
   match Files.read_file path with
   | None -> print_null ()
@@ -43,68 +43,68 @@ let code_lens ~path ~debug =
       lens |> List.map (fun l -> Lsp.Types.CodeLens.yojson_of_t l) |> print_list
     | None -> print_null ())
 
-let hover ~path ~pos ~current_file ~debug ~supports_markdown_links =
-  let full = Cmt.load_full_cmt_from_path ~path in
+let hover ~state ~path ~pos ~current_file ~debug ~supports_markdown_links =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
   let kind_file = Files.classify_source_file current_file in
   match Files.read_file current_file with
   | None -> print_null ()
   | Some source -> (
     match
       Commands.hover ~source ~kind_file ~pos ~debug ~supports_markdown_links
-        ~full
+        ~state ~full
     with
     | Some value -> Lsp.Types.Hover.yojson_of_t value |> print_string
     | None -> print_null ())
 
-let signature_help ~path ~pos ~current_file ~debug
+let signature_help ~state ~path ~pos ~current_file ~debug
     ~allow_for_constructor_payloads =
-  let full = Cmt.load_full_cmt_from_path ~path in
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
   let kind_file = Files.classify_source_file current_file in
   match Files.read_file current_file with
   | None -> print_null ()
   | Some source -> (
     match
-      Signature_help.signature_help ~source ~kind_file ~pos
+      Commands.signature_help ~state ~source ~kind_file ~pos
         ~allow_for_constructor_payloads ~full ~debug
     with
     | None -> print_null ()
     | Some s -> Lsp.Types.SignatureHelp.yojson_of_t s |> print_string)
 
-let code_action ~path ~start_pos ~end_pos ~current_file ~debug =
+let code_action ~state ~path ~start_pos ~end_pos ~current_file ~debug =
   let kind_file = Files.classify_source_file current_file in
   match Files.read_file current_file with
   | None -> print_null ()
   | Some source ->
-    Xform.extract_code_actions ~path ~start_pos ~end_pos ~source ~kind_file
-      ~debug
+    Xform.extract_code_actions ~state ~path ~start_pos ~end_pos ~source
+      ~kind_file ~debug
     |> List.map (fun c -> Lsp.Types.CodeAction.yojson_of_t c)
     |> print_list
 
-let definition ~path ~pos ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
+let definition ~state ~path ~pos ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
 
-  match Commands.definition ~full ~pos ~debug with
+  match Commands.definition ~state ~full ~pos ~debug with
   | None -> print_null ()
   | Some location -> location |> Lsp.Types.Location.yojson_of_t |> print_string
 
-let type_definition ~path ~pos ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
-  match Commands.type_definition ~full ~pos ~debug with
+let type_definition ~state ~path ~pos ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
+  match Commands.type_definition ~state ~full ~pos ~debug with
   | None -> print_null ()
   | Some location -> location |> Lsp.Types.Location.yojson_of_t |> print_string
 
-let references ~path ~pos ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
-  let all_locs = Commands.references ~full ~pos ~debug in
+let references ~state ~path ~pos ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
+  let all_locs = Commands.references ~state ~full ~pos ~debug in
   if all_locs = [] then print_null ()
   else
     all_locs
     |> List.map (fun l -> Lsp.Types.Location.yojson_of_t l)
     |> print_list
 
-let rename ~path ~pos ~new_name ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
-  match Commands.rename ~full ~pos ~new_name ~debug with
+let rename ~state ~path ~pos ~new_name ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
+  match Commands.rename ~state ~full ~pos ~new_name ~debug with
   | Some {documentChanges = Some document_changes} ->
     document_changes
     |> List.map (fun c ->
@@ -116,9 +116,9 @@ let rename ~path ~pos ~new_name ~debug =
     |> print_list
   | _ -> print_null ()
 
-let prepare_rename ~path ~pos ~debug =
-  let full = Cmt.load_full_cmt_from_path ~path in
-  match Commands.prepare_rename ~full ~pos ~debug with
+let prepare_rename ~state ~path ~pos ~debug =
+  let full = Cmt.load_full_cmt_from_path ~state ~path in
+  match Commands.prepare_rename ~state ~full ~pos ~debug with
   | None -> print_null ()
   | Some {range; placeholder = None} ->
     Lsp.Types.Range.yojson_of_t range |> print_string
@@ -130,12 +130,12 @@ let prepare_rename ~path ~pos ~debug =
       ]
     |> print_string
 
-let format ~path =
+let format ~state ~path =
   match Files.read_file path with
   | None -> print_null ()
   | Some source -> (
     let kind_file = Files.classify_source_file path in
-    match Commands.format ~source ~kind_file with
+    match Commands.format ~state ~source ~kind_file with
     | Ok text_edits -> (
       match text_edits with
       | {newText} :: _ -> print_string (`String newText)
@@ -159,7 +159,7 @@ let semantic_tokens ~path =
     let tokens = Semantic_tokens.semantic_tokens ~source ~kind_file in
     Lsp.Types.SemanticTokens.yojson_of_t tokens |> print_string
 
-let test ~path =
+let test ~state ~path =
   Uri.strip_path := true;
   match Files.read_file path with
   | None -> assert false
@@ -224,19 +224,19 @@ let test ~path =
             print_endline
               ("Definition " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
-            definition ~path ~pos:(line, col) ~debug:true
+            definition ~state ~path ~pos:(line, col) ~debug:true
           | "com" ->
             print_endline
               ("Complete " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
             let current_file = create_current_file () in
-            completion ~debug:true ~path ~pos:(line, col) ~current_file;
+            completion ~state ~debug:true ~path ~pos:(line, col) ~current_file;
             Sys.remove current_file
           | "cre" ->
             let module_path = String.sub rest 3 (String.length rest - 3) in
             let module_path = String.trim module_path in
             print_endline ("Completion resolve: " ^ module_path);
-            completion_resolve ~path ~module_path
+            completion_resolve ~state ~path ~module_path
           | "dce" ->
             print_endline ("DCE " ^ path);
             Reanalyze.Run_config.run_config.suppress <- ["src"];
@@ -259,7 +259,7 @@ let test ~path =
               ("Hover " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
             let current_file = create_current_file () in
-            hover ~supports_markdown_links:true ~path ~pos:(line, col)
+            hover ~state ~supports_markdown_links:true ~path ~pos:(line, col)
               ~current_file ~debug:true;
             Sys.remove current_file
           | "she" ->
@@ -267,8 +267,8 @@ let test ~path =
               ("Signature help " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
             let current_file = create_current_file () in
-            signature_help ~path ~pos:(line, col) ~current_file ~debug:true
-              ~allow_for_constructor_payloads:true;
+            signature_help ~state ~path ~pos:(line, col) ~current_file
+              ~debug:true ~allow_for_constructor_payloads:true;
             Sys.remove current_file
           | "int" ->
             print_endline ("Create Interface " ^ path);
@@ -279,17 +279,17 @@ let test ~path =
               let dir = dirname path in
               dir ++ parent_dir_name ++ "lib" ++ "bs" ++ "src" ++ name
             in
-            Printf.printf "%s" (Create_interface.command ~path ~cmi_file)
+            Printf.printf "%s" (Create_interface.command ~state ~path ~cmi_file)
           | "ref" ->
             print_endline
               ("References " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
-            references ~path ~pos:(line, col) ~debug:true
+            references ~state ~path ~pos:(line, col) ~debug:true
           | "pre" ->
             print_endline
               ("PrepareRename " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
-            prepare_rename ~path ~pos:(line, col) ~debug:true
+            prepare_rename ~state ~path ~pos:(line, col) ~debug:true
           | "ren" ->
             let new_name = String.sub rest 4 (len - mlen - 4) in
             let () =
@@ -297,12 +297,12 @@ let test ~path =
                 ("Rename " ^ path ^ " " ^ string_of_int line ^ ":"
                ^ string_of_int col ^ " " ^ new_name)
             in
-            rename ~path ~pos:(line, col) ~new_name ~debug:true
+            rename ~state ~path ~pos:(line, col) ~new_name ~debug:true
           | "typ" ->
             print_endline
               ("TypeDefinition " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
-            type_definition ~path ~pos:(line, col) ~debug:true
+            type_definition ~state ~path ~pos:(line, col) ~debug:true
           | "xfm" ->
             let current_file = create_current_file () in
             (* +2 is to ensure that the character ^ points to is what's considered the end of the selection. *)
@@ -323,8 +323,8 @@ let test ~path =
             in
             let kind_file = Files.classify_source_file current_file in
             let code_actions =
-              Xform.extract_code_actions ~path ~start_pos ~end_pos ~source
-                ~kind_file ~debug:true
+              Xform.extract_code_actions ~state ~path ~start_pos ~end_pos
+                ~source ~kind_file ~debug:true
             in
             Sys.remove current_file;
             code_actions
@@ -402,11 +402,11 @@ let test ~path =
             print_endline
               ("Inlay Hint " ^ path ^ " " ^ string_of_int line_start ^ ":"
              ^ string_of_int line_end);
-            inlayhint ~path ~pos:(line_start, line_end) ~max_length:"25"
+            inlayhint ~state ~path ~pos:(line_start, line_end) ~max_length:"25"
               ~debug:false
           | "cle" ->
             print_endline ("Code Lens " ^ path);
-            code_lens ~path ~debug:false
+            code_lens ~state ~path ~debug:false
           | "ast" ->
             print_endline
               ("Dump AST " ^ path ^ " " ^ string_of_int line ^ ":"

--- a/analysis/src/cli.ml
+++ b/analysis/src/cli.ml
@@ -66,7 +66,7 @@ let signature_help ~state ~path ~pos ~current_file ~debug
   | None -> print_null ()
   | Some source -> (
     match
-      Commands.signature_help ~state ~source ~kind_file ~pos
+      Commands.signature_help ~source ~kind_file ~pos
         ~allow_for_constructor_payloads ~full ~state ~debug
     with
     | None -> print_null ()
@@ -120,7 +120,7 @@ let rename ~state ~path ~pos ~new_name ~debug =
 
 let prepare_rename ~state ~path ~pos ~debug =
   let full = Cmt.load_full_cmt_from_path ~state ~path in
-  match Commands.prepare_rename ~state ~full ~pos ~debug with
+  match Commands.prepare_rename ~full ~pos ~debug with
   | None -> print_null ()
   | Some {range; placeholder = None} ->
     Lsp.Types.Range.yojson_of_t range |> print_string
@@ -132,12 +132,12 @@ let prepare_rename ~state ~path ~pos ~debug =
       ]
     |> print_string
 
-let format ~state ~path =
+let format ~path =
   match Files.read_file path with
   | None -> print_null ()
   | Some source -> (
     let kind_file = Files.classify_source_file path in
-    match Commands.format ~state ~source ~kind_file with
+    match Commands.format ~source ~kind_file with
     | Ok text_edits -> (
       match text_edits with
       | {newText} :: _ -> print_string (`String newText)

--- a/analysis/src/cmt.ml
+++ b/analysis/src/cmt.ml
@@ -34,9 +34,9 @@ let full_from_module_uri ~package ~module_name ~uri ~paths =
     let cmt = get_cmt_path ~uri paths in
     full_for_cmt ~module_name ~package ~uri cmt
 
-let full_from_uri ~uri =
+let full_from_uri ~state ~uri =
   let path = Uri.to_path uri in
-  match Packages.get_package ~uri with
+  match Packages.get_package ~state ~uri with
   | None -> None
   | Some package -> (
     let module_name =
@@ -68,13 +68,13 @@ let fulls_from_module ~package ~module_name =
     |> List.filter_map (fun uri ->
            full_from_module_uri ~package ~module_name ~uri ~paths)
 
-let load_full_cmt_from_path ~path =
+let load_full_cmt_from_path ~state ~path =
   let uri = Uri.from_path path in
-  full_from_uri ~uri
+  full_from_uri ~state ~uri
 
-let load_cmt_infos_from_path ~path =
+let load_cmt_infos_from_path ~state ~path =
   let uri = Uri.from_path path in
-  match Packages.get_package ~uri with
+  match Packages.get_package ~state ~uri with
   | None -> None
   | Some package -> (
     let module_name =

--- a/analysis/src/cmt_viewer.ml
+++ b/analysis/src/cmt_viewer.ml
@@ -16,11 +16,11 @@ let filter_by_cursor cursor (loc : Warnings.loc) : bool =
 
 type filter = Cursor of (int * int) | Loc of Loc.t
 
-let dump ?filter rescript_json cmt_path =
+let dump ~state ?filter rescript_json cmt_path =
   let uri = Uri.from_path (Filename.remove_extension cmt_path ^ ".res") in
   let package =
     let uri = Uri.from_path rescript_json in
-    Packages.get_package ~uri |> Option.get
+    Packages.get_package ~state ~uri |> Option.get
   in
   let module_name =
     Build_system.namespaced_name package.namespace

--- a/analysis/src/commands.ml
+++ b/analysis/src/commands.ml
@@ -95,10 +95,10 @@ let hover ~state ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
                  ~kind:Lsp.Types.MarkupKind.Markdown ~value))
          ())
 
-let signature_help ~state:_ ~source ~kind_file ~pos
+let signature_help ~state ~source ~kind_file ~pos
     ~allow_for_constructor_payloads ~full ~debug =
   Signature_help.signature_help ~debug ~source ~kind_file ~pos
-    ~allow_for_constructor_payloads ~full
+    ~allow_for_constructor_payloads ~full ~state
 
 let definition ~state ~full ~pos ~debug =
   let location_opt =
@@ -266,7 +266,7 @@ type prepare_rename_result = {
   placeholder: string option;
 }
 
-let prepare_rename ~state:_ ~full ~pos ~debug =
+let prepare_rename ~full ~pos ~debug =
   match full with
   | None -> None
   | Some full -> (
@@ -283,7 +283,7 @@ let prepare_rename ~state:_ ~full ~pos ~debug =
       in
       Some {range; placeholder = placeholder_opt})
 
-let format ~state:_ ~source ~kind_file =
+let format ~source ~kind_file =
   let create_range text =
     let lines = text |> String.split_on_char '\n' in
     let lines_len = List.length lines in

--- a/analysis/src/commands.ml
+++ b/analysis/src/commands.ml
@@ -1,6 +1,6 @@
 let completion ~state ~debug ~source ~kind_file ~pos ~full =
   match
-    Completions.get_completions ~debug ~source ~kind_file ~pos ~full
+    Completions.get_completions ~debug ~source ~kind_file ~pos ~full ~state
       ~for_hover:false
   with
   | None -> []

--- a/analysis/src/commands.ml
+++ b/analysis/src/commands.ml
@@ -1,13 +1,14 @@
-let completion ~debug ~source ~kind_file ~pos ~full =
+let completion ~state ~debug ~source ~kind_file ~pos ~full =
   match
     Completions.get_completions ~debug ~source ~kind_file ~pos ~full
       ~for_hover:false
   with
   | None -> []
   | Some (completions, full, _) ->
-    completions |> List.map (Completion_back_end.completion_to_item ~full)
+    completions
+    |> List.map (Completion_back_end.completion_to_item ~state ~full)
 
-let completion_resolve ~(full : Shared_types.full option) ~module_path =
+let completion_resolve ~state ~(full : Shared_types.full option) ~module_path =
   (* We ignore the internal module path as of now because there's currently
      no use case for it. But, if we wanted to move resolving documentation
      for regular modules and not just file modules to the completionResolve
@@ -25,7 +26,9 @@ let completion_resolve ~(full : Shared_types.full option) ~module_path =
         Printf.printf "[completion_resolve] Could not load cmt\n";
       None
     | Some full -> (
-      match Process_cmt.file_for_module ~package:full.package module_name with
+      match
+        Process_cmt.file_for_module ~state ~package:full.package module_name
+      with
       | None ->
         if Debug.verbose () then
           Printf.printf "[completion_resolve] Did not find file for module %s\n"
@@ -41,7 +44,7 @@ let completion_resolve ~(full : Shared_types.full option) ~module_path =
          (Lsp.Types.MarkupContent.create ~kind:Lsp.Types.MarkupKind.Markdown
             ~value))
 
-let hover ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
+let hover ~state ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
   let result =
     match full with
     | None -> None
@@ -52,7 +55,7 @@ let hover ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
           Printf.printf
             "Nothing at that position. Now trying to use completion.\n";
         match
-          Hover.get_hover_via_completions ~debug ~source ~kind_file ~pos
+          Hover.get_hover_via_completions ~debug ~source ~kind_file ~pos ~state
             ~for_hover:true ~supports_markdown_links ~full:(Some full)
         with
         | None -> None
@@ -63,7 +66,9 @@ let hover ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
           | LModule _ | TopLevelModule _ -> true
           | TypeDefinition _ | Typed _ | Constant _ -> false
         in
-        let uri_loc_opt = References.definition_for_loc_item ~full loc_item in
+        let uri_loc_opt =
+          References.definition_for_loc_item ~state ~full loc_item
+        in
         let skip_zero =
           match uri_loc_opt with
           | None -> false
@@ -77,7 +82,7 @@ let hover ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
             && pos_is_zero loc.loc_end
         in
         if skip_zero then None
-        else Hover.new_hover ~supports_markdown_links ~full loc_item)
+        else Hover.new_hover ~state ~supports_markdown_links ~full loc_item)
   in
   match result with
   | None -> None
@@ -90,12 +95,12 @@ let hover ~source ~kind_file ~pos ~supports_markdown_links ~full ~debug =
                  ~kind:Lsp.Types.MarkupKind.Markdown ~value))
          ())
 
-let signature_help ~source ~kind_file ~pos ~allow_for_constructor_payloads ~full
-    ~debug =
+let signature_help ~state:_ ~source ~kind_file ~pos
+    ~allow_for_constructor_payloads ~full ~debug =
   Signature_help.signature_help ~debug ~source ~kind_file ~pos
     ~allow_for_constructor_payloads ~full
 
-let definition ~full ~pos ~debug =
+let definition ~state ~full ~pos ~debug =
   let location_opt =
     match full with
     | None -> None
@@ -103,7 +108,7 @@ let definition ~full ~pos ~debug =
       match References.get_loc_item ~full ~pos ~debug with
       | None -> None
       | Some loc_item -> (
-        match References.definition_for_loc_item ~full loc_item with
+        match References.definition_for_loc_item ~state ~full loc_item with
         | None -> None
         | Some (uri, loc) when not loc.loc_ghost ->
           let is_interface = full.file.uri |> Uri.is_interface in
@@ -130,7 +135,7 @@ let definition ~full ~pos ~debug =
   in
   location_opt
 
-let type_definition ~full ~pos ~debug =
+let type_definition ~state ~full ~pos ~debug =
   let maybe_location =
     match full with
     | None -> None
@@ -138,7 +143,7 @@ let type_definition ~full ~pos ~debug =
       match References.get_loc_item ~full ~pos ~debug with
       | None -> None
       | Some loc_item -> (
-        match References.type_definition_for_loc_item ~full loc_item with
+        match References.type_definition_for_loc_item ~state ~full loc_item with
         | None -> None
         | Some (uri, loc) ->
           Some
@@ -148,7 +153,7 @@ let type_definition ~full ~pos ~debug =
   in
   maybe_location
 
-let references ~full ~pos ~debug =
+let references ~state ~full ~pos ~debug =
   let all_locs =
     match full with
     | None -> []
@@ -157,7 +162,7 @@ let references ~full ~pos ~debug =
       | None -> []
       | Some loc_item ->
         let all_references =
-          References.all_references_for_loc_item ~full loc_item
+          References.all_references_for_loc_item ~state ~full loc_item
         in
         all_references
         |> List.fold_left
@@ -176,7 +181,7 @@ let references ~full ~pos ~debug =
   in
   all_locs
 
-let rename ~full ~pos ~new_name ~debug =
+let rename ~state ~full ~pos ~new_name ~debug =
   let result =
     match full with
     | None -> None
@@ -185,7 +190,7 @@ let rename ~full ~pos ~new_name ~debug =
       | None -> None
       | Some loc_item ->
         let all_references =
-          References.all_references_for_loc_item ~full loc_item
+          References.all_references_for_loc_item ~state ~full loc_item
         in
         let references_to_toplevel_modules =
           all_references
@@ -261,7 +266,7 @@ type prepare_rename_result = {
   placeholder: string option;
 }
 
-let prepare_rename ~full ~pos ~debug =
+let prepare_rename ~state:_ ~full ~pos ~debug =
   match full with
   | None -> None
   | Some full -> (
@@ -278,7 +283,7 @@ let prepare_rename ~full ~pos ~debug =
       in
       Some {range; placeholder = placeholder_opt})
 
-let format ~source ~kind_file =
+let format ~state:_ ~source ~kind_file =
   let create_range text =
     let lines = text |> String.split_on_char '\n' in
     let lines_len = List.length lines in

--- a/analysis/src/completion_back_end.ml
+++ b/analysis/src/completion_back_end.ml
@@ -27,8 +27,7 @@ let show_constructor {Constructor.cname = {txt}; args; res} =
   | Some typ -> "\n" ^ (typ |> Shared.type_to_string)
 
 (* TODO: local opens *)
-let resolve_opens ?state ~env opens ~package =
-  let state = Option.value state ~default:package.state in
+let resolve_opens ~env opens ~package ~state =
   List.fold_left
     (fun previous path ->
       (* Finding an open, first trying to find it in previoulsly resolved opens *)
@@ -177,9 +176,8 @@ let find_module_in_scope ~env ~module_name ~scope =
   scope |> Scope.iter_modules_after_first_open process_module;
   !result
 
-let rec module_item_to_structure_env ?state ~(env : Query_env.t) ~package
+let rec module_item_to_structure_env ~(env : Query_env.t) ~state ~package
     (item : Module.t) =
-  let state = Option.value state ~default:package.state in
   match item with
   | Module.Structure structure -> Some (env, structure)
   | Module.Constraint (_, module_type) ->
@@ -194,9 +192,8 @@ let rec module_item_to_structure_env ?state ~(env : Query_env.t) ~package
 
 (* Given a declared module, return the env entered into its concrete structure
    and the structure itself. Follows constraints and aliases *)
-let enter_structure_from_declared ?state ~(env : Query_env.t) ~package
+let enter_structure_from_declared ~state ~(env : Query_env.t) ~package
     (declared : Module.t Declared.t) =
-  let state = Option.value state ~default:package.state in
   match module_item_to_structure_env ~state ~env ~package declared.item with
   | Some (env, s) -> Some (Query_env.enter_structure env s, s)
   | None -> None
@@ -231,7 +228,7 @@ let resolve_path_from_stamps ~state ~(env : Query_env.t) ~package ~scope
     (* [""] means completion after `ModuleName.` (trailing dot). *)
     match path with
     | [""] -> (
-      match module_item_to_structure_env ~env ~package declared.item with
+      match module_item_to_structure_env ~state ~env ~package declared.item with
       | Some (env, structure) ->
         Some (Query_env.enter_structure env structure, "")
       | None -> None)
@@ -271,9 +268,8 @@ let resolve_file_module ~state ~module_name ~package =
     let env = Query_env.from_file file in
     Some env
 
-let get_env_with_opens ?state ~scope ~(env : Query_env.t) ~package
+let get_env_with_opens ~scope ~(env : Query_env.t) ~state ~package
     ~(opens : Query_env.t list) ~module_name (path : string list) =
-  let state = Option.value state ~default:package.state in
   (* TODO: handle interleaving of opens and local modules correctly *)
   match
     resolve_path_from_stamps ~state ~env ~scope ~module_name ~path ~package
@@ -292,8 +288,7 @@ let get_env_with_opens ?state ~scope ~(env : Query_env.t) ~package
       | [""] -> Some (env, "")
       | _ -> Resolve_path.resolve_path ~state ~env ~package ~path))
 
-let rec expand_type_expr ?state ~env ~package type_expr =
-  let state = Option.value state ~default:package.state in
+let rec expand_type_expr ~state ~env ~package type_expr =
   match type_expr |> Shared.dig_constructor with
   | Some path -> (
     match References.dig_constructor ~state ~env ~package path with
@@ -303,9 +298,8 @@ let rec expand_type_expr ?state ~env ~package type_expr =
     | Some (_, {docstring; item}) -> Some (docstring, item))
   | None -> None
 
-let kind_to_documentation ?state ~env ~full ~current_docstring name
+let kind_to_documentation ~state ~env ~full ~current_docstring name
     (kind : Completion.kind) =
-  let state = Option.value state ~default:full.package.state in
   let docs_from_kind =
     match kind with
     | ObjLabel _ | Label _ | FileModule _ | Snippet _ | FollowContextPath _ ->
@@ -711,9 +705,8 @@ let get_complementary_completions_for_typed_value ~opens ~all_files ~scope ~env
   in
   local_completions_with_opens @ file_modules
 
-let get_completions_for_path ?state ~debug ~opens ~full ~pos ~exact ~scope
+let get_completions_for_path ~state ~debug ~opens ~full ~pos ~exact ~scope
     ~completion_context ~env path =
-  let state = Option.value state ~default:full.package.state in
   if debug then Printf.printf "Path %s\n" (path |> String.concat ".");
   let all_files = all_files_in_package full.package in
   match path with
@@ -784,10 +777,9 @@ let get_completions_for_path ?state ~debug ~opens ~full ~pos ~exact ~scope
       | None -> []))
 
 (** Completions intended for piping, from a completion path. *)
-let completions_for_pipe_from_completion_path ?state
+let completions_for_pipe_from_completion_path ~state
     ~env_completion_is_made_from ~opens ~pos ~scope ~debug ~prefix ~env
     ~raw_opens ~full completion_path =
-  let state = Option.value state ~default:full.package.state in
   let completion_path_without_current_module =
     Type_utils.remove_current_module_if_needed ~env_completion_is_made_from
       completion_path
@@ -813,9 +805,8 @@ let completions_for_pipe_from_completion_path ?state
   in
   completions
 
-let rec dig_to_record_fields_for_completion ?state ~debug ~package ~opens ~full
+let rec dig_to_record_fields_for_completion ~state ~debug ~package ~opens ~full
     ~pos ~env ~scope path =
-  let state = Option.value state ~default:package.state in
   match
     path
     |> get_completions_for_path ~state ~debug ~completion_context:Type
@@ -870,7 +861,7 @@ let mk_item ?data ?additional_text_edits name ~kind ~detail ~deprecated
     ?deprecated ?data ?additionalTextEdits:additional_text_edits ?sortText:None
     ?insertText:None ?insertTextFormat:None ?filterText:None ()
 
-let completion_to_item ?state
+let completion_to_item ~state
     {
       Completion.name;
       deprecated;
@@ -884,7 +875,6 @@ let completion_to_item ?state
       env;
       additional_text_edits;
     } ~full =
-  let state = Option.value state ~default:full.package.state in
   let item =
     mk_item name ?additional_text_edits
       ?data:(kind_to_data (full.file.uri |> Uri.to_path) kind)
@@ -918,7 +908,7 @@ let completions_get_type_env = function
 
 type get_completions_for_context_path_mode = Regular | Pipe
 
-let completions_get_completion_type ~full completions =
+let completions_get_completion_type ~full ~state completions =
   let first_non_synthetic_completion =
     List.find_opt (fun c -> not c.Completion.synthetic) completions
   in
@@ -927,18 +917,17 @@ let completions_get_completion_type ~full completions =
   | Some {Completion.kind = ObjLabel typ; env}
   | Some {Completion.kind = Field ({typ}, _); env} ->
     typ
-    |> Type_utils.extract_type ~env ~package:full.package
+    |> Type_utils.extract_type ~state ~env ~package:full.package
     |> Option.map (fun (typ, _) -> (typ, env))
   | Some {Completion.kind = Type typ; env} -> (
-    match Type_utils.extract_type_from_resolved_type typ ~env ~full with
+    match Type_utils.extract_type_from_resolved_type typ ~state ~env ~full with
     | None -> None
     | Some extracted_type -> Some (extracted_type, env))
   | Some {Completion.kind = ExtractedType (typ, _); env} -> Some (typ, env)
   | _ -> None
 
-let rec completions_get_completion_type2 ?state ~debug ~full ~opens ~raw_opens
+let rec completions_get_completion_type2 ~state ~debug ~full ~opens ~raw_opens
     ~pos completions =
-  let state = Option.value state ~default:full.package.state in
   let first_non_synthetic_completion =
     List.find_opt (fun c -> not c.Completion.synthetic) completions
   in
@@ -955,16 +944,15 @@ let rec completions_get_completion_type2 ?state ~debug ~full ~opens ~raw_opens
     |> completions_get_completion_type2 ~state ~debug ~full ~opens ~raw_opens
          ~pos
   | Some {Completion.kind = Type typ; env} -> (
-    match Type_utils.extract_type_from_resolved_type typ ~env ~full with
+    match Type_utils.extract_type_from_resolved_type typ ~state ~env ~full with
     | None -> None
     | Some extracted_type -> Some (ExtractedType extracted_type, env))
   | Some {Completion.kind = ExtractedType (typ, _); env} ->
     Some (ExtractedType typ, env)
   | _ -> None
 
-and completions_get_type_env2 ?state ~debug (completions : Completion.t list)
+and completions_get_type_env2 ~state ~debug (completions : Completion.t list)
     ~full ~opens ~raw_opens ~pos =
-  let state = Option.value state ~default:full.package.state in
   let first_non_synthetic_completion =
     List.find_opt (fun c -> not c.Completion.synthetic) completions
   in
@@ -979,9 +967,8 @@ and completions_get_type_env2 ?state ~debug (completions : Completion.t list)
     |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
   | _ -> None
 
-and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
+and get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens ~pos
     ~env ~exact ~scope ?(mode = Regular) context_path =
-  let state = Option.value state ~default:full.package.state in
   let env_completion_is_made_from = env in
   if debug then
     Printf.printf "ContextPath %s\n"
@@ -1015,7 +1002,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
         cp
         |> get_completions_for_context_path ~state ~debug ~full ~opens
              ~raw_opens ~pos ~env ~exact:true ~scope
-        |> completions_get_completion_type ~full
+        |> completions_get_completion_type ~full ~state
       with
       | None -> []
       | Some (typ, env) ->
@@ -1037,7 +1024,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       cp
       |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
            ~pos ~env ~exact:true ~scope
-      |> completions_get_completion_type ~full
+      |> completions_get_completion_type ~state ~full
     with
     | None -> []
     | Some (typ, env) ->
@@ -1052,7 +1039,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       cp
       |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
            ~pos ~env ~exact:true ~scope
-      |> completions_get_completion_type ~full
+      |> completions_get_completion_type ~state ~full
     with
     | Some (Tpromise (env, typ), _env) ->
       [Completion.create "dummy" ~env ~kind:(Completion.Value typ)]
@@ -1139,7 +1126,8 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       in
 
       match
-        Type_utils.extract_function_type ~env ~package ~dig_into:false typ
+        Type_utils.extract_function_type ~env ~state ~package ~dig_into:false
+          typ
       with
       | args, t_ret when args <> [] ->
         let args = process_apply args labels in
@@ -1173,8 +1161,8 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       []
     | Some (typ, env) ->
       let field_completions =
-        Dot_completion_utils.field_completions_for_dot_completion typ ~env
-          ~package ~prefix:field_name ?pos_of_dot ~exact
+        Dot_completion_utils.field_completions_for_dot_completion typ ~state
+          ~env ~package ~prefix:field_name ?pos_of_dot ~exact
       in
       (* Get additional completions acting as if this field completion was actually a pipe completion. *)
       let cp_as_pipe_completion =
@@ -1184,7 +1172,8 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
             context_path =
               (match cp with
               | CPApply (c, args) -> CPApply (c, args @ [Asttypes.Nolabel])
-              | CPId _ when Type_utils.is_function_type ~env ~package typ ->
+              | CPId _ when Type_utils.is_function_type ~state ~env ~package typ
+                ->
                 CPApply (cp, [Asttypes.Nolabel])
               | _ -> cp);
             id = field_name;
@@ -1211,7 +1200,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     with
     | Some (typ, env) -> (
-      match typ |> Type_utils.extract_object_type ~env ~package with
+      match typ |> Type_utils.extract_object_type ~state ~env ~package with
       | Some (env, t_obj) ->
         t_obj |> Type_utils.get_obj_fields
         |> Utils.filter_map (fun (field, typ) ->
@@ -1238,10 +1227,10 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
     | Some (typ, env) -> (
       let env, typ =
         typ
-        |> Type_utils.resolve_type_for_pipe_completion ~env
+        |> Type_utils.resolve_type_for_pipe_completion ~env ~state
              ~package:full.package ~full ~lhs_loc
       in
-      let main_type_id = Type_utils.find_root_type_id ~full ~env typ in
+      let main_type_id = Type_utils.find_root_type_id ~state ~full ~env typ in
       let type_path = Type_utils.path_from_type_expr typ in
       match main_type_id with
       | None ->
@@ -1294,7 +1283,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
             completions_for_pipe_from_completion_path ~state
               ~env_completion_is_made_from ~opens ~pos ~scope ~debug ~prefix
               ~env ~raw_opens ~full completion_path
-            |> Type_utils.filter_pipeable_functions ~env ~full ~synthetic
+            |> Type_utils.filter_pipeable_functions ~env ~state ~full ~synthetic
                  ~target_type_id:main_type_id
             |> List.filter (fun (c : Completion.t) ->
                    (* If we're completing from the current module then we need to care about scope.
@@ -1329,21 +1318,22 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
                    ~env_completion_is_made_from ~opens ~pos ~scope ~debug
                    ~prefix ~env ~raw_opens ~full completion_path)
           |> List.flatten
-          |> Type_utils.filter_pipeable_functions ~synthetic:true ~env ~full
-               ~target_type_id:main_type_id
+          |> Type_utils.filter_pipeable_functions ~synthetic:true ~state ~env
+               ~full ~target_type_id:main_type_id
         in
 
         (* Extra completions can be drawn from the @editor.completeFrom attribute. Here we
            find and add those completions as well. *)
         let extra_completions =
-          Type_utils.get_extra_modules_to_complete_from_for_type ~env ~full typ
+          Type_utils.get_extra_modules_to_complete_from_for_type ~state ~env
+            ~full typ
           |> List.map (fun completion_path ->
                  completions_for_pipe_from_completion_path ~state
                    ~env_completion_is_made_from ~opens ~pos ~scope ~debug
                    ~prefix ~env ~raw_opens ~full completion_path)
           |> List.flatten
-          |> Type_utils.filter_pipeable_functions ~synthetic:true ~env ~full
-               ~target_type_id:main_type_id
+          |> Type_utils.filter_pipeable_functions ~synthetic:true ~state ~env
+               ~full ~target_type_id:main_type_id
         in
         (* Add JSX completion items if we're in a JSX context. *)
         let jsx_completions =
@@ -1356,8 +1346,8 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
         let current_module_completions =
           get_completions_for_path ~state ~debug ~completion_context:Value
             ~exact:false ~opens:[] ~full ~pos ~env:env_at_cursor ~scope [prefix]
-          |> Type_utils.filter_pipeable_functions ~synthetic:true ~env ~full
-               ~target_type_id:main_type_id
+          |> Type_utils.filter_pipeable_functions ~synthetic:true ~state ~env
+               ~full ~target_type_id:main_type_id
         in
         jsx_completions @ pipe_completions @ extra_completions
         @ current_module_completions @ globally_configured_completions))
@@ -1416,7 +1406,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
         Type_utils.path_to_element_props package |> dig_to_type_for_completion
       else
         Completion_jsx.get_jsx_labels ~component_path:path_to_component
-          ~find_type_of_value ~package
+          ~find_type_of_value ~package ~state
     in
     (* We have a heuristic that kicks in when completing empty prop expressions in the middle of a JSX element,
        like <SomeComp firstProp=test second=<com> third=123 />.
@@ -1469,7 +1459,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
       with
       | Some ((TypeExpr typ | ExtractedType (Tfunction {typ})), env) ->
         if Debug.verbose () then print_endline "--> found function type";
-        (typ |> Type_utils.get_args ~full ~env, env)
+        (typ |> Type_utils.get_args ~full ~env ~state, env)
       | _ ->
         if Debug.verbose () then
           print_endline "--> could not find function type";
@@ -1517,7 +1507,7 @@ and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
     with
     | Some (typ, env) -> (
       match
-        typ |> Type_utils.resolve_nested_pattern_path ~env ~full ~nested
+        typ |> Type_utils.resolve_nested_pattern_path ~env ~full ~state ~nested
       with
       | Some (typ, env) ->
         [Completion.create "dummy" ~env ~kind:(kind_from_inner_type typ)]
@@ -1586,7 +1576,7 @@ let print_constructor_args ~mode ~as_snippet args_len =
   else ""
 
 let rec complete_typed_value ?(type_arg_context : type_arg_context option)
-    ~raw_opens ~full ~prefix ~completion_context ~mode
+    ~raw_opens ~full ~state ~prefix ~completion_context ~mode
     (t : Shared_types.completion_type) =
   let empty_case = empty_case ~mode in
   let print_constructor_args = print_constructor_args ~mode in
@@ -1650,7 +1640,9 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
       match t.Types.desc with
       | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> fn_returns_type_t t1
       | Tarrow _ -> (
-        match Type_utils.extract_function_type ~env ~package:full.package t with
+        match
+          Type_utils.extract_function_type ~env ~state ~package:full.package t
+        with
         | ( (Nolabel, {desc = Tconstr (Path.Pident {name = "t"}, _, _)}) :: _,
             {desc = Tconstr (Path.Pident {name = "t"}, _, _)} ) ->
           (* Filter out functions that take type t first. These are often
@@ -1790,15 +1782,16 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
     let inner_type =
       match t with
       | ExtractedType t -> Some (t, None)
-      | TypeExpr t -> t |> Type_utils.extract_type ~env ~package:full.package
+      | TypeExpr t ->
+        t |> Type_utils.extract_type ~env ~package:full.package ~state
     in
     let expanded_completions =
       match inner_type with
       | None -> []
       | Some (inner_type, _typeArgsContext) ->
         inner_type
-        |> complete_typed_value ~raw_opens ~full ~prefix ~completion_context
-             ~mode
+        |> complete_typed_value ~raw_opens ~full ~state ~prefix
+             ~completion_context ~mode
         |> List.map (fun (c : Completion.t) ->
                {
                  c with
@@ -1835,10 +1828,10 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
   | Tresult {env; ok_type; error_type} ->
     if Debug.verbose () then print_endline "[complete_typed_value]--> Tresult";
     let ok_inner_type =
-      ok_type |> Type_utils.extract_type ~env ~package:full.package
+      ok_type |> Type_utils.extract_type ~env ~package:full.package ~state
     in
     let error_inner_type =
-      error_type |> Type_utils.extract_type ~env ~package:full.package
+      error_type |> Type_utils.extract_type ~env ~package:full.package ~state
     in
     let expanded_ok_completions =
       match ok_inner_type with
@@ -1846,7 +1839,7 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
       | Some (inner_type, _) ->
         inner_type
         |> complete_typed_value ~raw_opens ~full ~prefix ~completion_context
-             ~mode
+             ~mode ~state
         |> List.map (fun (c : Completion.t) ->
                {
                  c with
@@ -1864,7 +1857,7 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
       | Some (inner_type, _) ->
         inner_type
         |> complete_typed_value ~raw_opens ~full ~prefix ~completion_context
-             ~mode
+             ~mode ~state
         |> List.map (fun (c : Completion.t) ->
                {
                  c with
@@ -1951,7 +1944,7 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
       | [(Nolabel, arg_typ)] ->
         let var_name =
           Completion_expressions.pretty_print_fn_template_arg_name ~env ~full
-            arg_typ
+            ~state arg_typ
         in
         if as_snippet then "${1:" ^ var_name ^ "}" else var_name
       | _ ->
@@ -1969,7 +1962,7 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
                      let num = !current_unlabelled_index in
                      let var_name =
                        Completion_expressions.pretty_print_fn_template_arg_name
-                         ~current_index:num ~env ~full typ
+                         ~current_index:num ~env ~full ~state typ
                      in
                      if as_snippet then
                        "${" ^ string_of_int num ^ ":" ^ var_name ^ "}"
@@ -1979,7 +1972,9 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
         "(" ^ args_text ^ ")"
     in
     let is_async =
-      match Type_utils.extract_type ~env ~package:full.package return_type with
+      match
+        Type_utils.extract_type ~env ~package:full.package ~state return_type
+      with
       | Some (Tpromise _, _) -> true
       | _ -> false
     in
@@ -1989,7 +1984,7 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
       | [(Nolabel, arg_typ)] ->
         let var_name =
           Completion_expressions.pretty_print_fn_template_arg_name ~env ~full
-            arg_typ
+            ~state arg_typ
         in
         ( (" => " ^ if var_name = "()" then "{}" else var_name),
           " => ${0:" ^ var_name ^ "}" )
@@ -2029,9 +2024,8 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
 
 module String_set = Set.Make (String)
 
-let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
+let rec process_completable ~state ~debug ~full ~scope ~env ~pos ~for_hover
     completable =
-  let state = Option.value state ~default:full.package.state in
   if debug then
     Printf.printf "Completable: %s\n" (Completable.to_string completable);
   let package = full.package in
@@ -2096,6 +2090,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
   | Cjsx (component_path, prefix, idents_seen) ->
     let labels =
       Completion_jsx.get_jsx_labels ~component_path ~find_type_of_value ~package
+        ~state
     in
     let mkLabel_ name typ_string =
       Completion.create name ~kind:(Label typ_string) ~env
@@ -2139,12 +2134,12 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
             ];
         }
     in
-    match typ |> Type_utils.resolve_nested ~env ~full ~nested with
+    match typ |> Type_utils.resolve_nested ~env ~full ~nested ~state with
     | None -> []
     | Some (typ, _env, completion_context, type_arg_context) ->
       typ
       |> complete_typed_value ?type_arg_context ~raw_opens ~mode:Expression
-           ~full ~prefix ~completion_context)
+           ~full ~prefix ~completion_context ~state)
   | CdecoratorPayload (ModuleWithImportAttributes {prefix; nested}) -> (
     let mk_field ~name ~primitive =
       {
@@ -2182,12 +2177,12 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
         (rest, import_attributes_config)
       | _ -> (nested, root_config)
     in
-    match typ |> Type_utils.resolve_nested ~env ~full ~nested with
+    match typ |> Type_utils.resolve_nested ~env ~full ~nested ~state with
     | None -> []
     | Some (typ, _env, completion_context, type_arg_context) ->
       typ
       |> complete_typed_value ?type_arg_context ~raw_opens ~mode:Expression
-           ~full ~prefix ~completion_context)
+           ~full ~prefix ~completion_context ~state)
   | CdecoratorPayload (Module prefix) ->
     let package_json_path =
       Utils.find_package_json (full.package.root_path |> Uri.from_path)
@@ -2315,7 +2310,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
             (typ |> Shared.type_to_string);
 
         typ
-        |> Type_utils.get_args ~full ~env
+        |> Type_utils.get_args ~full ~env ~state
         |> List.filter_map (fun arg ->
                match arg with
                | Shared_types.Completable.Labelled name, a -> Some (name, a)
@@ -2349,10 +2344,11 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
     | Some (typ, env) -> (
       match
         typ
-        |> Type_utils.extract_type ~env ~package:full.package
+        |> Type_utils.extract_type ~env ~package:full.package ~state
         |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
                typ
-               |> Type_utils.resolve_nested ?type_arg_context ~env ~full ~nested)
+               |> Type_utils.resolve_nested ?type_arg_context ~env ~full ~nested
+                    ~state)
       with
       | None -> fallback_or_empty ()
       | Some (typ, _env, completion_context, type_arg_context) ->
@@ -2360,6 +2356,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
           typ
           |> complete_typed_value ?type_arg_context ~raw_opens
                ~mode:(Pattern pattern_mode) ~full ~prefix ~completion_context
+               ~state
         in
         fallback_or_empty ~items ())
     | None -> fallback_or_empty ())
@@ -2395,7 +2392,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
       context_path
       |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
            ~pos ~env ~exact:true ~scope
-      |> completions_get_completion_type ~full
+      |> completions_get_completion_type ~full ~state
     with
     | None ->
       if Debug.verbose () then
@@ -2403,7 +2400,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
           "[process_completable]--> could not get completions for context path";
       regular_completions
     | Some (typ, env) -> (
-      match typ |> Type_utils.resolve_nested ~env ~full ~nested with
+      match typ |> Type_utils.resolve_nested ~env ~full ~nested ~state with
       | None ->
         if Debug.verbose () then
           print_endline
@@ -2416,7 +2413,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
           let items_for_raw_jsx_prop_value =
             typ
             |> complete_typed_value ~raw_opens ~mode:Expression ~full ~prefix
-                 ~completion_context:None
+                 ~completion_context:None ~state
           in
           items_for_raw_jsx_prop_value @ regular_completions)
         else regular_completions
@@ -2437,7 +2434,7 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
         let items =
           typ
           |> complete_typed_value ?type_arg_context ~raw_opens ~mode:Expression
-               ~full ~prefix ~completion_context
+               ~full ~prefix ~completion_context ~state
           |> List.map (fun (c : Completion.t) ->
                  if wrap_insert_text_in_braces then
                    {
@@ -2501,7 +2498,9 @@ let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
     |> List.map (fun (c : Completion.t) ->
            match c.kind with
            | Value typ_expr -> (
-             match typ_expr |> Type_utils.extract_type ~env:c.env ~package with
+             match
+               typ_expr |> Type_utils.extract_type ~env:c.env ~package ~state
+             with
              | Some (Tvariant v, _) ->
                with_exhaustive_item c
                  ~cases:

--- a/analysis/src/completion_back_end.ml
+++ b/analysis/src/completion_back_end.ml
@@ -27,7 +27,8 @@ let show_constructor {Constructor.cname = {txt}; args; res} =
   | Some typ -> "\n" ^ (typ |> Shared.type_to_string)
 
 (* TODO: local opens *)
-let resolve_opens ~env opens ~package =
+let resolve_opens ?state ~env opens ~package =
+  let state = Option.value state ~default:package.state in
   List.fold_left
     (fun previous path ->
       (* Finding an open, first trying to find it in previoulsly resolved opens *)
@@ -37,13 +38,13 @@ let resolve_opens ~env opens ~package =
           match path with
           | [] | [_] -> previous
           | name :: path -> (
-            match Process_cmt.file_for_module ~package name with
+            match Process_cmt.file_for_module ~state ~package name with
             | None ->
               Log.log ("Could not get module " ^ name);
               previous (* TODO: warn? *)
             | Some file -> (
               match
-                Resolve_path.resolve_path ~env:(Query_env.from_file file)
+                Resolve_path.resolve_path ~env:(Query_env.from_file file) ~state
                   ~package ~path
               with
               | None ->
@@ -51,12 +52,12 @@ let resolve_opens ~env opens ~package =
                 previous
               | Some (env, _placeholder) -> previous @ [env])))
         | env :: rest -> (
-          match Resolve_path.resolve_path ~env ~package ~path with
+          match Resolve_path.resolve_path ~state ~env ~package ~path with
           | None -> loop rest
           | Some (env, _placeholder) -> previous @ [env])
       in
       Log.log ("resolving open " ^ path_to_string path);
-      match Resolve_path.resolve_path ~env ~package ~path with
+      match Resolve_path.resolve_path ~state ~env ~package ~path with
       | None ->
         Log.log "Not local";
         loop previous
@@ -176,23 +177,27 @@ let find_module_in_scope ~env ~module_name ~scope =
   scope |> Scope.iter_modules_after_first_open process_module;
   !result
 
-let rec module_item_to_structure_env ~(env : Query_env.t) ~package
+let rec module_item_to_structure_env ?state ~(env : Query_env.t) ~package
     (item : Module.t) =
+  let state = Option.value state ~default:package.state in
   match item with
   | Module.Structure structure -> Some (env, structure)
   | Module.Constraint (_, module_type) ->
-    module_item_to_structure_env ~env ~package module_type
+    module_item_to_structure_env ~state ~env ~package module_type
   | Module.Ident p -> (
-    match Resolve_path.resolve_module_from_compiler_path ~env ~package p with
+    match
+      Resolve_path.resolve_module_from_compiler_path ~state ~env ~package p
+    with
     | Some (env2, Some declared2) ->
-      module_item_to_structure_env ~env:env2 ~package declared2.item
+      module_item_to_structure_env ~state ~env:env2 ~package declared2.item
     | _ -> None)
 
 (* Given a declared module, return the env entered into its concrete structure
    and the structure itself. Follows constraints and aliases *)
-let enter_structure_from_declared ~(env : Query_env.t) ~package
+let enter_structure_from_declared ?state ~(env : Query_env.t) ~package
     (declared : Module.t Declared.t) =
-  match module_item_to_structure_env ~env ~package declared.item with
+  let state = Option.value state ~default:package.state in
+  match module_item_to_structure_env ~state ~env ~package declared.item with
   | Some (env, s) -> Some (Query_env.enter_structure env s, s)
   | None -> None
 
@@ -216,8 +221,8 @@ let completions_from_structure_items ~(env : Query_env.t)
              (Completion.create ~env ~docstring:it.docstring
                 ~kind:(Completion.Type t) it.name))
 
-let resolve_path_from_stamps ~(env : Query_env.t) ~package ~scope ~module_name
-    ~path =
+let resolve_path_from_stamps ~state ~(env : Query_env.t) ~package ~scope
+    ~module_name ~path =
   (* Log.log("Finding from stamps " ++ name); *)
   match find_module_in_scope ~env ~module_name ~scope with
   | None -> None
@@ -237,63 +242,70 @@ let resolve_path_from_stamps ~(env : Query_env.t) ~package ~scope ~module_name
         match res with
         | `Local (env, name) -> Some (env, name)
         | `Global (module_name, full_path) -> (
-          match Process_cmt.file_for_module ~package module_name with
+          match Process_cmt.file_for_module ~state ~package module_name with
           | None -> None
           | Some file ->
-            Resolve_path.resolve_path ~env:(Query_env.from_file file)
+            Resolve_path.resolve_path ~env:(Query_env.from_file file) ~state
               ~path:full_path ~package))))
 
-let resolve_module_with_opens ~opens ~package ~module_name =
+let resolve_module_with_opens ~state ~opens ~package ~module_name =
   let rec loop opens =
     match opens with
     | (env : Query_env.t) :: rest -> (
       Log.log ("Looking for env in " ^ Uri.to_string env.file.uri);
-      match Resolve_path.resolve_path ~env ~package ~path:[module_name; ""] with
+      match
+        Resolve_path.resolve_path ~state ~env ~package ~path:[module_name; ""]
+      with
       | Some (env, _) -> Some env
       | None -> loop rest)
     | [] -> None
   in
   loop opens
 
-let resolve_file_module ~module_name ~package =
+let resolve_file_module ~state ~module_name ~package =
   Log.log ("Getting module " ^ module_name);
-  match Process_cmt.file_for_module ~package module_name with
+  match Process_cmt.file_for_module ~state ~package module_name with
   | None -> None
   | Some file ->
     Log.log "got it";
     let env = Query_env.from_file file in
     Some env
 
-let get_env_with_opens ~scope ~(env : Query_env.t) ~package
+let get_env_with_opens ?state ~scope ~(env : Query_env.t) ~package
     ~(opens : Query_env.t list) ~module_name (path : string list) =
+  let state = Option.value state ~default:package.state in
   (* TODO: handle interleaving of opens and local modules correctly *)
-  match resolve_path_from_stamps ~env ~scope ~module_name ~path ~package with
+  match
+    resolve_path_from_stamps ~state ~env ~scope ~module_name ~path ~package
+  with
   | Some x -> Some x
   | None -> (
     let env_opt =
-      match resolve_module_with_opens ~opens ~package ~module_name with
+      match resolve_module_with_opens ~state ~opens ~package ~module_name with
       | Some env_opens -> Some env_opens
-      | None -> resolve_file_module ~module_name ~package
+      | None -> resolve_file_module ~state ~module_name ~package
     in
     match env_opt with
     | None -> None
     | Some env -> (
       match path with
       | [""] -> Some (env, "")
-      | _ -> Resolve_path.resolve_path ~env ~package ~path))
+      | _ -> Resolve_path.resolve_path ~state ~env ~package ~path))
 
-let rec expand_type_expr ~env ~package type_expr =
+let rec expand_type_expr ?state ~env ~package type_expr =
+  let state = Option.value state ~default:package.state in
   match type_expr |> Shared.dig_constructor with
   | Some path -> (
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~state ~env ~package path with
     | None -> None
     | Some (env, {item = {decl = {type_manifest = Some t}}}) ->
-      expand_type_expr ~env ~package t
+      expand_type_expr ~state ~env ~package t
     | Some (_, {docstring; item}) -> Some (docstring, item))
   | None -> None
 
-let kind_to_documentation ~env ~full ~current_docstring name
+let kind_to_documentation ?state ~env ~full ~current_docstring name
     (kind : Completion.kind) =
+  let state = Option.value state ~default:full.package.state in
   let docs_from_kind =
     match kind with
     | ObjLabel _ | Label _ | FileModule _ | Snippet _ | FollowContextPath _ ->
@@ -302,7 +314,7 @@ let kind_to_documentation ~env ~full ~current_docstring name
     | Type {decl; name} ->
       [decl |> Shared.decl_to_string name |> Markdown.code_block]
     | Value typ -> (
-      match expand_type_expr ~env ~package:full.package typ with
+      match expand_type_expr ~state ~env ~package:full.package typ with
       | None -> []
       | Some (docstrings, {decl; name; kind}) ->
         docstrings
@@ -699,8 +711,9 @@ let get_complementary_completions_for_typed_value ~opens ~all_files ~scope ~env
   in
   local_completions_with_opens @ file_modules
 
-let get_completions_for_path ~debug ~opens ~full ~pos ~exact ~scope
+let get_completions_for_path ?state ~debug ~opens ~full ~pos ~exact ~scope
     ~completion_context ~env path =
+  let state = Option.value state ~default:full.package.state in
   if debug then Printf.printf "Path %s\n" (path |> String.concat ".");
   let all_files = all_files_in_package full.package in
   match path with
@@ -742,15 +755,15 @@ let get_completions_for_path ~debug ~opens ~full ~pos ~exact ~scope
       | Some (declared : Module.t Declared.t) when declared.is_exported = false
         -> (
         match
-          enter_structure_from_declared ~env:env_file ~package:full.package
-            declared
+          enter_structure_from_declared ~state ~env:env_file
+            ~package:full.package declared
         with
         | None -> []
         | Some (env_in_module, structure) ->
           completions_from_structure_items ~env:env_in_module structure)
       | _ -> (
         match
-          get_env_with_opens ~scope ~env ~package:full.package ~opens
+          get_env_with_opens ~state ~scope ~env ~package:full.package ~opens
             ~module_name path
         with
         | Some (env, prefix) ->
@@ -761,8 +774,8 @@ let get_completions_for_path ~debug ~opens ~full ~pos ~exact ~scope
         | None -> []))
     | _ -> (
       match
-        get_env_with_opens ~scope ~env ~package:full.package ~opens ~module_name
-          path
+        get_env_with_opens ~state ~scope ~env ~package:full.package ~opens
+          ~module_name path
       with
       | Some (env, prefix) ->
         Log.log "Got the env";
@@ -771,8 +784,10 @@ let get_completions_for_path ~debug ~opens ~full ~pos ~exact ~scope
       | None -> []))
 
 (** Completions intended for piping, from a completion path. *)
-let completions_for_pipe_from_completion_path ~env_completion_is_made_from
-    ~opens ~pos ~scope ~debug ~prefix ~env ~raw_opens ~full completion_path =
+let completions_for_pipe_from_completion_path ?state
+    ~env_completion_is_made_from ~opens ~pos ~scope ~debug ~prefix ~env
+    ~raw_opens ~full completion_path =
+  let state = Option.value state ~default:full.package.state in
   let completion_path_without_current_module =
     Type_utils.remove_current_module_if_needed ~env_completion_is_made_from
       completion_path
@@ -788,8 +803,8 @@ let completions_for_pipe_from_completion_path ~env_completion_is_made_from
   in
   let completions =
     completion_path @ [prefix]
-    |> get_completions_for_path ~debug ~completion_context:Value ~exact:false
-         ~opens ~full ~pos ~env ~scope
+    |> get_completions_for_path ~state ~debug ~completion_context:Value
+         ~exact:false ~opens ~full ~pos ~env ~scope
   in
   let completions =
     completions
@@ -798,12 +813,13 @@ let completions_for_pipe_from_completion_path ~env_completion_is_made_from
   in
   completions
 
-let rec dig_to_record_fields_for_completion ~debug ~package ~opens ~full ~pos
-    ~env ~scope path =
+let rec dig_to_record_fields_for_completion ?state ~debug ~package ~opens ~full
+    ~pos ~env ~scope path =
+  let state = Option.value state ~default:package.state in
   match
     path
-    |> get_completions_for_path ~debug ~completion_context:Type ~exact:true
-         ~opens ~full ~pos ~env ~scope
+    |> get_completions_for_path ~state ~debug ~completion_context:Type
+         ~exact:true ~opens ~full ~pos ~env ~scope
   with
   | {kind = Type {kind = Abstract (Some (p, _))}} :: _ ->
     (* This case happens when what we're looking for is a type alias.
@@ -811,8 +827,8 @@ let rec dig_to_record_fields_for_completion ~debug ~package ~opens ~full ~pos
        ReactDOM.domProps is an alias for JsxEvent.t. *)
     let path_rev = p |> Utils.expand_path in
     path_rev |> List.rev
-    |> dig_to_record_fields_for_completion ~debug ~package ~opens ~full ~pos
-         ~env ~scope
+    |> dig_to_record_fields_for_completion ~state ~debug ~package ~opens ~full
+         ~pos ~env ~scope
   | {kind = Type {kind = Record fields}} :: _ -> Some fields
   | _ -> None
 
@@ -854,7 +870,7 @@ let mk_item ?data ?additional_text_edits name ~kind ~detail ~deprecated
     ?deprecated ?data ?additionalTextEdits:additional_text_edits ?sortText:None
     ?insertText:None ?insertTextFormat:None ?filterText:None ()
 
-let completion_to_item
+let completion_to_item ?state
     {
       Completion.name;
       deprecated;
@@ -868,6 +884,7 @@ let completion_to_item
       env;
       additional_text_edits;
     } ~full =
+  let state = Option.value state ~default:full.package.state in
   let item =
     mk_item name ?additional_text_edits
       ?data:(kind_to_data (full.file.uri |> Uri.to_path) kind)
@@ -879,8 +896,8 @@ let completion_to_item
         | Some detail -> detail)
       ~docstring:
         (match
-           kind_to_documentation ~current_docstring:docstring ~full ~env name
-             kind
+           kind_to_documentation ~state ~current_docstring:docstring ~full ~env
+             name kind
          with
         | "" -> []
         | docstring -> [docstring])
@@ -919,8 +936,9 @@ let completions_get_completion_type ~full completions =
   | Some {Completion.kind = ExtractedType (typ, _); env} -> Some (typ, env)
   | _ -> None
 
-let rec completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
-    completions =
+let rec completions_get_completion_type2 ?state ~debug ~full ~opens ~raw_opens
+    ~pos completions =
+  let state = Option.value state ~default:full.package.state in
   let first_non_synthetic_completion =
     List.find_opt (fun c -> not c.Completion.synthetic) completions
   in
@@ -932,9 +950,10 @@ let rec completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
     Some (TypeExpr typ, env)
   | Some {Completion.kind = FollowContextPath (ctx_path, scope); env} ->
     ctx_path
-    |> get_completions_for_context_path ~debug ~full ~env ~exact:true ~opens
-         ~raw_opens ~pos ~scope
-    |> completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
+    |> get_completions_for_context_path ~state ~debug ~full ~env ~exact:true
+         ~opens ~raw_opens ~pos ~scope
+    |> completions_get_completion_type2 ~state ~debug ~full ~opens ~raw_opens
+         ~pos
   | Some {Completion.kind = Type typ; env} -> (
     match Type_utils.extract_type_from_resolved_type typ ~env ~full with
     | None -> None
@@ -943,8 +962,9 @@ let rec completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
     Some (ExtractedType typ, env)
   | _ -> None
 
-and completions_get_type_env2 ~debug (completions : Completion.t list) ~full
-    ~opens ~raw_opens ~pos =
+and completions_get_type_env2 ?state ~debug (completions : Completion.t list)
+    ~full ~opens ~raw_opens ~pos =
+  let state = Option.value state ~default:full.package.state in
   let first_non_synthetic_completion =
     List.find_opt (fun c -> not c.Completion.synthetic) completions
   in
@@ -954,13 +974,14 @@ and completions_get_type_env2 ~debug (completions : Completion.t list) ~full
   | Some {Completion.kind = Field ({typ}, _); env} -> Some (typ, env)
   | Some {Completion.kind = FollowContextPath (ctx_path, scope); env} ->
     ctx_path
-    |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
-         ~exact:true ~scope
-    |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+    |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+         ~pos ~env ~exact:true ~scope
+    |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
   | _ -> None
 
-and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
-    ~exact ~scope ?(mode = Regular) context_path =
+and get_completions_for_context_path ?state ~debug ~full ~opens ~raw_opens ~pos
+    ~env ~exact ~scope ?(mode = Regular) context_path =
+  let state = Option.value state ~default:full.package.state in
   let env_completion_is_made_from = env in
   if debug then
     Printf.printf "ContextPath %s\n"
@@ -992,8 +1013,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     | Regular -> (
       match
         cp
-        |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-             ~env ~exact:true ~scope
+        |> get_completions_for_context_path ~state ~debug ~full ~opens
+             ~raw_opens ~pos ~env ~exact:true ~scope
         |> completions_get_completion_type ~full
       with
       | None -> []
@@ -1014,8 +1035,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CPOption";
     match
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
       |> completions_get_completion_type ~full
     with
     | None -> []
@@ -1029,8 +1050,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CPAwait";
     match
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
       |> completions_get_completion_type ~full
     with
     | Some (Tpromise (env, typ), _env) ->
@@ -1056,7 +1077,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     let use_tvar_lookup = !Cfg.in_incremental_typechecking_mode in
     let by_path =
       path
-      |> get_completions_for_path ~debug ~opens ~full ~pos ~exact
+      |> get_completions_for_path ~state ~debug ~opens ~full ~pos ~exact
            ~completion_context ~env ~scope
     in
     let has_tvars =
@@ -1079,9 +1100,10 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CPApply";
     match
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
-      |> completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
+      |> completions_get_completion_type2 ~state ~debug ~full ~opens ~raw_opens
+           ~pos
     with
     | Some ((TypeExpr typ | ExtractedType (Tfunction {typ})), env) -> (
       let rec reconstruct_function_type args t_ret =
@@ -1130,18 +1152,18 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CPField: M.field";
     (* M.field *)
     path @ [field_name]
-    |> get_completions_for_path ~debug ~opens ~full ~pos ~exact
+    |> get_completions_for_path ~state ~debug ~opens ~full ~pos ~exact
          ~completion_context:Field ~env ~scope
   | CPField {context_path = cp; field_name; pos_of_dot; expr_loc; in_jsx} -> (
     if Debug.verbose () then print_endline "[dot_completion]--> Triggered";
     let completions_from_ctx_path =
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
     in
     let main_type_completion_env =
       completions_from_ctx_path
-      |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+      |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     in
     match main_type_completion_env with
     | None ->
@@ -1172,8 +1194,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
       in
       let pipe_completions =
         cp_as_pipe_completion
-        |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-             ~env:env_completion_is_made_from ~exact ~scope
+        |> get_completions_for_context_path ~state ~debug ~full ~opens
+             ~raw_opens ~pos ~env:env_completion_is_made_from ~exact ~scope
         |> List.filter_map (fun c ->
                Type_utils.transform_completion_to_pipe_completion
                  ~synthetic:true ~env ?pos_of_dot c)
@@ -1184,9 +1206,9 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CPObj";
     match
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
-      |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
+      |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     with
     | Some (typ, env) -> (
       match typ |> Type_utils.extract_object_type ~env ~package with
@@ -1205,9 +1227,9 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     let env_at_cursor = env in
     match
       cp
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope ~mode:Pipe
-      |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope ~mode:Pipe
+      |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     with
     | None ->
       if Debug.verbose () then
@@ -1269,7 +1291,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
           match completion_path with
           | None -> []
           | Some (is_from_current_module, completion_path) ->
-            completions_for_pipe_from_completion_path
+            completions_for_pipe_from_completion_path ~state
               ~env_completion_is_made_from ~opens ~pos ~scope ~debug ~prefix
               ~env ~raw_opens ~full completion_path
             |> Type_utils.filter_pipeable_functions ~env ~full ~synthetic
@@ -1303,7 +1325,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
         let globally_configured_completions =
           globally_configured_completions_for_type
           |> List.map (fun completion_path ->
-                 completions_for_pipe_from_completion_path
+                 completions_for_pipe_from_completion_path ~state
                    ~env_completion_is_made_from ~opens ~pos ~scope ~debug
                    ~prefix ~env ~raw_opens ~full completion_path)
           |> List.flatten
@@ -1316,7 +1338,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
         let extra_completions =
           Type_utils.get_extra_modules_to_complete_from_for_type ~env ~full typ
           |> List.map (fun completion_path ->
-                 completions_for_pipe_from_completion_path
+                 completions_for_pipe_from_completion_path ~state
                    ~env_completion_is_made_from ~opens ~pos ~scope ~debug
                    ~prefix ~env ~raw_opens ~full completion_path)
           |> List.flatten
@@ -1332,8 +1354,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
         in
         (* Add completions from the current module. *)
         let current_module_completions =
-          get_completions_for_path ~debug ~completion_context:Value ~exact:false
-            ~opens:[] ~full ~pos ~env:env_at_cursor ~scope [prefix]
+          get_completions_for_path ~state ~debug ~completion_context:Value
+            ~exact:false ~opens:[] ~full ~pos ~env:env_at_cursor ~scope [prefix]
           |> Type_utils.filter_pipeable_functions ~synthetic:true ~env ~full
                ~target_type_id:main_type_id
         in
@@ -1346,8 +1368,8 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
       ctx_paths
       |> List.map (fun context_path ->
              context_path
-             |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens
-                  ~pos ~env ~exact:true ~scope)
+             |> get_completions_for_context_path ~state ~debug ~full ~opens
+                  ~raw_opens ~pos ~env ~exact:true ~scope)
       |> List.filter_map (fun completion_items ->
              match completion_items with
              | {Completion.kind = Value typ} :: _ -> Some typ
@@ -1363,9 +1385,9 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     if Debug.verbose () then print_endline "[ctx_path]--> CJsxPropValue";
     let find_type_of_value path =
       path
-      |> get_completions_for_path ~debug ~completion_context:Value ~exact:true
-           ~opens ~full ~pos ~env ~scope
-      |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_path ~state ~debug ~completion_context:Value
+           ~exact:true ~opens ~full ~pos ~env ~scope
+      |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     in
     let lowercase_component =
       match path_to_component with
@@ -1378,7 +1400,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
         let rec dig_to_type_for_completion path =
           match
             path
-            |> get_completions_for_path ~debug ~completion_context:Type
+            |> get_completions_for_path ~state ~debug ~completion_context:Type
                  ~exact:true ~opens ~full ~pos ~env ~scope
           with
           | {kind = Type {kind = Abstract (Some (p, _))}} :: _ ->
@@ -1440,9 +1462,10 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     let labels, env =
       match
         function_context_path
-        |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-             ~env ~exact:true ~scope
-        |> completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
+        |> get_completions_for_context_path ~state ~debug ~full ~opens
+             ~raw_opens ~pos ~env ~exact:true ~scope
+        |> completions_get_completion_type2 ~state ~debug ~full ~opens
+             ~raw_opens ~pos
       with
       | Some ((TypeExpr typ | ExtractedType (Tfunction {typ})), env) ->
         if Debug.verbose () then print_endline "--> found function type";
@@ -1487,9 +1510,10 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     (* TODO(env-stuff) Get rid of innerType etc *)
     match
       root_ctx_path
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
-      |> completions_get_completion_type2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
+      |> completions_get_completion_type2 ~state ~debug ~full ~opens ~raw_opens
+           ~pos
     with
     | Some (typ, env) -> (
       match
@@ -1505,7 +1529,7 @@ and get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
     | None -> []
     | Some typ_expr -> [Completion.create "dummy" ~env ~kind:(Value typ_expr)])
 
-let get_opens ~debug ~raw_opens ~package ~env =
+let get_opens ~state ~debug ~raw_opens ~package ~env =
   if debug && raw_opens <> [] then
     Printf.printf "%s\n"
       ("Raw opens: "
@@ -1519,7 +1543,7 @@ let get_opens ~debug ~raw_opens ~package ~env =
       ^ String.concat " "
           (package_opens |> List.map (fun p -> p |> path_to_string)));
   let resolved_opens =
-    resolve_opens ~env (List.rev (raw_opens @ package_opens)) ~package
+    resolve_opens ~state ~env (List.rev (raw_opens @ package_opens)) ~package
   in
   if debug && resolved_opens <> [] then
     Printf.printf "%s\n"
@@ -2005,26 +2029,27 @@ let rec complete_typed_value ?(type_arg_context : type_arg_context option)
 
 module String_set = Set.Make (String)
 
-let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
-    =
+let rec process_completable ?state ~debug ~full ~scope ~env ~pos ~for_hover
+    completable =
+  let state = Option.value state ~default:full.package.state in
   if debug then
     Printf.printf "Completable: %s\n" (Completable.to_string completable);
   let package = full.package in
   let raw_opens = Scope.get_raw_opens scope in
-  let opens = get_opens ~debug ~raw_opens ~package ~env in
+  let opens = get_opens ~state ~debug ~raw_opens ~package ~env in
   let all_files = all_files_in_package package in
   let find_type_of_value path =
     path
-    |> get_completions_for_path ~debug ~completion_context:Value ~exact:true
-         ~opens ~full ~pos ~env ~scope
-    |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+    |> get_completions_for_path ~state ~debug ~completion_context:Value
+         ~exact:true ~opens ~full ~pos ~env ~scope
+    |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
   in
   match completable with
   | Cnone -> []
   | Cpath context_path ->
     context_path
-    |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos ~env
-         ~exact:for_hover ~scope
+    |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+         ~pos ~env ~exact:for_hover ~scope
   | Cjsx ([id], prefix, idents_seen) when String.uncapitalize_ascii id = id -> (
     (* Lowercase JSX tag means builtin *)
     let mk_label (name, typ_string) =
@@ -2042,8 +2067,8 @@ let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
     let from_element_props =
       match
         path_to_element_props
-        |> dig_to_record_fields_for_completion ~debug ~package ~opens ~full ~pos
-             ~env ~scope
+        |> dig_to_record_fields_for_completion ~state ~debug ~package ~opens
+             ~full ~pos ~env ~scope
       with
       | None -> None
       | Some fields ->
@@ -2280,9 +2305,9 @@ let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
     let labels =
       match
         cp
-        |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-             ~env ~exact:true ~scope
-        |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+        |> get_completions_for_context_path ~state ~debug ~full ~opens
+             ~raw_opens ~pos ~env ~exact:true ~scope
+        |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
       with
       | Some (typ, _env) ->
         if debug then
@@ -2310,15 +2335,16 @@ let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
     let fallback_or_empty ?items () =
       match (fallback, items) with
       | Some fallback, (None | Some []) ->
-        fallback |> process_completable ~debug ~full ~scope ~env ~pos ~for_hover
+        fallback
+        |> process_completable ~state ~debug ~full ~scope ~env ~pos ~for_hover
       | _, Some items -> items
       | None, None -> []
     in
     match
       context_path
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
-      |> completions_get_type_env2 ~debug ~full ~opens ~raw_opens ~pos
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
+      |> completions_get_type_env2 ~state ~debug ~full ~opens ~raw_opens ~pos
     with
     | Some (typ, env) -> (
       match
@@ -2367,8 +2393,8 @@ let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
     in
     match
       context_path
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:true ~scope
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:true ~scope
       |> completions_get_completion_type ~full
     with
     | None ->
@@ -2468,8 +2494,8 @@ let rec process_completable ~debug ~full ~scope ~env ~pos ~for_hover completable
     in
     let completions_for_context_path =
       context_path
-      |> get_completions_for_context_path ~debug ~full ~opens ~raw_opens ~pos
-           ~env ~exact:for_hover ~scope
+      |> get_completions_for_context_path ~state ~debug ~full ~opens ~raw_opens
+           ~pos ~env ~exact:for_hover ~scope
     in
     completions_for_context_path
     |> List.map (fun (c : Completion.t) ->

--- a/analysis/src/completion_expressions.ml
+++ b/analysis/src/completion_expressions.ml
@@ -239,7 +239,7 @@ and traverse_expr_tuple_items tuple_items ~next_expr_path
     else None
   | v, _ -> v
 
-let pretty_print_fn_template_arg_name ?current_index ~env ~full
+let pretty_print_fn_template_arg_name ?current_index ~env ~state ~full
     (arg_typ : Types.type_expr) =
   let index_text =
     match current_index with
@@ -249,7 +249,7 @@ let pretty_print_fn_template_arg_name ?current_index ~env ~full
   let default_var_name = "v" ^ index_text in
   let arg_typ, suffix, _env =
     Type_utils.dig_to_relevant_template_name_type ~env ~package:full.package
-      arg_typ
+      ~state arg_typ
   in
   match arg_typ |> Type_utils.path_from_type_expr with
   | None -> default_var_name

--- a/analysis/src/completion_jsx.ml
+++ b/analysis/src/completion_jsx.ml
@@ -207,11 +207,11 @@ let html_elements =
     ("wbr", "Represents a line break opportunity.", false);
   ]
 
-let get_jsx_labels ~component_path ~find_type_of_value ~package =
+let get_jsx_labels ~component_path ~find_type_of_value ~package ~state =
   match component_path @ ["make"] |> find_type_of_value with
   | Some (typ, make_env) ->
     let get_fields ~path ~type_args =
-      match References.dig_constructor ~env:make_env ~package path with
+      match References.dig_constructor ~env:make_env ~state ~package path with
       | Some
           ( env,
             {
@@ -285,10 +285,10 @@ type jsx_props = {
   children_start: (int * int) option;
 }
 
-(** 
+(**
 <div muted= />
 
-This is a special case for JSX props, where the above code is parsed 
+This is a special case for JSX props, where the above code is parsed
 as <div muted=//, a regexp literal. We leverage that fact to trigger completion
 for the JSX prop value.
 

--- a/analysis/src/completions.ml
+++ b/analysis/src/completions.ml
@@ -1,5 +1,5 @@
 let get_completions ~debug ~source ~kind_file ~pos ~for_hover
-    ~(full : Shared_types.full option) =
+    ~(full : Shared_types.full option) ~state =
   match source with
   | "" -> None
   | source -> (
@@ -24,7 +24,7 @@ let get_completions ~debug ~source ~kind_file ~pos ~for_hover
         let env = Shared_types.Query_env.from_file full.file in
         let completables =
           completable
-          |> Completion_back_end.process_completable ~debug ~full ~pos ~scope
-               ~env ~for_hover
+          |> Completion_back_end.process_completable ~debug ~full ~state ~pos
+               ~scope ~env ~for_hover
         in
         Some (completables, full, scope)))

--- a/analysis/src/create_interface.ml
+++ b/analysis/src/create_interface.ml
@@ -319,11 +319,11 @@ let print_signature ~extractor ~signature =
   process_signature ~indent:"" signature;
   Buffer.contents buf
 
-let command ~path ~cmi_file =
+let command ~state ~path ~cmi_file =
   match Shared.try_read_cmi cmi_file with
   | Some cmi_info ->
     (* For reading the config *)
-    let _ = Cmt.load_full_cmt_from_path ~path in
+    ignore (Cmt.load_full_cmt_from_path ~state ~path);
     let extractor = Source_file_extractor.create ~path in
     print_signature ~extractor ~signature:cmi_info.cmi_sign
   | None -> ""

--- a/analysis/src/dot_completion_utils.ml
+++ b/analysis/src/dot_completion_utils.ml
@@ -8,9 +8,9 @@ let filter_record_fields ~env ~record_as_string ~prefix ~exact fields =
                 ~kind:(Shared_types.Completion.Field (field, record_as_string)))
          else None)
 
-let field_completions_for_dot_completion ?pos_of_dot typ ~env ~package ~prefix
-    ~exact =
-  let as_object = typ |> Type_utils.extract_object_type ~env ~package in
+let field_completions_for_dot_completion ?pos_of_dot typ ~env ~state ~package
+    ~prefix ~exact =
+  let as_object = typ |> Type_utils.extract_object_type ~env ~state ~package in
   match as_object with
   | Some (obj_env, obj) ->
     (* Handle obj completion via dot *)
@@ -33,7 +33,7 @@ let field_completions_for_dot_completion ?pos_of_dot typ ~env ~package ~prefix
                            pos_of_dot)))
            else None)
   | None -> (
-    match typ |> Type_utils.extract_record_type ~env ~package with
+    match typ |> Type_utils.extract_record_type ~env ~state ~package with
     | Some (env, fields, typ_decl) ->
       fields
       |> filter_record_fields ~env ~prefix ~exact

--- a/analysis/src/hint.ml
+++ b/analysis/src/hint.ml
@@ -4,7 +4,7 @@ type inlay_hint_kind = Type
 let inlay_kind_to_lsp_inlay_hint = function
   | Type -> Lsp.Types.InlayHintKind.Type
 
-let loc_item_to_type_hint ~full:{file; package} loc_item =
+let loc_item_to_type_hint ~state ~full:{file; package} loc_item =
   match loc_item.loc_type with
   | Constant t ->
     Some
@@ -22,7 +22,7 @@ let loc_item_to_type_hint ~full:{file; package} loc_item =
       |> Str.global_replace (Str.regexp "[\r\n\t]") ""
     in
     Some
-      (match References.defined_for_loc ~file ~package loc_kind with
+      (match References.defined_for_loc ~state ~file ~package loc_kind with
       | None -> from_type t
       | Some (_, res) -> (
         match res with
@@ -31,7 +31,7 @@ let loc_item_to_type_hint ~full:{file; package} loc_item =
         | `Field -> from_type t))
   | _ -> None
 
-let inlay ~source ~kind_file ~pos ~max_length ~full ~debug =
+let inlay ~source ~kind_file ~pos ~max_length ~full ~state ~debug =
   let maxlen = try Some (int_of_string max_length) with Failure _ -> None in
   let hints = ref [] in
   let start_line, end_line = pos in
@@ -95,7 +95,7 @@ let inlay ~source ~kind_file ~pos ~max_length ~full ~debug =
                  Lsp.Types.Position.create ~line:range.start.line
                    ~character:range.end_.character
                in
-               match loc_item_to_type_hint loc_item ~full with
+               match loc_item_to_type_hint loc_item ~state ~full with
                | Some label -> (
                  let kind = inlay_kind_to_lsp_inlay_hint hint_kind in
                  let label = ": " ^ label in

--- a/analysis/src/hover.ml
+++ b/analysis/src/hover.ml
@@ -34,7 +34,7 @@ let show_module_top_level ~docstring ~is_type ~name
   in
   Some (doc ^ full)
 
-let rec show_module ~docstring ~(file : File.t) ~package ~name
+let rec show_module ~state ~docstring ~(file : File.t) ~package ~name
     (declared : Module.t Declared.t option) =
   match declared with
   | None ->
@@ -48,13 +48,15 @@ let rec show_module ~docstring ~(file : File.t) ~package ~name
     show_module_top_level ~docstring ~is_type ~name items
   | Some ({item = Constraint (_moduleItem, module_type_item)} as declared) ->
     (* show the interface *)
-    show_module ~docstring ~file ~name ~package
+    show_module ~state ~docstring ~file ~name ~package
       (Some {declared with item = module_type_item})
   | Some ({item = Ident path} as declared) -> (
-    match References.resolve_module_reference ~file ~package declared with
+    match
+      References.resolve_module_reference ~state ~file ~package declared
+    with
     | None -> Some ("Unable to resolve module reference " ^ Path.name path)
-    | Some (_, declared) -> show_module ~docstring ~file ~name ~package declared
-    )
+    | Some (_, declared) ->
+      show_module ~state ~docstring ~file ~name ~package declared)
 
 type extracted_type = {
   name: string;
@@ -64,7 +66,8 @@ type extracted_type = {
   loc: Warnings.loc;
 }
 
-let find_relevant_types_from_type ~file ~package typ =
+let find_relevant_types_from_type ?state ~file ~package typ =
+  let state = Option.value state ~default:package.state in
   (* Expand definitions of types mentioned in typ.
      If typ itself is a record or variant, search its body *)
   let env = Query_env.from_file file in
@@ -74,7 +77,7 @@ let find_relevant_types_from_type ~file ~package typ =
       let label_declarations_types lds =
         lds |> List.map (fun (ld : Types.label_declaration) -> ld.ld_type)
       in
-      match References.dig_constructor ~env ~package path with
+      match References.dig_constructor ~state ~env ~package path with
       | None -> (env, [typ])
       | Some (env1, {item = {decl}}) -> (
         match decl.type_kind with
@@ -99,7 +102,7 @@ let find_relevant_types_from_type ~file ~package typ =
     | None -> (env, [typ])
   in
   let from_constructor_path ~env path =
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~state ~env ~package path with
     | None -> None
     | Some (env, {name = {txt}; extent_loc; item = {decl}}) ->
       if Utils.is_uncurried_internal path then None
@@ -108,8 +111,9 @@ let find_relevant_types_from_type ~file ~package typ =
   let constructors = Shared.find_type_constructors types_to_search in
   constructors |> List.filter_map (from_constructor_path ~env:env_to_search)
 
-let expand_types ~file ~package ~supports_markdown_links typ =
-  match find_relevant_types_from_type typ ~file ~package with
+let expand_types ?state ~file ~package ~supports_markdown_links typ =
+  let state = Option.value state ~default:package.state in
+  match find_relevant_types_from_type ~state typ ~file ~package with
   | {decl; path} :: _
     when Res_parsetree_viewer.has_inline_record_definition_attribute
            decl.type_attributes ->
@@ -158,10 +162,11 @@ let expand_types ~file ~package ~supports_markdown_links typ =
       `Default )
 
 (* Produces a hover with relevant types expanded in the main type being hovered. *)
-let hover_with_expanded_types ~file ~package ~supports_markdown_links ?docstring
-    ?constructor typ =
+let hover_with_expanded_types ?state ~file ~package ~supports_markdown_links
+    ?docstring ?constructor typ =
+  let state = Option.value state ~default:package.state in
   let expanded_types, expansion_type =
-    expand_types ~file ~package ~supports_markdown_links typ
+    expand_types ~state ~file ~package ~supports_markdown_links typ
   in
   match expansion_type with
   | `Default ->
@@ -185,7 +190,7 @@ let hover_with_expanded_types ~file ~package ~supports_markdown_links ?docstring
 
 (* Leverages autocomplete functionality to produce a hover for a position. This
    makes it (most often) work with unsaved content. *)
-let get_hover_via_completions ~debug ~source ~kind_file ~pos ~for_hover
+let get_hover_via_completions ~state ~debug ~source ~kind_file ~pos ~for_hover
     ~supports_markdown_links ~full =
   match
     Completions.get_completions ~debug ~source ~kind_file ~pos ~for_hover ~full
@@ -203,36 +208,38 @@ let get_hover_via_completions ~debug ~source ~kind_file ~pos ~for_hover
       Some (String.concat "\n\n" parts)
     | {kind = Field _; env; docstring} :: _ -> (
       let opens =
-        Completion_back_end.get_opens ~debug ~raw_opens ~package ~env
+        Completion_back_end.get_opens ~state ~debug ~raw_opens ~package ~env
       in
       match
-        Completion_back_end.completions_get_type_env2 ~debug ~full ~raw_opens
-          ~opens ~pos completions
+        Completion_back_end.completions_get_type_env2 ~state ~debug ~full
+          ~raw_opens ~opens ~pos completions
       with
       | Some (typ, _env) ->
         let type_string =
-          hover_with_expanded_types ~file ~package ~docstring
+          hover_with_expanded_types ~state ~file ~package ~docstring
             ~supports_markdown_links typ
         in
         Some type_string
       | None -> None)
     | {env} :: _ -> (
       let opens =
-        Completion_back_end.get_opens ~debug ~raw_opens ~package ~env
+        Completion_back_end.get_opens ~state ~debug ~raw_opens ~package ~env
       in
       match
-        Completion_back_end.completions_get_type_env2 ~debug ~full ~raw_opens
-          ~opens ~pos completions
+        Completion_back_end.completions_get_type_env2 ~state ~debug ~full
+          ~raw_opens ~opens ~pos completions
       with
       | Some (typ, _env) ->
         let type_string =
-          hover_with_expanded_types ~file ~package ~supports_markdown_links typ
+          hover_with_expanded_types ~state ~file ~package
+            ~supports_markdown_links typ
         in
         Some type_string
       | None -> None)
     | _ -> None)
 
-let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
+let new_hover ?state ~full:{file; package} ~supports_markdown_links loc_item =
+  let state = Option.value state ~default:package.state in
   match loc_item.loc_type with
   | TypeDefinition (name, decl, _stamp) -> (
     let type_def = Markdown.code_block (Shared.decl_to_string name decl) in
@@ -240,7 +247,7 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
     | None -> Some type_def
     | Some typ -> (
       let expanded_types, expansion_type =
-        expand_types ~file ~package ~supports_markdown_links typ
+        expand_types ~state ~file ~package ~supports_markdown_links typ
       in
       match expansion_type with
       | `Default -> Some (type_def :: expanded_types |> String.concat "\n")
@@ -250,7 +257,7 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
     match Stamps.find_module file.stamps stamp with
     | None -> None
     | Some md -> (
-      match References.resolve_module_reference ~file ~package md with
+      match References.resolve_module_reference ~state ~file ~package md with
       | None -> None
       | Some (file, declared) ->
         let name, docstring =
@@ -258,19 +265,21 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
           | Some d -> (d.name.txt, d.docstring)
           | None -> (file.module_name, file.structure.docstring)
         in
-        show_module ~docstring ~name ~file declared ~package))
+        show_module ~state ~docstring ~name ~file declared ~package))
   | LModule (GlobalReference (module_name, path, tip)) -> (
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None -> None
     | Some file -> (
       let env = Query_env.from_file file in
-      match References.exported_for_tip ~env ~path ~package ~tip with
+      match References.exported_for_tip ~state ~env ~path ~package ~tip with
       | None -> None
       | Some (_env, _name, stamp) -> (
         match Stamps.find_module file.stamps stamp with
         | None -> None
         | Some md -> (
-          match References.resolve_module_reference ~file ~package md with
+          match
+            References.resolve_module_reference ~state ~file ~package md
+          with
           | None -> None
           | Some (file, declared) ->
             let name, docstring =
@@ -278,14 +287,14 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
               | Some d -> (d.name.txt, d.docstring)
               | None -> (file.module_name, file.structure.docstring)
             in
-            show_module ~docstring ~name ~file ~package declared))))
+            show_module ~state ~docstring ~name ~file ~package declared))))
   | LModule NotFound -> None
   | TopLevelModule name -> (
-    match Process_cmt.file_for_module ~package name with
+    match Process_cmt.file_for_module ~state ~package name with
     | None -> None
     | Some file ->
-      show_module ~docstring:file.structure.docstring ~name:file.module_name
-        ~file ~package None)
+      show_module ~state ~docstring:file.structure.docstring
+        ~name:file.module_name ~file ~package None)
   | Typed (_, _, Definition (_, (Field _ | Constructor _))) -> None
   | Constant t ->
     Some
@@ -300,7 +309,7 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
          | Const_bigint _ -> "bigint"))
   | Typed (_, t, loc_kind) -> (
     let from_type ?docstring ?constructor typ =
-      hover_with_expanded_types ~file ~package ~supports_markdown_links
+      hover_with_expanded_types ~state ~file ~package ~supports_markdown_links
         ?docstring ?constructor typ
     in
     (* Expand first-class modules to the underlying module type signature. *)
@@ -309,17 +318,17 @@ let new_hover ~full:{file; package} ~supports_markdown_links loc_item =
     | Tpackage (path, _lids, _tys) -> (
       let env = Query_env.from_file file in
       match
-        Resolve_path.resolve_module_from_compiler_path ~env ~package path
+        Resolve_path.resolve_module_from_compiler_path ~state ~env ~package path
       with
       | None -> Some (from_type t)
       | Some (env_for_module, Some declared) ->
         let name = Path.name path in
-        show_module ~docstring:declared.docstring ~name
+        show_module ~state ~docstring:declared.docstring ~name
           ~file:env_for_module.file ~package (Some declared)
       | Some (_, None) -> Some (from_type t))
     | _ ->
       Some
-        (match References.defined_for_loc ~file ~package loc_kind with
+        (match References.defined_for_loc ~state ~file ~package loc_kind with
         | None -> t |> from_type
         | Some (docstring, res) -> (
           match res with

--- a/analysis/src/hover.ml
+++ b/analysis/src/hover.ml
@@ -66,8 +66,7 @@ type extracted_type = {
   loc: Warnings.loc;
 }
 
-let find_relevant_types_from_type ?state ~file ~package typ =
-  let state = Option.value state ~default:package.state in
+let find_relevant_types_from_type ~state ~file ~package typ =
   (* Expand definitions of types mentioned in typ.
      If typ itself is a record or variant, search its body *)
   let env = Query_env.from_file file in
@@ -111,13 +110,12 @@ let find_relevant_types_from_type ?state ~file ~package typ =
   let constructors = Shared.find_type_constructors types_to_search in
   constructors |> List.filter_map (from_constructor_path ~env:env_to_search)
 
-let expand_types ?state ~file ~package ~supports_markdown_links typ =
-  let state = Option.value state ~default:package.state in
+let expand_types ~state ~file ~package ~supports_markdown_links typ =
   match find_relevant_types_from_type ~state typ ~file ~package with
   | {decl; path} :: _
     when Res_parsetree_viewer.has_inline_record_definition_attribute
            decl.type_attributes ->
-    (* We print inline record types just with their definition, not the constr pointing 
+    (* We print inline record types just with their definition, not the constr pointing
     to them, since that doesn't make sense to show the user. *)
     ( [
         Markdown.code_block
@@ -162,9 +160,8 @@ let expand_types ?state ~file ~package ~supports_markdown_links typ =
       `Default )
 
 (* Produces a hover with relevant types expanded in the main type being hovered. *)
-let hover_with_expanded_types ?state ~file ~package ~supports_markdown_links
+let hover_with_expanded_types ~state ~file ~package ~supports_markdown_links
     ?docstring ?constructor typ =
-  let state = Option.value state ~default:package.state in
   let expanded_types, expansion_type =
     expand_types ~state ~file ~package ~supports_markdown_links typ
   in
@@ -194,6 +191,7 @@ let get_hover_via_completions ~state ~debug ~source ~kind_file ~pos ~for_hover
     ~supports_markdown_links ~full =
   match
     Completions.get_completions ~debug ~source ~kind_file ~pos ~for_hover ~full
+      ~state
   with
   | None -> None
   | Some (completions, ({file; package} as full), scope) -> (
@@ -238,8 +236,7 @@ let get_hover_via_completions ~state ~debug ~source ~kind_file ~pos ~for_hover
       | None -> None)
     | _ -> None)
 
-let new_hover ?state ~full:{file; package} ~supports_markdown_links loc_item =
-  let state = Option.value state ~default:package.state in
+let new_hover ~state ~full:{file; package} ~supports_markdown_links loc_item =
   match loc_item.loc_type with
   | TypeDefinition (name, decl, _stamp) -> (
     let type_def = Markdown.code_block (Shared.decl_to_string name decl) in

--- a/analysis/src/packages.ml
+++ b/analysis/src/packages.ml
@@ -33,7 +33,7 @@ let get_re_script_version () =
       version
     with Not_found -> default_version)
 
-let new_bs_package ~state ~root_path =
+let new_bs_package ~root_path =
   let rescript_json = Filename.concat root_path "rescript.json" in
 
   let parse_raw raw =
@@ -173,7 +173,6 @@ let new_bs_package ~state ~root_path =
              |> List.map (fun path -> path @ ["place holder"])
            in
            {
-             state;
              generic_jsx_module;
              suffix;
              rescript_version;
@@ -224,7 +223,7 @@ let get_package ~state ~uri =
         (Hashtbl.find state.packages_by_root
            (Hashtbl.find state.root_for_uri uri))
     | Some (`Bs root_path) -> (
-      match new_bs_package ~state ~root_path with
+      match new_bs_package ~root_path with
       | None -> None
       | Some package ->
         Hashtbl.replace state.root_for_uri uri package.root_path;

--- a/analysis/src/packages.ml
+++ b/analysis/src/packages.ml
@@ -14,7 +14,7 @@ let make_paths_for_module ~project_files_and_paths ~dependencies_files_and_paths
 
 let override_rescript_version = ref None
 
-let get_re_script_version () =
+let get_rescript_version () =
   match !override_rescript_version with
   | Some override_rescript_version -> override_rescript_version
   | None -> (
@@ -45,7 +45,7 @@ let new_bs_package ~root_path =
     match Yojson_helpers.from_string_opt raw with
     | Some config -> (
       let namespace = Find_files.get_namespace config in
-      let rescript_version = get_re_script_version () in
+      let rescript_version = get_rescript_version () in
       let suffix =
         match config |> Yojson_helpers.get "suffix" with
         | Some (`String suffix) -> suffix

--- a/analysis/src/packages.ml
+++ b/analysis/src/packages.ml
@@ -33,7 +33,7 @@ let get_re_script_version () =
       version
     with Not_found -> default_version)
 
-let new_bs_package ~root_path =
+let new_bs_package ~state ~root_path =
   let rescript_json = Filename.concat root_path "rescript.json" in
 
   let parse_raw raw =
@@ -173,6 +173,7 @@ let new_bs_package ~root_path =
              |> List.map (fun path -> path @ ["place holder"])
            in
            {
+             state;
              generic_jsx_module;
              suffix;
              rescript_version;
@@ -206,7 +207,7 @@ let find_root ~uri packages_by_root =
   in
   loop (if Sys.is_directory path then path else Filename.dirname path)
 
-let get_package ~uri =
+let get_package ~state ~uri =
   let open Shared_types in
   if Hashtbl.mem state.root_for_uri uri then
     Some
@@ -223,7 +224,7 @@ let get_package ~uri =
         (Hashtbl.find state.packages_by_root
            (Hashtbl.find state.root_for_uri uri))
     | Some (`Bs root_path) -> (
-      match new_bs_package ~root_path with
+      match new_bs_package ~state ~root_path with
       | None -> None
       | Some package ->
         Hashtbl.replace state.root_for_uri uri package.root_path;

--- a/analysis/src/process_cmt.ml
+++ b/analysis/src/process_cmt.ml
@@ -793,8 +793,7 @@ let file_for_cmt ~state ~module_name ~cmt ~uri =
       Hashtbl.replace state.cmt_cache cmt file;
       Some file)
 
-let file_for_module ?state module_name ~package =
-  let state = Option.value state ~default:package.state in
+let file_for_module ~state module_name ~package =
   match Hashtbl.find_opt package.paths_for_module module_name with
   | Some paths ->
     let uri = get_uri paths in

--- a/analysis/src/process_cmt.ml
+++ b/analysis/src/process_cmt.ml
@@ -782,7 +782,7 @@ let file_for_cmt_infos ~module_name ~uri
     {uri; module_name = cmt_modname; stamps = env.stamps; structure}
   | _ -> File.create module_name uri
 
-let file_for_cmt ~module_name ~cmt ~uri =
+let file_for_cmt ~state ~module_name ~cmt ~uri =
   match Hashtbl.find_opt state.cmt_cache cmt with
   | Some file -> Some file
   | None -> (
@@ -793,13 +793,14 @@ let file_for_cmt ~module_name ~cmt ~uri =
       Hashtbl.replace state.cmt_cache cmt file;
       Some file)
 
-let file_for_module module_name ~package =
+let file_for_module ?state module_name ~package =
+  let state = Option.value state ~default:package.state in
   match Hashtbl.find_opt package.paths_for_module module_name with
   | Some paths ->
     let uri = get_uri paths in
     let cmt = get_cmt_path ~uri paths in
     Log.log ("fileForModule " ^ show_paths paths);
-    file_for_cmt ~cmt ~module_name ~uri
+    file_for_cmt ~state ~cmt ~module_name ~uri
   | None ->
     Log.log ("No path for module " ^ module_name);
     None

--- a/analysis/src/references.ml
+++ b/analysis/src/references.ml
@@ -179,8 +179,7 @@ let exported_for_tip ~state ~env ~path ~package ~(tip : Tip.t) =
       None
     | Some stamp -> Some (env, name, stamp))
 
-let defined_for_loc ?state ~file ~package loc_kind =
-  let state = Option.value state ~default:package.state in
+let defined_for_loc ~state ~file ~package loc_kind =
   let inner ~file stamp (tip : Tip.t) =
     match tip with
     | Constructor name -> (
@@ -227,9 +226,8 @@ let defined_for_loc ?state ~file ~package loc_kind =
           Some res)))
 
 (** Find alternative declaration: from res in case of interface, or from resi in case of implementation  *)
-let alternate_declared ?state ~(file : File.t) ~package
+let alternate_declared ~state ~(file : File.t) ~package
     (declared : _ Declared.t) tip =
-  let state = Option.value state ~default:package.state in
   match Hashtbl.find_opt package.paths_for_module file.module_name with
   | None -> None
   | Some paths -> (
@@ -258,9 +256,8 @@ let alternate_declared ?state ~(file : File.t) ~package
 
       None)
 
-let rec resolve_module_reference ?(paths_seen = []) ?state ~file ~package
+let rec resolve_module_reference ?(paths_seen = []) ~state ~file ~package
     (declared : Module.t Declared.t) =
-  let state = Option.value state ~default:package.state in
   match declared.item with
   | Structure _ -> Some (file, Some declared)
   | Constraint (_moduleItem, module_type_item) ->
@@ -315,8 +312,7 @@ let validate_loc (loc : Location.t) (backup : Location.t) =
     else backup
   else loc
 
-let resolve_module_definition ?state ~(file : File.t) ~package stamp =
-  let state = Option.value state ~default:package.state in
+let resolve_module_definition ~state ~(file : File.t) ~package stamp =
   match Stamps.find_module file.stamps stamp with
   | None -> None
   | Some md -> (
@@ -330,8 +326,7 @@ let resolve_module_definition ?state ~(file : File.t) ~package stamp =
       in
       Some (file.uri, loc))
 
-let definition ?state ~file ~package stamp (tip : Tip.t) =
-  let state = Option.value state ~default:package.state in
+let definition ~state ~file ~package stamp (tip : Tip.t) =
   match tip with
   | Constructor name -> (
     match get_constructor file stamp name with
@@ -362,8 +357,7 @@ let definition ?state ~file ~package stamp (tip : Tip.t) =
       maybe_log ("Inner uri " ^ Uri.to_string uri);
       Some (uri, loc))
 
-let definition_for_loc_item ?state ~full:{file; package} loc_item =
-  let state = Option.value state ~default:package.state in
+let definition_for_loc_item ~state ~full:{file; package} loc_item =
   match loc_item.loc_type with
   | Typed (_, _, Definition (stamp, tip)) -> (
     maybe_log
@@ -413,8 +407,7 @@ let definition_for_loc_item ?state ~full:{file; package} loc_item =
         maybe_log ("Got stamp " ^ string_of_int stamp);
         definition ~state ~file:env.file ~package stamp tip))
 
-let dig_constructor ?state ~env ~package path =
-  let state = Option.value state ~default:package.state in
+let dig_constructor ~state ~env ~package path =
   match Resolve_path.resolve_from_compiler_path ~state ~env ~package path with
   | NotFound -> None
   | Stamp stamp -> (
@@ -430,8 +423,7 @@ let dig_constructor ?state ~env ~package path =
       | Some t -> Some (env, t)))
   | _ -> None
 
-let type_definition_for_loc_item ?state ~full:{file; package} loc_item =
-  let state = Option.value state ~default:package.state in
+let type_definition_for_loc_item ~state ~full:{file; package} loc_item =
   match loc_item.loc_type with
   | Constant _ | TopLevelModule _ | LModule _ -> None
   | TypeDefinition _ -> Some (file.uri, loc_item.loc)
@@ -461,8 +453,7 @@ type references = {
   loc_opt: Location.t option; (* None: reference to a toplevel module *)
 }
 
-let for_local_stamp ?state ~full:{file; extra; package} stamp (tip : Tip.t) =
-  let state = Option.value state ~default:package.state in
+let for_local_stamp ~state ~full:{file; extra; package} stamp (tip : Tip.t) =
   let env = Query_env.from_file file in
   match
     match tip with
@@ -551,9 +542,8 @@ let for_local_stamp ?state ~full:{file; extra; package} stamp (tip : Tip.t) =
         (locs |> List.map (fun loc -> {uri = file.uri; loc_opt = Some loc}))
         externals)
 
-let all_references_for_loc_item ?state ~full:({file; package} as full) loc_item
+let all_references_for_loc_item ~state ~full:({file; package} as full) loc_item
     =
-  let state = Option.value state ~default:package.state in
   match loc_item.loc_type with
   | TopLevelModule module_name ->
     let other_modules_references =

--- a/analysis/src/references.ml
+++ b/analysis/src/references.ml
@@ -161,8 +161,8 @@ let get_constructor (file : File.t) stamp name =
       | Some const -> Some const)
     | _ -> None)
 
-let exported_for_tip ~env ~path ~package ~(tip : Tip.t) =
-  match Resolve_path.resolve_path ~env ~path ~package with
+let exported_for_tip ~state ~env ~path ~package ~(tip : Tip.t) =
+  match Resolve_path.resolve_path ~state ~env ~path ~package with
   | None ->
     Log.log ("Cannot resolve path " ^ path_to_string path);
     None
@@ -179,7 +179,8 @@ let exported_for_tip ~env ~path ~package ~(tip : Tip.t) =
       None
     | Some stamp -> Some (env, name, stamp))
 
-let defined_for_loc ~file ~package loc_kind =
+let defined_for_loc ?state ~file ~package loc_kind =
+  let state = Option.value state ~default:package.state in
   let inner ~file stamp (tip : Tip.t) =
     match tip with
     | Constructor name -> (
@@ -207,13 +208,13 @@ let defined_for_loc ~file ~package loc_kind =
     inner ~file stamp tip
   | GlobalReference (module_name, path, tip) -> (
     maybe_log ("Getting global " ^ module_name);
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None ->
       Log.log ("Cannot get module " ^ module_name);
       None
     | Some file -> (
       let env = Query_env.from_file file in
-      match exported_for_tip ~env ~path ~package ~tip with
+      match exported_for_tip ~state ~env ~path ~package ~tip with
       | None -> None
       | Some (env, name, stamp) -> (
         maybe_log ("Getting for " ^ string_of_int stamp ^ " in " ^ name);
@@ -226,7 +227,9 @@ let defined_for_loc ~file ~package loc_kind =
           Some res)))
 
 (** Find alternative declaration: from res in case of interface, or from resi in case of implementation  *)
-let alternate_declared ~(file : File.t) ~package (declared : _ Declared.t) tip =
+let alternate_declared ?state ~(file : File.t) ~package
+    (declared : _ Declared.t) tip =
+  let state = Option.value state ~default:package.state in
   match Hashtbl.find_opt package.paths_for_module file.module_name with
   | None -> None
   | Some paths -> (
@@ -235,14 +238,14 @@ let alternate_declared ~(file : File.t) ~package (declared : _ Declared.t) tip =
       maybe_log
         ("alternateDeclared for " ^ file.module_name ^ " has both resi and res");
       let alternate_uri = if Uri.is_interface file.uri then res else resi in
-      match Cmt.full_from_uri ~uri:(Uri.from_path alternate_uri) with
+      match Cmt.full_from_uri ~state ~uri:(Uri.from_path alternate_uri) with
       | None -> None
       | Some {file; extra} -> (
         let env = Query_env.from_file file in
         let path = Module_path.to_path declared.module_path declared.name.txt in
         maybe_log ("find declared for path " ^ path_to_string path);
         let declared_opt =
-          match exported_for_tip ~env ~path ~package ~tip with
+          match exported_for_tip ~state ~env ~path ~package ~tip with
           | None -> None
           | Some (_env, _name, stamp) ->
             declared_for_tip ~stamps:file.stamps stamp tip
@@ -255,12 +258,13 @@ let alternate_declared ~(file : File.t) ~package (declared : _ Declared.t) tip =
 
       None)
 
-let rec resolve_module_reference ?(paths_seen = []) ~file ~package
+let rec resolve_module_reference ?(paths_seen = []) ?state ~file ~package
     (declared : Module.t Declared.t) =
+  let state = Option.value state ~default:package.state in
   match declared.item with
   | Structure _ -> Some (file, Some declared)
   | Constraint (_moduleItem, module_type_item) ->
-    resolve_module_reference ~paths_seen ~file ~package
+    resolve_module_reference ~paths_seen ~state ~file ~package
       {declared with item = module_type_item}
   | Ident path -> (
     let env = Query_env.from_file file in
@@ -274,11 +278,11 @@ let rec resolve_module_reference ?(paths_seen = []) ~file ~package
         | None -> None
         | Some md -> Some (env.file, Some md)))
     | Global (module_name, path) -> (
-      match Process_cmt.file_for_module ~package module_name with
+      match Process_cmt.file_for_module ~state ~package module_name with
       | None -> None
       | Some file -> (
         let env = Query_env.from_file file in
-        match Resolve_path.resolve_path ~env ~package ~path with
+        match Resolve_path.resolve_path ~state ~env ~package ~path with
         | None -> None
         | Some (env, name) -> (
           match Exported.find env.exported Exported.Module name with
@@ -292,11 +296,11 @@ let rec resolve_module_reference ?(paths_seen = []) ~file ~package
       | None -> None
       | Some ({item = Ident path} as md) when not (List.mem path paths_seen) ->
         (* avoid possible infinite loops *)
-        resolve_module_reference ~file ~package ~paths_seen:(path :: paths_seen)
-          md
+        resolve_module_reference ~state ~file ~package
+          ~paths_seen:(path :: paths_seen) md
       | Some md -> Some (file, Some md))
     | GlobalMod name -> (
-      match Process_cmt.file_for_module ~package name with
+      match Process_cmt.file_for_module ~state ~package name with
       | None -> None
       | Some file -> Some (file, None)))
 
@@ -311,11 +315,12 @@ let validate_loc (loc : Location.t) (backup : Location.t) =
     else backup
   else loc
 
-let resolve_module_definition ~(file : File.t) ~package stamp =
+let resolve_module_definition ?state ~(file : File.t) ~package stamp =
+  let state = Option.value state ~default:package.state in
   match Stamps.find_module file.stamps stamp with
   | None -> None
   | Some md -> (
-    match resolve_module_reference ~file ~package md with
+    match resolve_module_reference ~state ~file ~package md with
     | None -> None
     | Some (file, declared) ->
       let loc =
@@ -325,7 +330,8 @@ let resolve_module_definition ~(file : File.t) ~package stamp =
       in
       Some (file.uri, loc))
 
-let definition ~file ~package stamp (tip : Tip.t) =
+let definition ?state ~file ~package stamp (tip : Tip.t) =
+  let state = Option.value state ~default:package.state in
   match tip with
   | Constructor name -> (
     match get_constructor file stamp name with
@@ -335,13 +341,13 @@ let definition ~file ~package stamp (tip : Tip.t) =
     match get_field file stamp name with
     | None -> None
     | Some field -> Some (file.uri, field.fname.loc))
-  | Module -> resolve_module_definition ~file ~package stamp
+  | Module -> resolve_module_definition ~state ~file ~package stamp
   | _ -> (
     match declared_for_tip ~stamps:file.stamps stamp tip with
     | None -> None
     | Some declared ->
       let file_impl, declared_impl =
-        match alternate_declared ~package ~file declared tip with
+        match alternate_declared ~state ~package ~file declared tip with
         | Some (file_impl, _extra, declared_impl) when Uri.is_interface file.uri
           ->
           (file_impl, declared_impl)
@@ -350,12 +356,14 @@ let definition ~file ~package stamp (tip : Tip.t) =
       let loc = validate_loc declared_impl.name.loc declared_impl.extent_loc in
       let env = Query_env.from_file file_impl in
       let uri =
-        Resolve_path.get_source_uri ~env ~package declared_impl.module_path
+        Resolve_path.get_source_uri ~state ~env ~package
+          declared_impl.module_path
       in
       maybe_log ("Inner uri " ^ Uri.to_string uri);
       Some (uri, loc))
 
-let definition_for_loc_item ~full:{file; package} loc_item =
+let definition_for_loc_item ?state ~full:{file; package} loc_item =
+  let state = Option.value state ~default:package.state in
   match loc_item.loc_type with
   | Typed (_, _, Definition (stamp, tip)) -> (
     maybe_log
@@ -367,7 +375,7 @@ let definition_for_loc_item ~full:{file; package} loc_item =
       maybe_log ("Declared " ^ declared.name.txt);
       if declared.is_exported then (
         maybe_log ("exported, looking for alternate " ^ file.module_name);
-        match alternate_declared ~package ~file declared tip with
+        match alternate_declared ~state ~package ~file declared tip with
         | None -> None
         | Some (file, _extra, declared) ->
           let loc = validate_loc declared.name.loc declared.extent_loc in
@@ -388,25 +396,26 @@ let definition_for_loc_item ~full:{file; package} loc_item =
   | LModule (LocalReference (stamp, tip))
   | Typed (_, _, LocalReference (stamp, tip)) ->
     maybe_log ("Local defn " ^ Tip.to_string tip);
-    definition ~file ~package stamp tip
+    definition ~state ~file ~package stamp tip
   | LModule (GlobalReference (module_name, path, tip))
   | Typed (_, _, GlobalReference (module_name, path, tip)) -> (
     maybe_log
       ("Typed GlobalReference moduleName:" ^ module_name ^ " path:"
      ^ path_to_string path ^ " tip:" ^ Tip.to_string tip);
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None -> None
     | Some file -> (
       let env = Query_env.from_file file in
-      match exported_for_tip ~env ~path ~package ~tip with
+      match exported_for_tip ~state ~env ~path ~package ~tip with
       | None -> None
       | Some (env, _name, stamp) ->
         (* oooh wht do I do if the stamp is inside a pseudo-file? *)
         maybe_log ("Got stamp " ^ string_of_int stamp);
-        definition ~file:env.file ~package stamp tip))
+        definition ~state ~file:env.file ~package stamp tip))
 
-let dig_constructor ~env ~package path =
-  match Resolve_path.resolve_from_compiler_path ~env ~package path with
+let dig_constructor ?state ~env ~package path =
+  let state = Option.value state ~default:package.state in
+  match Resolve_path.resolve_from_compiler_path ~state ~env ~package path with
   | NotFound -> None
   | Stamp stamp -> (
     match Stamps.find_type env.file.stamps stamp with
@@ -421,7 +430,8 @@ let dig_constructor ~env ~package path =
       | Some t -> Some (env, t)))
   | _ -> None
 
-let type_definition_for_loc_item ~full:{file; package} loc_item =
+let type_definition_for_loc_item ?state ~full:{file; package} loc_item =
+  let state = Option.value state ~default:package.state in
   match loc_item.loc_type with
   | Constant _ | TopLevelModule _ | LModule _ -> None
   | TypeDefinition _ -> Some (file.uri, loc_item.loc)
@@ -430,7 +440,7 @@ let type_definition_for_loc_item ~full:{file; package} loc_item =
     match Shared.dig_constructor typ with
     | None -> None
     | Some path -> (
-      match dig_constructor ~env ~package path with
+      match dig_constructor ~state ~env ~package path with
       | Some (env, declared) -> Some (env.file.uri, declared.item.decl.type_loc)
       | None -> None))
 
@@ -451,7 +461,8 @@ type references = {
   loc_opt: Location.t option; (* None: reference to a toplevel module *)
 }
 
-let for_local_stamp ~full:{file; extra; package} stamp (tip : Tip.t) =
+let for_local_stamp ?state ~full:{file; extra; package} stamp (tip : Tip.t) =
+  let state = Option.value state ~default:package.state in
   let env = Query_env.from_file file in
   match
     match tip with
@@ -473,7 +484,7 @@ let for_local_stamp ~full:{file; extra; package} stamp (tip : Tip.t) =
         | Some declared ->
           if is_visible declared then (
             let alternative_references =
-              match alternate_declared ~package ~file declared tip with
+              match alternate_declared ~state ~package ~file declared tip with
               | None -> []
               | Some (file, extra, {stamp}) -> (
                 match
@@ -540,7 +551,9 @@ let for_local_stamp ~full:{file; extra; package} stamp (tip : Tip.t) =
         (locs |> List.map (fun loc -> {uri = file.uri; loc_opt = Some loc}))
         externals)
 
-let all_references_for_loc_item ~full:({file; package} as full) loc_item =
+let all_references_for_loc_item ?state ~full:({file; package} as full) loc_item
+    =
+  let state = Option.value state ~default:package.state in
   match loc_item.loc_type with
   | TopLevelModule module_name ->
     let other_modules_references =
@@ -568,20 +581,20 @@ let all_references_for_loc_item ~full:({file; package} as full) loc_item =
     in
     List.append target_module_references other_modules_references
   | Typed (_, _, NotFound) | LModule NotFound | Constant _ -> []
-  | TypeDefinition (_, _, stamp) -> for_local_stamp ~full stamp Type
+  | TypeDefinition (_, _, stamp) -> for_local_stamp ~state ~full stamp Type
   | Typed (_, _, (LocalReference (stamp, tip) | Definition (stamp, tip)))
   | LModule (LocalReference (stamp, tip) | Definition (stamp, tip)) ->
     maybe_log
       ("Finding references for " ^ Uri.to_string file.uri ^ " and stamp "
      ^ string_of_int stamp ^ " and tip " ^ Tip.to_string tip);
-    for_local_stamp ~full stamp tip
+    for_local_stamp ~state ~full stamp tip
   | LModule (GlobalReference (module_name, path, tip))
   | Typed (_, _, GlobalReference (module_name, path, tip)) -> (
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None -> []
     | Some file -> (
       let env = Query_env.from_file file in
-      match exported_for_tip ~env ~path ~package ~tip with
+      match exported_for_tip ~state ~env ~path ~package ~tip with
       | None -> []
       | Some (env, _name, stamp) -> (
         match
@@ -593,4 +606,4 @@ let all_references_for_loc_item ~full:({file; package} as full) loc_item =
             ("Finding references for (global) " ^ Uri.to_string env.file.uri
            ^ " and stamp " ^ string_of_int stamp ^ " and tip "
            ^ Tip.to_string tip);
-          for_local_stamp ~full stamp tip)))
+          for_local_stamp ~state ~full stamp tip)))

--- a/analysis/src/resolve_path.ml
+++ b/analysis/src/resolve_path.ml
@@ -58,7 +58,7 @@ and find_in_module ~(env : Query_env.t) module_ path =
       | None -> None
       | Some {item} -> find_in_module ~env item full_path)
 
-let rec resolve_path ~env ~path ~package =
+let rec resolve_path ~state ~env ~path ~package =
   Log.log ("resolvePath path:" ^ path_to_string path);
   match resolve_path_inner ~env ~path with
   | None -> None
@@ -69,10 +69,11 @@ let rec resolve_path ~env ~path ~package =
       Log.log
         ("resolvePath Global path:" ^ path_to_string full_path ^ " module:"
        ^ module_name);
-      match Process_cmt.file_for_module ~package module_name with
+      match Process_cmt.file_for_module ~state ~package module_name with
       | None -> None
       | Some file ->
-        resolve_path ~env:(Query_env.from_file file) ~path:full_path ~package))
+        resolve_path ~state ~env:(Query_env.from_file file) ~path:full_path
+          ~package))
 
 let from_compiler_path ~(env : Query_env.t) path : resolution =
   match make_path ~env path with
@@ -82,14 +83,14 @@ let from_compiler_path ~(env : Query_env.t) path : resolution =
   | Exported (env, name) -> Exported (env, name)
   | Global (module_name, full_path) -> Global (module_name, full_path)
 
-let resolve_module_from_compiler_path ~env ~package path =
+let resolve_module_from_compiler_path ~state ~env ~package path =
   match from_compiler_path ~env path with
   | Global (module_name, path) -> (
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None -> None
     | Some file -> (
       let env = Query_env.from_file file in
-      match resolve_path ~env ~package ~path with
+      match resolve_path ~state ~env ~package ~path with
       | None -> None
       | Some (env, name) -> (
         match Exported.find env.exported Exported.Module name with
@@ -103,7 +104,7 @@ let resolve_module_from_compiler_path ~env ~package path =
     | None -> None
     | Some declared -> Some (env, Some declared))
   | GlobalMod module_name -> (
-    match Process_cmt.file_for_module ~package module_name with
+    match Process_cmt.file_for_module ~state ~package module_name with
     | None -> None
     | Some file ->
       let env = Query_env.from_file file in
@@ -117,15 +118,15 @@ let resolve_module_from_compiler_path ~env ~package path =
       | None -> None
       | Some declared -> Some (env, Some declared)))
 
-let resolve_from_compiler_path ~env ~package path =
+let resolve_from_compiler_path ~state ~env ~package path =
   match from_compiler_path ~env path with
   | Global (module_name, path) -> (
     let res =
-      match Process_cmt.file_for_module ~package module_name with
+      match Process_cmt.file_for_module ~state ~package module_name with
       | None -> None
       | Some file ->
         let env = Query_env.from_file file in
-        resolve_path ~env ~package ~path
+        resolve_path ~state ~env ~package ~path
     in
     match res with
     | None -> NotFound
@@ -135,15 +136,17 @@ let resolve_from_compiler_path ~env ~package path =
   | NotFound -> NotFound
   | Exported (env, name) -> Exported (env, name)
 
-let rec get_source_uri ~(env : Query_env.t) ~package (path : Module_path.t) =
+let rec get_source_uri ~state ~(env : Query_env.t) ~package
+    (path : Module_path.t) =
   match path with
   | File (uri, _moduleName) -> uri
   | NotVisible -> env.file.uri
   | IncludedModule (path, inner) -> (
     Log.log "INCLUDED MODULE";
-    match resolve_module_from_compiler_path ~env ~package path with
+    match resolve_module_from_compiler_path ~state ~env ~package path with
     | None ->
       Log.log "NOT FOUND";
-      get_source_uri ~env ~package inner
+      get_source_uri ~state ~env ~package inner
     | Some (env, _declared) -> env.file.uri)
-  | ExportedModule {module_path = inner} -> get_source_uri ~env ~package inner
+  | ExportedModule {module_path = inner} ->
+    get_source_uri ~state ~env ~package inner

--- a/analysis/src/shared_types.ml
+++ b/analysis/src/shared_types.ml
@@ -526,7 +526,6 @@ type state = {
 }
 
 and package = {
-  state: state;
   generic_jsx_module: string option;
   suffix: string;
   root_path: file_path;

--- a/analysis/src/shared_types.ml
+++ b/analysis/src/shared_types.ml
@@ -519,7 +519,14 @@ type file = string
 
 module File_set = Set.Make (String)
 
-type package = {
+type state = {
+  packages_by_root: (string, package) Hashtbl.t;
+  root_for_uri: (Uri.t, string) Hashtbl.t;
+  cmt_cache: (file_path, File.t) Hashtbl.t;
+}
+
+and package = {
+  state: state;
   generic_jsx_module: string option;
   suffix: string;
   root_path: file_path;
@@ -545,14 +552,7 @@ let init_extra () =
     loc_items = [];
   }
 
-type state = {
-  packages_by_root: (string, package) Hashtbl.t;
-  root_for_uri: (Uri.t, string) Hashtbl.t;
-  cmt_cache: (file_path, File.t) Hashtbl.t;
-}
-
-(* There's only one state, so it can as well be global *)
-let state =
+let create_state () =
   {
     packages_by_root = Hashtbl.create 1;
     root_for_uri = Hashtbl.create 30;

--- a/analysis/src/signature_help.ml
+++ b/analysis/src/signature_help.ml
@@ -2,8 +2,10 @@ open Shared_types
 type cursor_at_arg = Unlabelled of int | Labelled of string
 
 (* Produces the doc string shown below the signature help for each parameter. *)
-let docs_for_label type_expr ~file ~package ~supports_markdown_links =
-  let types = Hover.find_relevant_types_from_type ~file ~package type_expr in
+let docs_for_label type_expr ~file ~state ~package ~supports_markdown_links =
+  let types =
+    Hover.find_relevant_types_from_type ~state ~file ~package type_expr
+  in
   let type_names = types |> List.map (fun {Hover.name} -> name) in
   let type_definitions =
     types
@@ -33,7 +35,7 @@ let docs_for_label type_expr ~file ~package ~supports_markdown_links =
   in
   type_definitions |> String.concat "\n"
 
-let find_function_type ~debug ~source ~kind_file ~pos ~full =
+let find_function_type ~debug ~source ~kind_file ~pos ~full ~state =
   (* Start by looking at the typed info at the loc of the fn *)
   match full with
   | None -> None
@@ -44,7 +46,7 @@ let find_function_type ~debug ~source ~kind_file ~pos ~full =
       match References.get_loc_item ~full ~pos ~debug:false with
       | Some {loc_type = Typed (_, type_expr, loc_kind)} -> (
         let docstring =
-          match References.defined_for_loc ~file ~package loc_kind with
+          match References.defined_for_loc ~file ~package ~state loc_kind with
           | None -> []
           | Some (docstring, _) -> docstring
         in
@@ -52,7 +54,8 @@ let find_function_type ~debug ~source ~kind_file ~pos ~full =
           Printf.printf "[sig_help_fn] Found loc item: %s.\n"
             (Shared.type_to_string type_expr);
         match
-          Type_utils.extract_function_type2 ~env ~package:full.package type_expr
+          Type_utils.extract_function_type2 ~env ~package:full.package ~state
+            type_expr
         with
         | args, _tRet, _ when args <> [] ->
           Some (args, docstring, type_expr, package, env, file)
@@ -87,7 +90,7 @@ let find_function_type ~debug ~source ~kind_file ~pos ~full =
             Some
               ( completable
                 |> Completion_back_end.process_completable ~debug ~full ~pos
-                     ~scope ~env ~for_hover:true,
+                     ~scope ~state ~env ~for_hover:true,
                 env,
                 package,
                 file ))
@@ -95,7 +98,7 @@ let find_function_type ~debug ~source ~kind_file ~pos ~full =
       match completables with
       | Some ({kind = Value type_expr; docstring} :: _, env, package, file) ->
         let args, _, _ =
-          Type_utils.extract_function_type2 type_expr ~env ~package
+          Type_utils.extract_function_type2 type_expr ~env ~state ~package
         in
         Some (args, docstring, type_expr, package, env, file)
       | _ -> None))
@@ -181,14 +184,16 @@ type constructor_info = {
   args: constructor_args;
 }
 
-let find_constructor_args ~full ~env ~constructor_name loc =
+let find_constructor_args ~full ~env ~state ~constructor_name loc =
   match
     References.get_loc_item ~debug:false ~full
       ~pos:(Pos.of_lexing loc.Location.loc_end)
   with
   | None -> None
   | Some {loc_type = Typed (_, typ_expr, _)} -> (
-    match Type_utils.extract_type ~env ~package:full.package typ_expr with
+    match
+      Type_utils.extract_type ~env ~state ~package:full.package typ_expr
+    with
     | Some ((Toption (_, TypeExpr t) as extracted_type), _) -> (
       match constructor_name with
       | "Some" ->
@@ -238,7 +243,7 @@ let find_constructor_args ~full ~env ~constructor_name loc =
   | _ -> None
 
 let signature_help ~debug ~source ~kind_file ~pos
-    ~allow_for_constructor_payloads ~full =
+    ~allow_for_constructor_payloads ~full ~state =
   match source with
   | "" -> None
   | text -> (
@@ -429,7 +434,9 @@ let signature_help ~debug ~source ~kind_file ~pos
       | Some (_, `FunctionCall (arg_at_cursor, exp, _extractedArgs)) -> (
         (* Not looking for the cursor position after this, but rather the target function expression's loc. *)
         let pos = exp.pexp_loc |> Loc.end_ in
-        match find_function_type ~source ~kind_file ~debug ~pos ~full with
+        match
+          find_function_type ~source ~kind_file ~debug ~pos ~full ~state
+        with
         | Some (args, docstring, type_expr, package, _env, file) ->
           if debug then
             Printf.printf "argAtCursor: %s\n"
@@ -499,7 +506,7 @@ let signature_help ~debug ~source ~kind_file ~pos
                        Lsp.Types.MarkupContent.create
                          ~kind:Lsp.Types.MarkupKind.Markdown
                          ~value:
-                           (docs_for_label ~supports_markdown_links ~file
+                           (docs_for_label ~supports_markdown_links ~file ~state
                               ~package label_typ_expr)
                    in
                    Lsp.Types.ParameterInformation.create
@@ -547,7 +554,7 @@ let signature_help ~debug ~source ~kind_file ~pos
           let env = Query_env.from_file file in
           let constructor_name = Longident.last lid.txt in
           match
-            find_constructor_args ~full ~env ~constructor_name
+            find_constructor_args ~full ~state ~env ~constructor_name
               {lid.loc with loc_start = lid.loc.loc_end}
           with
           | None ->
@@ -584,7 +591,7 @@ let signature_help ~debug ~source ~kind_file ~pos
                   (`SingleArg
                      ( typ |> Shared.type_to_string,
                        docs_for_label ~file:full.file ~package:full.package
-                         ~supports_markdown_links typ ))
+                         ~state ~supports_markdown_links typ ))
               | Args args ->
                 let offset = ref 0 in
                 Some
@@ -600,7 +607,7 @@ let signature_help ~debug ~source ~kind_file ~pos
                             ( arg_text,
                               docs_for_label ~file:full.file
                                 ~package:full.package ~supports_markdown_links
-                                typ,
+                                ~state typ,
                               (start_offset, end_offset) ))))
             in
             let label =

--- a/analysis/src/type_utils.ml
+++ b/analysis/src/type_utils.ml
@@ -232,12 +232,12 @@ let instantiate_type2 ?(type_arg_context : type_arg_context option)
     in
     loop t
 
-let rec extract_record_type ~env ~package (t : Types.type_expr) =
+let rec extract_record_type ~state ~env ~package (t : Types.type_expr) =
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
-    extract_record_type ~env ~package t1
+    extract_record_type ~state ~env ~package t1
   | Tconstr (path, type_args, _) -> (
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~state ~env ~package path with
     | Some (env, ({item = {kind = Record fields}} as typ)) ->
       let type_params = typ.item.decl.type_params in
       let fields =
@@ -251,30 +251,30 @@ let rec extract_record_type ~env ~package (t : Types.type_expr) =
       Some (env, fields, typ)
     | Some (env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
       let t1 = t1 |> instantiate_type ~type_params ~type_args in
-      extract_record_type ~env ~package t1
+      extract_record_type ~state ~env ~package t1
     | _ -> None)
   | _ -> None
 
-let rec extract_object_type ~env ~package (t : Types.type_expr) =
+let rec extract_object_type ~state ~env ~package (t : Types.type_expr) =
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
-    extract_object_type ~env ~package t1
+    extract_object_type ~state ~env ~package t1
   | Tobject (t_obj, _) -> Some (env, t_obj)
   | Tconstr (path, type_args, _) -> (
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~state ~env ~package path with
     | Some (env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
       let t1 = t1 |> instantiate_type ~type_params ~type_args in
-      extract_object_type ~env ~package t1
+      extract_object_type ~state ~env ~package t1
     | _ -> None)
   | _ -> None
 
-let extract_function_type ~env ~package ?(dig_into = true) typ =
+let extract_function_type ~state ~env ~package ?(dig_into = true) typ =
   let rec loop ~env acc (t : Types.type_expr) =
     match t.desc with
     | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> loop ~env acc t1
     | Tarrow (arg, t_ret, _, _) -> loop ~env ((arg.lbl, arg.typ) :: acc) t_ret
     | Tconstr (path, type_args, _) when dig_into -> (
-      match References.dig_constructor ~env ~package path with
+      match References.dig_constructor ~state ~env ~package path with
       | Some (env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
         let t1 = t1 |> instantiate_type ~type_params ~type_args in
         loop ~env acc t1
@@ -283,13 +283,13 @@ let extract_function_type ~env ~package ?(dig_into = true) typ =
   in
   loop ~env [] typ
 
-let extract_function_type_with_env ~env ~package typ =
+let extract_function_type_with_env ~state ~env ~package typ =
   let rec loop ~env acc (t : Types.type_expr) =
     match t.desc with
     | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> loop ~env acc t1
     | Tarrow (arg, t_ret, _, _) -> loop ~env ((arg.lbl, arg.typ) :: acc) t_ret
     | Tconstr (path, type_args, _) -> (
-      match References.dig_constructor ~env ~package path with
+      match References.dig_constructor ~state ~env ~package path with
       | Some (_env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
         let t1 = t1 |> instantiate_type ~type_params ~type_args in
         loop ~env acc t1
@@ -318,7 +318,7 @@ let maybe_set_type_arg_ctx ?type_arg_context_from_type_manifest ~type_params
     type_arg_context
 
 (* TODO(env-stuff) Maybe this could be removed entirely if we can guarantee that we don't have to look up functions from in here. *)
-let extract_function_type2 ?type_arg_context ~env ~package typ =
+let extract_function_type2 ?type_arg_context ~state ~env ~package typ =
   let rec loop ?type_arg_context ~env acc (t : Types.type_expr) =
     match t.desc with
     | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
@@ -326,7 +326,7 @@ let extract_function_type2 ?type_arg_context ~env ~package typ =
     | Tarrow (arg, t_ret, _, _) ->
       loop ?type_arg_context ~env ((arg.lbl, arg.typ) :: acc) t_ret
     | Tconstr (path, type_args, _) -> (
-      match References.dig_constructor ~env ~package path with
+      match References.dig_constructor ~state ~env ~package path with
       | Some (env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
         let type_arg_context =
           maybe_set_type_arg_ctx ~type_params ~type_args env
@@ -339,7 +339,7 @@ let extract_function_type2 ?type_arg_context ~env ~package typ =
 
 let rec extract_type ?(print_opening_debug = true)
     ?(type_arg_context : type_arg_context option)
-    ?(type_arg_context_from_type_manifest : type_arg_context option) ~env
+    ?(type_arg_context_from_type_manifest : type_arg_context option) ~env ~state
     ~package (t : Types.type_expr) =
   let maybe_set_type_arg_ctx =
     maybe_set_type_arg_ctx ?type_arg_context_from_type_manifest
@@ -360,7 +360,8 @@ let rec extract_type ?(print_opening_debug = true)
   let instantiate_type = instantiate_type2 in
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
-    extract_type ?type_arg_context ~print_opening_debug:false ~env ~package t1
+    extract_type ?type_arg_context ~print_opening_debug:false ~env ~package
+      ~state t1
   | Tconstr (Path.Pident {name = "option"}, [payload_type_expr], _) ->
     Some (Toption (env, TypeExpr payload_type_expr), type_arg_context)
   | Tconstr (Path.Pident {name = "promise"}, [payload_type_expr], _) ->
@@ -376,7 +377,7 @@ let rec extract_type ?(print_opening_debug = true)
   | Tconstr (Path.Pident {name = "exn"}, [], _) ->
     Some (Texn env, type_arg_context)
   | Tarrow _ -> (
-    match extract_function_type2 ?type_arg_context t ~env ~package with
+    match extract_function_type2 ?type_arg_context t ~state ~env ~package with
     | args, t_ret, type_arg_context when args <> [] ->
       Some
         (Tfunction {env; args; typ = t; return_type = t_ret}, type_arg_context)
@@ -386,7 +387,7 @@ let rec extract_type ?(print_opening_debug = true)
       Printf.printf "[extract_type]--> digging for type %s in %s\n"
         (Path.name path)
         (Debug.debug_print_env env);
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~env ~state ~package path with
     | Some
         ( env_from_declaration,
           {item = {decl = {type_manifest = Some t1; type_params}}} ) ->
@@ -401,7 +402,7 @@ let rec extract_type ?(print_opening_debug = true)
       in
       t1
       |> extract_type ?type_arg_context_from_type_manifest:type_arg_context
-           ~env:env_from_declaration ~package
+           ~env:env_from_declaration ~state ~package
     | Some
         (env_from_item, {name; item = {decl; kind = Type.Variant constructors}})
       ->
@@ -495,41 +496,43 @@ let rec extract_type ?(print_opening_debug = true)
         | Some {env} -> env
         | None -> env
       in
-      instantiated |> extract_type ?type_arg_context ~env:next_env ~package)
+      instantiated
+      |> extract_type ?type_arg_context ~env:next_env ~package ~state)
   | _ ->
     if Debug.verbose () then print_endline "[extract_type]--> miss";
     None
 
-let is_function_type ~env ~package t =
-  match extract_type ~env ~package t with
+let is_function_type ~env ~package ~state t =
+  match extract_type ~env ~package ~state t with
   | Some (Tfunction _, _) -> true
   | _ -> false
 
-let find_return_type_of_function_at_loc loc ~(env : Query_env.t) ~full ~debug =
+let find_return_type_of_function_at_loc loc ~(env : Query_env.t) ~full ~state
+    ~debug =
   match References.get_loc_item ~full ~pos:(loc |> Loc.end_) ~debug with
   | Some {loc_type = Typed (_, typ_expr, _)} -> (
-    match extract_function_type ~env ~package:full.package typ_expr with
+    match extract_function_type ~env ~package:full.package ~state typ_expr with
     | args, t_ret when args <> [] -> Some t_ret
     | _ -> None)
   | _ -> None
 
-let rec dig_to_relevant_template_name_type ~env ~package ?(suffix = "")
+let rec dig_to_relevant_template_name_type ~env ~package ~state ?(suffix = "")
     (t : Types.type_expr) =
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
-    dig_to_relevant_template_name_type ~suffix ~env ~package t1
+    dig_to_relevant_template_name_type ~suffix ~env ~package ~state t1
   | Tconstr (Path.Pident {name = "option"}, [t1], _) ->
-    dig_to_relevant_template_name_type ~suffix ~env ~package t1
+    dig_to_relevant_template_name_type ~suffix ~env ~package ~state t1
   | Tconstr (Path.Pident {name = "array"}, [t1], _) ->
-    dig_to_relevant_template_name_type ~suffix:"s" ~env ~package t1
+    dig_to_relevant_template_name_type ~suffix:"s" ~env ~package ~state t1
   | Tconstr (path, _, _) -> (
-    match References.dig_constructor ~env ~package path with
+    match References.dig_constructor ~env ~package ~state path with
     | Some (env, {item = {decl = {type_manifest = Some typ}}}) ->
-      dig_to_relevant_template_name_type ~suffix ~env ~package typ
+      dig_to_relevant_template_name_type ~suffix ~env ~package ~state typ
     | _ -> (t, suffix, env))
   | _ -> (t, suffix, env)
 
-let rec resolve_type_for_pipe_completion ~env ~package ~lhs_loc ~full
+let rec resolve_type_for_pipe_completion ~env ~package ~state ~lhs_loc ~full
     (t : Types.type_expr) =
   (* If the type we're completing on is a type parameter, we won't be able to
      do completion unless we know what that type parameter is compiled as.
@@ -538,14 +541,14 @@ let rec resolve_type_for_pipe_completion ~env ~package ~lhs_loc ~full
   let typ_from_loc =
     match t with
     | {Types.desc = Tvar _} ->
-      find_return_type_of_function_at_loc lhs_loc ~env ~full ~debug:false
+      find_return_type_of_function_at_loc lhs_loc ~env ~full ~state ~debug:false
     | _ -> None
   in
   match typ_from_loc with
   | Some ({desc = Tvar _} as t) -> (env, t)
   | Some typ_from_loc ->
     typ_from_loc
-    |> resolve_type_for_pipe_completion ~lhs_loc ~env ~package ~full
+    |> resolve_type_for_pipe_completion ~lhs_loc ~env ~package ~full ~state
   | None ->
     let rec dig_to_relevant_type ~env ~package (t : Types.type_expr) =
       match t.desc with
@@ -554,7 +557,7 @@ let rec resolve_type_for_pipe_completion ~env ~package ~lhs_loc ~full
       (* Don't descend into types named "t". Type t is a convention in the ReScript ecosystem. *)
       | Tconstr (path, _, _) when path |> Path.last = "t" -> (env, t)
       | Tconstr (path, _, _) -> (
-        match References.dig_constructor ~env ~package path with
+        match References.dig_constructor ~env ~package ~state path with
         | Some (env, {item = {decl = {type_manifest = Some typ}}}) ->
           dig_to_relevant_type ~env ~package typ
         | _ -> (env, t))
@@ -562,7 +565,7 @@ let rec resolve_type_for_pipe_completion ~env ~package ~lhs_loc ~full
     in
     dig_to_relevant_type ~env ~package t
 
-let extract_type_from_resolved_type (typ : Type.t) ~env ~full =
+let extract_type_from_resolved_type (typ : Type.t) ~env ~full ~state =
   match typ.kind with
   | Tuple items -> Some (Tuple (env, items, Ctype.newty (Ttuple items)))
   | Record fields ->
@@ -575,12 +578,12 @@ let extract_type_from_resolved_type (typ : Type.t) ~env ~full =
     match typ.decl.type_manifest with
     | None -> None
     | Some t ->
-      t |> extract_type ~env ~package:full.package |> get_extracted_type)
+      t |> extract_type ~state ~env ~package:full.package |> get_extracted_type)
 
 (** The context we just came from as we resolve the nested structure. *)
 type ctx = Rfield of string  (** A record field of name *)
 
-let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
+let rec resolve_nested ?type_arg_context ~env ~full ~state ~nested ?ctx
     (typ : completion_type) =
   let extract_type = extract_type ?type_arg_context in
   if Debug.verbose () then
@@ -618,9 +621,10 @@ let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
         None
       | Some typ ->
         typ
-        |> extract_type ~env ~package:full.package
+        |> extract_type ~state ~env ~package:full.package
         |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
-               typ |> resolve_nested ?type_arg_context ~env ~full ~nested))
+               typ |> resolve_nested ?type_arg_context ~env ~state ~full ~nested)
+      )
     | ( NFollowRecordField {field_name},
         (TinlineRecord {env; fields} | Trecord {env; fields}) ) -> (
       if Debug.verbose () then
@@ -643,15 +647,15 @@ let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
             (Shared.type_to_string typ)
             (Debug.debug_print_env env);
         typ
-        |> extract_type ~env ~package:full.package
+        |> extract_type ~env ~state ~package:full.package
         |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
                typ
                |> resolve_nested ?type_arg_context ~ctx:(Rfield field_name) ~env
-                    ~full ~nested))
+                    ~state ~full ~nested))
     | NRecordBody {seen_fields}, Trecord {env; definition = `TypeExpr type_expr}
       ->
       type_expr
-      |> extract_type ~env ~package:full.package
+      |> extract_type ~env ~state ~package:full.package
       |> Option.map (fun (typ, type_arg_context) ->
              ( typ,
                env,
@@ -674,30 +678,30 @@ let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
         Toption (env, ExtractedType typ) ) ->
       if Debug.verbose () then
         print_endline "[nested]--> moving into option Some";
-      typ |> resolve_nested ?type_arg_context ~env ~full ~nested
+      typ |> resolve_nested ?type_arg_context ~env ~full ~state ~nested
     | ( NVariantPayload {constructor_name = "Some"; item_num = 0},
         Toption (env, TypeExpr typ) ) ->
       if Debug.verbose () then
         print_endline "[nested]--> moving into option Some";
       typ
-      |> extract_type ~env ~package:full.package
+      |> extract_type ~env ~state ~package:full.package
       |> Utils.Option.flat_map (fun (t, type_arg_context) ->
-             t |> resolve_nested ?type_arg_context ~env ~full ~nested)
+             t |> resolve_nested ?type_arg_context ~env ~state ~full ~nested)
     | NVariantPayload {constructor_name = "Ok"; item_num = 0}, Tresult {ok_type}
       ->
       if Debug.verbose () then print_endline "[nested]--> moving into result Ok";
       ok_type
-      |> extract_type ~env ~package:full.package
+      |> extract_type ~env ~state ~package:full.package
       |> Utils.Option.flat_map (fun (t, type_arg_context) ->
-             t |> resolve_nested ?type_arg_context ~env ~full ~nested)
+             t |> resolve_nested ?type_arg_context ~env ~state ~full ~nested)
     | ( NVariantPayload {constructor_name = "Error"; item_num = 0},
         Tresult {error_type} ) ->
       if Debug.verbose () then
         print_endline "[nested]--> moving into result Error";
       error_type
-      |> extract_type ~env ~package:full.package
+      |> extract_type ~env ~state ~package:full.package
       |> Utils.Option.flat_map (fun (t, type_arg_context) ->
-             t |> resolve_nested ?type_arg_context ~env ~full ~nested)
+             t |> resolve_nested ?type_arg_context ~env ~state ~full ~nested)
     | NVariantPayload {constructor_name; item_num}, Tvariant {env; constructors}
       -> (
       if Debug.verbose () then
@@ -724,19 +728,20 @@ let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
               (Shared.type_to_string typ);
 
           typ
-          |> extract_type ~env ~package:full.package
+          |> extract_type ~env ~state ~package:full.package
           |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
                  if Debug.verbose () then
                    Printf.printf
                      "[nested]--> extracted %s, continuing descent of %i items\n"
                      (extracted_type_to_string typ)
                      (List.length nested);
-                 typ |> resolve_nested ?type_arg_context ~env ~full ~nested))
+                 typ
+                 |> resolve_nested ?type_arg_context ~env ~state ~full ~nested))
       | Some {args = InlineRecord fields} when item_num = 0 ->
         if Debug.verbose () then
           print_endline "[nested]--> found constructor (inline record)";
         TinlineRecord {env; fields}
-        |> resolve_nested ?type_arg_context ~env ~full ~nested
+        |> resolve_nested ?type_arg_context ~env ~state ~full ~nested
       | _ -> None)
     | ( NPolyvariantPayload {constructor_name; item_num},
         Tpolyvariant {env; constructors} ) -> (
@@ -751,16 +756,18 @@ let rec resolve_nested ?type_arg_context ~env ~full ~nested ?ctx
         | None -> None
         | Some typ ->
           typ
-          |> extract_type ~env ~package:full.package
+          |> extract_type ~env ~state ~package:full.package
           |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
-                 typ |> resolve_nested ?type_arg_context ~env ~full ~nested)))
+                 typ
+                 |> resolve_nested ?type_arg_context ~env ~state ~full ~nested))
+      )
     | NArray, Tarray (env, ExtractedType typ) ->
-      typ |> resolve_nested ?type_arg_context ~env ~full ~nested
+      typ |> resolve_nested ?type_arg_context ~env ~state ~full ~nested
     | NArray, Tarray (env, TypeExpr typ) ->
       typ
-      |> extract_type ~env ~package:full.package
+      |> extract_type ~env ~state ~package:full.package
       |> Utils.Option.flat_map (fun (typ, type_arg_context) ->
-             typ |> resolve_nested ?type_arg_context ~env ~full ~nested)
+             typ |> resolve_nested ?type_arg_context ~env ~state ~full ~nested)
     | _ -> None)
 
 let find_type_of_record_field fields ~field_name =
@@ -799,12 +806,13 @@ let find_type_of_polyvariant_arg constructors ~constructor_name ~payload_num =
     | Some typ -> Some typ)
   | None -> None
 
-let rec resolve_nested_pattern_path (typ : inner_type) ~env ~full ~nested =
+let rec resolve_nested_pattern_path (typ : inner_type) ~env ~full ~state ~nested
+    =
   if Debug.verbose () then print_endline "[nested_pattern_path]";
   let t =
     match typ with
     | TypeExpr t ->
-      t |> extract_type ~env ~package:full.package |> get_extracted_type
+      t |> extract_type ~env ~state ~package:full.package |> get_extracted_type
     | ExtractedType t -> Some t
   in
   match nested with
@@ -863,21 +871,21 @@ let rec resolve_nested_pattern_path (typ : inner_type) ~env ~full ~nested =
         | None -> None
         | Some typ ->
           typ
-          |> extract_type ~env ~package:full.package
+          |> extract_type ~env ~state ~package:full.package
           |> get_extracted_type
           |> Utils.Option.flat_map (fun typ ->
                  ExtractedType typ
-                 |> resolve_nested_pattern_path ~env ~full ~nested))
+                 |> resolve_nested_pattern_path ~env ~state ~full ~nested))
       | NTupleItem {item_num}, Tuple (env, tuple_items, _) -> (
         match List.nth_opt tuple_items item_num with
         | None -> None
         | Some typ ->
           typ
-          |> extract_type ~env ~package:full.package
+          |> extract_type ~env ~state ~package:full.package
           |> get_extracted_type
           |> Utils.Option.flat_map (fun typ ->
                  ExtractedType typ
-                 |> resolve_nested_pattern_path ~env ~full ~nested))
+                 |> resolve_nested_pattern_path ~env ~state ~full ~nested))
       | ( NVariantPayload {constructor_name; item_num},
           Tvariant {env; constructors} ) -> (
         match
@@ -885,7 +893,8 @@ let rec resolve_nested_pattern_path (typ : inner_type) ~env ~full ~nested =
           |> find_type_of_constructor_arg ~constructor_name
                ~payload_num:item_num ~env
         with
-        | Some typ -> typ |> resolve_nested_pattern_path ~env ~full ~nested
+        | Some typ ->
+          typ |> resolve_nested_pattern_path ~env ~state ~full ~nested
         | None -> None)
       | ( NPolyvariantPayload {constructor_name; item_num},
           Tpolyvariant {env; constructors} ) -> (
@@ -895,22 +904,24 @@ let rec resolve_nested_pattern_path (typ : inner_type) ~env ~full ~nested =
                ~payload_num:item_num
         with
         | Some typ ->
-          TypeExpr typ |> resolve_nested_pattern_path ~env ~full ~nested
+          TypeExpr typ |> resolve_nested_pattern_path ~env ~state ~full ~nested
         | None -> None)
       | ( NVariantPayload {constructor_name = "Some"; item_num = 0},
           Toption (env, typ) ) ->
-        typ |> resolve_nested_pattern_path ~env ~full ~nested
+        typ |> resolve_nested_pattern_path ~env ~state ~full ~nested
       | ( NVariantPayload {constructor_name = "Ok"; item_num = 0},
           Tresult {env; ok_type} ) ->
-        TypeExpr ok_type |> resolve_nested_pattern_path ~env ~full ~nested
+        TypeExpr ok_type
+        |> resolve_nested_pattern_path ~env ~state ~full ~nested
       | ( NVariantPayload {constructor_name = "Error"; item_num = 0},
           Tresult {env; error_type} ) ->
-        TypeExpr error_type |> resolve_nested_pattern_path ~env ~full ~nested
+        TypeExpr error_type
+        |> resolve_nested_pattern_path ~env ~state ~full ~nested
       | NArray, Tarray (env, typ) ->
-        typ |> resolve_nested_pattern_path ~env ~full ~nested
+        typ |> resolve_nested_pattern_path ~env ~state ~full ~nested
       | _ -> None))
 
-let get_args ~env (t : Types.type_expr) ~full =
+let get_args ~env (t : Types.type_expr) ~full ~state =
   let rec get_args_loop ~env (t : Types.type_expr) ~full
       ~current_argument_position =
     match t.desc with
@@ -928,7 +939,9 @@ let get_args ~env (t : Types.type_expr) ~full =
            ~current_argument_position:(current_argument_position + 1)
            t_ret
     | Tconstr (path, type_args, _) -> (
-      match References.dig_constructor ~env ~package:full.package path with
+      match
+        References.dig_constructor ~env ~state ~package:full.package path
+      with
       | Some (env, {item = {decl = {type_manifest = Some t1; type_params}}}) ->
         let t1 = t1 |> instantiate_type ~type_params ~type_args in
         get_args_loop ~full ~env ~current_argument_position t1
@@ -984,7 +997,8 @@ module Codegen = struct
 
   let any () = Ast_helper.Pat.any ()
 
-  let rec extracted_type_to_exhaustive_patterns ~env ~full extracted_type =
+  let rec extracted_type_to_exhaustive_patterns ~env ~full ~state extracted_type
+      =
     match extracted_type with
     | Tvariant v ->
       Some
@@ -1011,14 +1025,15 @@ module Codegen = struct
         match inner_type with
         | ExtractedType t -> Some t
         | TypeExpr t ->
-          extract_type t ~env ~package:full.package |> get_extracted_type
+          extract_type t ~env ~state ~package:full.package |> get_extracted_type
       in
       let expanded_branches =
         match extracted_type with
         | None -> []
         | Some extracted_type -> (
           match
-            extracted_type_to_exhaustive_patterns ~env ~full extracted_type
+            extracted_type_to_exhaustive_patterns ~env ~state ~full
+              extracted_type
           with
           | None -> []
           | Some patterns -> patterns)
@@ -1033,11 +1048,13 @@ module Codegen = struct
                  mk_construct_pat ~payload:pat "Some")))
     | Tresult {ok_type; error_type} ->
       let extracted_ok_type =
-        ok_type |> extract_type ~env ~package:full.package |> get_extracted_type
+        ok_type
+        |> extract_type ~env ~state ~package:full.package
+        |> get_extracted_type
       in
       let extracted_error_type =
         error_type
-        |> extract_type ~env ~package:full.package
+        |> extract_type ~env ~state ~package:full.package
         |> get_extracted_type
       in
       let expanded_ok_branches =
@@ -1045,7 +1062,8 @@ module Codegen = struct
         | None -> []
         | Some extracted_type -> (
           match
-            extracted_type_to_exhaustive_patterns ~env ~full extracted_type
+            extracted_type_to_exhaustive_patterns ~env ~state ~full
+              extracted_type
           with
           | None -> []
           | Some patterns -> patterns)
@@ -1055,7 +1073,8 @@ module Codegen = struct
         | None -> []
         | Some extracted_type -> (
           match
-            extracted_type_to_exhaustive_patterns ~env ~full extracted_type
+            extracted_type_to_exhaustive_patterns ~env ~state ~full
+              extracted_type
           with
           | None -> []
           | Some patterns -> patterns)
@@ -1070,9 +1089,9 @@ module Codegen = struct
     | Tbool _ -> Some [mk_construct_pat "true"; mk_construct_pat "false"]
     | _ -> None
 
-  let extracted_type_to_exhaustive_cases ~env ~full extracted_type =
+  let extracted_type_to_exhaustive_cases ~env ~state ~full extracted_type =
     let patterns =
-      extracted_type_to_exhaustive_patterns ~env ~full extracted_type
+      extracted_type_to_exhaustive_patterns ~env ~state ~full extracted_type
     in
 
     match patterns with
@@ -1137,8 +1156,8 @@ let path_to_element_props package =
 
 module String_set = Set.Make (String)
 
-let get_extra_modules_to_complete_from_for_type ~env ~full (t : Types.type_expr)
-    =
+let get_extra_modules_to_complete_from_for_type ~env ~state ~full
+    (t : Types.type_expr) =
   let found_module_paths = ref String_set.empty in
   let add_to_module_paths attributes =
     Process_attributes.find_editor_complete_from_attribute attributes
@@ -1149,7 +1168,9 @@ let get_extra_modules_to_complete_from_for_type ~env ~full (t : Types.type_expr)
   let rec inner ~env ~full (t : Types.type_expr) =
     match t |> Shared.dig_constructor with
     | Some path -> (
-      match References.dig_constructor ~env ~package:full.package path with
+      match
+        References.dig_constructor ~env ~state ~package:full.package path
+      with
       | None -> ()
       | Some (env, {item = {decl = {type_manifest = Some t}; attributes}}) ->
         add_to_module_paths attributes;
@@ -1161,9 +1182,9 @@ let get_extra_modules_to_complete_from_for_type ~env ~full (t : Types.type_expr)
   !found_module_paths |> String_set.elements
   |> List.map (fun l -> String.split_on_char '.' l)
 
-let get_first_fn_unlabelled_arg_type ~env ~full t =
+let get_first_fn_unlabelled_arg_type ~env ~state ~full t =
   let labels, _, env =
-    extract_function_type_with_env ~env ~package:full.package t
+    extract_function_type_with_env ~env ~state ~package:full.package t
   in
   let rec find_first_unlabelled_arg_type labels =
     match labels with
@@ -1215,20 +1236,21 @@ let transform_completion_to_pipe_completion ?(synthetic = false) ~env
     id for that specific type. The globally unique id is the full path to the type as seen from the root
     of the project. Example: type x in module SomeModule in file SomeFile would get the globally
     unique id `SomeFile.SomeModule.x`.*)
-let rec find_root_type_id ~full ~env (t : Types.type_expr) =
+let rec find_root_type_id ~full ~env ~state (t : Types.type_expr) =
   let debug = false in
   match t.desc with
-  | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> find_root_type_id ~full ~env t1
+  | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
+    find_root_type_id ~full ~env ~state t1
   | Tconstr (path, _, _) -> (
     (* We have a path. Try to dig to its declaration *)
     if debug then
       Printf.printf "[findRootTypeId] path %s, dig\n" (Path.name path);
-    match References.dig_constructor ~env ~package:full.package path with
+    match References.dig_constructor ~env ~state ~package:full.package path with
     | Some (env, {item = {decl = {type_manifest = Some t1}}}) ->
       if debug then
         Printf.printf "[findRootTypeId] dug up type alias at module path %s \n"
           (module_path_from_env env |> String.concat ".");
-      find_root_type_id ~full ~env t1
+      find_root_type_id ~full ~env ~state t1
     | Some (env, {item = {name}; module_path}) ->
       (* if it's a named type, then we know its name will be its module path from the env + its name.*)
       if debug then
@@ -1252,8 +1274,8 @@ let rec find_root_type_id ~full ~env (t : Types.type_expr) =
   | _ -> None
 
 (** Filters out completions that are not pipeable from a list of completions. *)
-let filter_pipeable_functions ~env ~full ?synthetic ?target_type_id ?pos_of_dot
-    completions =
+let filter_pipeable_functions ~env ~state ~full ?synthetic ?target_type_id
+    ?pos_of_dot completions =
   match target_type_id with
   | None -> completions
   | Some target_type_id ->
@@ -1263,11 +1285,12 @@ let filter_pipeable_functions ~env ~full ?synthetic ?target_type_id ?pos_of_dot
              match completion.kind with
              | Value t -> (
                match
-                 get_first_fn_unlabelled_arg_type ~full ~env:completion.env t
+                 get_first_fn_unlabelled_arg_type ~full ~env:completion.env
+                   ~state t
                with
                | None -> None
                | Some (t, env_from_labelled_arg) ->
-                 find_root_type_id ~full ~env:env_from_labelled_arg t)
+                 find_root_type_id ~full ~env:env_from_labelled_arg ~state t)
              | _ -> None
            in
            match this_completion_item_type_id with

--- a/analysis/src/xform.ml
+++ b/analysis/src/xform.ml
@@ -32,7 +32,7 @@ let extract_type_from_expr ~state expr ~debug ~source ~kind_file ~full ~pos =
           match typ with
           | ExtractedType t -> Some t
           | TypeExpr t ->
-            Type_utils.extract_type t ~env ~package:full.package
+            Type_utils.extract_type t ~env ~package:full.package ~state
             |> Type_utils.get_extracted_type
         in
         extracted_type
@@ -480,7 +480,9 @@ module Expand_catch_all_for_variants = struct
           match inner_type with
           | ExtractedType t -> Some t
           | TypeExpr t -> (
-            match Type_utils.extract_type ~env ~package:full.package t with
+            match
+              Type_utils.extract_type ~env ~package:full.package t ~state
+            with
             | None -> None
             | Some (t, _) -> Some t)
         in
@@ -626,7 +628,7 @@ module Exhaustive_switch = struct
         let exhaustive_switch =
           extracted_type_to_exhaustive_cases
             ~env:(Shared_types.Query_env.from_file full.file)
-            ~full extracted_type
+            ~full ~state extracted_type
         in
         match exhaustive_switch with
         | None -> ()
@@ -651,7 +653,7 @@ module Exhaustive_switch = struct
         let exhaustive_switch =
           extracted_type_to_exhaustive_cases
             ~env:(Shared_types.Query_env.from_file full.file)
-            ~full extracted_type
+            ~full ~state extracted_type
         in
         match exhaustive_switch with
         | None -> ()

--- a/analysis/src/xform.ml
+++ b/analysis/src/xform.ml
@@ -2,7 +2,7 @@
 
 let is_braced_expr = Res_parsetree_viewer.is_braced_expr
 
-let extract_type_from_expr expr ~debug ~source ~kind_file ~full ~pos =
+let extract_type_from_expr ~state expr ~debug ~source ~kind_file ~full ~pos =
   match
     expr.Parsetree.pexp_loc
     |> Completion_front_end.find_type_of_expression_at_loc ~debug ~source
@@ -13,18 +13,18 @@ let extract_type_from_expr expr ~debug ~source ~kind_file ~full ~pos =
     let env = Shared_types.Query_env.from_file full.Shared_types.file in
     let completions =
       completable
-      |> Completion_back_end.process_completable ~debug ~full ~pos ~scope ~env
-           ~for_hover:true
+      |> Completion_back_end.process_completable ~state ~debug ~full ~pos ~scope
+           ~env ~for_hover:true
     in
     let raw_opens = Scope.get_raw_opens scope in
     match completions with
     | {env} :: _ -> (
       let opens =
-        Completion_back_end.get_opens ~debug ~raw_opens ~package:full.package
-          ~env
+        Completion_back_end.get_opens ~state ~debug ~raw_opens
+          ~package:full.package ~env
       in
       match
-        Completion_back_end.completions_get_completion_type2 ~debug ~full
+        Completion_back_end.completions_get_completion_type2 ~state ~debug ~full
           ~raw_opens ~opens ~pos completions
       with
       | Some (typ, _env) ->
@@ -385,8 +385,8 @@ module Expand_catch_all_for_variants = struct
     in
     {Ast_iterator.default_iterator with expr}
 
-  let xform ~source ~kind_file ~path ~pos ~full ~structure ~code_actions ~debug
-      =
+  let xform ~state ~source ~kind_file ~path ~pos ~full ~structure ~code_actions
+      ~debug =
     let result = ref None in
     let iterator = mk_iterator ~pos ~result in
     iterator.structure iterator structure;
@@ -421,7 +421,7 @@ module Expand_catch_all_for_variants = struct
       let current_constructor_names = get_current_constructor_names cases in
       match
         switch_expr
-        |> extract_type_from_expr ~debug ~source ~kind_file ~full
+        |> extract_type_from_expr ~state ~debug ~source ~kind_file ~full
              ~pos:(Pos.of_lexing switch_expr.pexp_loc.loc_end)
       with
       | Some (Tvariant {constructors}) ->
@@ -592,7 +592,7 @@ module Exhaustive_switch = struct
     in
     {Ast_iterator.default_iterator with expr}
 
-  let xform ~print_expr ~path ~source ~kind_file ~pos ~full ~structure
+  let xform ~state ~print_expr ~path ~source ~kind_file ~pos ~full ~structure
       ~code_actions ~debug =
     (* TODO: Adapt to '(' as leading/trailing character (skip one col, it's not included in the AST) *)
     let result = ref None in
@@ -617,7 +617,7 @@ module Exhaustive_switch = struct
     | Some (Selection {expr}) -> (
       match
         expr
-        |> extract_type_from_expr ~debug ~source ~kind_file ~full
+        |> extract_type_from_expr ~state ~debug ~source ~kind_file ~full
              ~pos:(Pos.of_lexing expr.pexp_loc.loc_start)
       with
       | None -> ()
@@ -643,7 +643,7 @@ module Exhaustive_switch = struct
     | Some (Switch {switch_expr; completion_expr; pos}) -> (
       match
         completion_expr
-        |> extract_type_from_expr ~debug ~source ~kind_file ~full ~pos
+        |> extract_type_from_expr ~state ~debug ~source ~kind_file ~full ~pos
       with
       | None -> ()
       | Some extracted_type -> (
@@ -912,7 +912,8 @@ let parse_interface ~source =
   in
   (structure, print_signature_item)
 
-let extract_code_actions ~path ~start_pos ~end_pos ~source ~kind_file ~debug =
+let extract_code_actions ~state ~path ~start_pos ~end_pos ~source ~kind_file
+    ~debug =
   let pos = start_pos in
   let code_actions = ref [] in
   match kind_file with
@@ -931,13 +932,13 @@ let extract_code_actions ~path ~start_pos ~end_pos ~source ~kind_file ~debug =
 
     (* This Code Action needs type info *)
     let () =
-      match Cmt.load_full_cmt_from_path ~path with
+      match Cmt.load_full_cmt_from_path ~state ~path with
       | Some full ->
         Add_type_annotation.xform ~path ~pos ~full ~structure ~code_actions
           ~debug;
-        Expand_catch_all_for_variants.xform ~path ~source ~kind_file ~pos ~full
-          ~structure ~code_actions ~debug;
-        Exhaustive_switch.xform ~print_expr ~path ~source ~kind_file
+        Expand_catch_all_for_variants.xform ~state ~path ~source ~kind_file ~pos
+          ~full ~structure ~code_actions ~debug;
+        Exhaustive_switch.xform ~state ~print_expr ~path ~source ~kind_file
           ~pos:
             (if start_pos = end_pos then Single start_pos
              else Range (start_pos, end_pos))

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -82,7 +82,8 @@ let main () =
     let root_path =
       if Filename.is_relative root then Unix.realpath root else root
     in
-    match Analysis.Packages.new_bs_package ~root_path with
+    let state = Analysis.Shared_types.create_state () in
+    match Analysis.Packages.new_bs_package ~state ~root_path with
     | None ->
       log_and_exit
         (Error

--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -82,8 +82,7 @@ let main () =
     let root_path =
       if Filename.is_relative root then Unix.realpath root else root
     in
-    let state = Analysis.Shared_types.create_state () in
-    match Analysis.Packages.new_bs_package ~state ~root_path with
+    match Analysis.Packages.new_bs_package ~root_path with
     | None ->
       log_and_exit
         (Error

--- a/tools/src/migrate.ml
+++ b/tools/src/migrate.ml
@@ -745,13 +745,14 @@ let migrate ~entry_point_file ~output_mode =
     | true -> Unix.realpath entry_point_file
     | false -> entry_point_file
   in
+  let state = Shared_types.create_state () in
   let result =
     if Filename.check_suffix path ".res" then
       let parser =
         Res_driver.parsing_engine.parse_implementation ~for_printer:true
       in
       let {Res_driver.parsetree; comments; source} = parser ~filename:path in
-      match Cmt.load_cmt_infos_from_path ~path with
+      match Cmt.load_cmt_infos_from_path ~state ~path with
       | None ->
         Error
           (Printf.sprintf
@@ -784,7 +785,7 @@ let migrate ~entry_point_file ~output_mode =
         parser ~filename:path
       in
 
-      match Cmt.load_cmt_infos_from_path ~path with
+      match Cmt.load_cmt_infos_from_path ~state ~path with
       | None ->
         Error
           (Printf.sprintf

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -278,9 +278,9 @@ let field_to_field_doc (field : Shared_types.field) : field_doc =
     deprecated = field.deprecated;
   }
 
-let type_detail typ ~env ~full =
+let type_detail typ ~env ~full ~state =
   let open Shared_types in
-  match Type_utils.extract_type_from_resolved_type ~env ~full typ with
+  match Type_utils.extract_type_from_resolved_type ~env ~full ~state typ with
   | Some (Trecord {fields}) ->
     Some (Record {field_docs = fields |> List.map field_to_field_doc})
   | Some (Tvariant {constructors}) ->
@@ -470,7 +470,7 @@ let extract_docs ~entry_point_file ~debug =
                                 typ.decl |> Shared.decl_to_string item.name;
                               name = item.name;
                               deprecated = item.deprecated;
-                              detail = type_detail typ ~full ~env;
+                              detail = type_detail typ ~full ~env ~state;
                               source;
                             })
                      | Module {type_ = Ident p; is_module_type = false} ->
@@ -482,7 +482,7 @@ let extract_docs ~entry_point_file ~debug =
                        let items, internal_docstrings =
                          match
                            Process_cmt.file_for_module ~package:full.package
-                             alias_to_module
+                             ~state alias_to_module
                          with
                          | None -> ([], [])
                          | Some file ->
@@ -554,7 +554,7 @@ let extract_docs ~entry_point_file ~debug =
                        let module_type_id_path =
                          match
                            Process_cmt.file_for_module ~package:full.package
-                             ident_module_path
+                             ~state ident_module_path
                            |> Option.is_none
                          with
                          | false -> []

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -379,6 +379,7 @@ let extract_docs ~entry_point_file ~debug =
     | true -> Unix.realpath entry_point_file
     | false -> entry_point_file
   in
+  let state = Shared_types.create_state () in
   if debug then Printf.printf "extracting docs for %s\n" path;
   let result =
     match
@@ -401,7 +402,7 @@ let extract_docs ~entry_point_file ~debug =
           else path
         else path
       in
-      match Cmt.load_full_cmt_from_path ~path with
+      match Cmt.load_full_cmt_from_path ~state ~path with
       | None ->
         Error
           (Printf.sprintf
@@ -1003,6 +1004,7 @@ module Extract_codeblocks = struct
 
   let extract_code_blocks ~entry_point_file
       ~(process_docstrings : id:string -> name:string -> string -> unit) =
+    let state = Shared_types.create_state () in
     let path =
       match Filename.is_relative entry_point_file with
       | true -> Unix.realpath entry_point_file
@@ -1024,7 +1026,7 @@ module Extract_codeblocks = struct
             if Sys.file_exists path_as_resi then path_as_resi else path
           else path
         in
-        match Cmt.load_full_cmt_from_path ~path with
+        match Cmt.load_full_cmt_from_path ~state ~path with
         | None ->
           Error
             (Printf.sprintf


### PR DESCRIPTION
The old global state kept shared mutable caches for: packages by root, URI to root mapping and CMT file cache. That is okay for short CLI calls, but bad for a long-running server because stale cached data can survive across unrelated requests, workspaces, or project changes. A server needs state scoped to the server lifecycle so caches can be isolated and eventually reset/recreated

- Removed the global `Shared_types.state`; added `Shared_types.create_state`.
- CLI creates one analysis state per invocation and passes it through `Cli`/`Commands`.

Cherry-pick of #8425 