### PR TITLE
Support v12 CMT files in analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix formatting of trailing comments before `=` in let bindings. https://github.com/rescript-lang/rescript/pull/8444
 - Fix analysis namespace parsing after the Yojson migration. https://github.com/rescript-lang/rescript/pull/8454
 - Fix namespaced reference lookup in editor analysis. https://github.com/rescript-lang/rescript/pull/8455
+- Fix analysis segmentation fault for references after https://github.com/rescript-lang/rescript/pull/7887. https://github.com/rescript-lang/rescript/pull/8477
 
 #### :memo: Documentation
 

--- a/compiler/ml/parsetree.ml
+++ b/compiler/ml/parsetree.ml
@@ -290,10 +290,6 @@ and expression_desc =
     (* for i = E1 to E2 do E3 done      (flag = Upto)
        for i = E1 downto E2 do E3 done  (flag = Downto)
     *)
-  | Pexp_for_of of pattern * expression * expression
-    (* for pattern of array_expr do body_expr *)
-  | Pexp_for_await_of of pattern * expression * expression
-    (* for await pattern of iterable_expr do body_expr *)
   | Pexp_constraint of expression * core_type (* (E : T) *)
   | Pexp_coerce of expression * unit * core_type
     (* (E :> T)        (None, T)
@@ -322,6 +318,10 @@ and expression_desc =
   (* . *)
   | Pexp_await of expression
   | Pexp_jsx_element of jsx_element
+  | Pexp_for_of of pattern * expression * expression
+    (* for pattern of array_expr do body_expr *)
+  | Pexp_for_await_of of pattern * expression * expression
+(* for await pattern of iterable_expr do body_expr *)
 
 (* an element of a record pattern or expression *)
 and 'a record_element = {lid: Longident.t loc; x: 'a; opt: bool (* optional *)}

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -119,14 +119,17 @@ and expression_desc =
       * expression
       * direction_flag
       * expression
-  | Texp_for_of of Ident.t * Parsetree.pattern * expression * expression
-  | Texp_for_await_of of Ident.t * Parsetree.pattern * expression * expression
   | Texp_send of expression * meth * expression option
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression
   | Texp_pack of module_expr
   | Texp_extension_constructor of Longident.t loc * Path.t
+  (* Keep new expression constructors at the end. CMT files are marshalled by
+     runtime constructor tag, so inserting constructors before existing ones
+     breaks analysis when it reads CMTs produced by older compiler versions. *)
+  | Texp_for_of of Ident.t * Parsetree.pattern * expression * expression
+  | Texp_for_await_of of Ident.t * Parsetree.pattern * expression * expression
 
 and meth = Tmeth_name of string
 

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -220,14 +220,17 @@ and expression_desc =
       * expression
       * direction_flag
       * expression
-  | Texp_for_of of Ident.t * Parsetree.pattern * expression * expression
-  | Texp_for_await_of of Ident.t * Parsetree.pattern * expression * expression
   | Texp_send of expression * meth * expression option
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression
   | Texp_pack of module_expr
   | Texp_extension_constructor of Longident.t loc * Path.t
+  (* Keep new expression constructors at the end. CMT files are marshalled by
+     runtime constructor tag, so inserting constructors before existing ones
+     breaks analysis when it reads CMTs produced by older compiler versions. *)
+  | Texp_for_of of Ident.t * Parsetree.pattern * expression * expression
+  | Texp_for_await_of of Ident.t * Parsetree.pattern * expression * expression
 
 and meth = Tmeth_name of string
 


### PR DESCRIPTION
## Summary

This fixes an analysis/LSP crash when a v13 analysis binary reads v12 `.cmt`/`.cmti` files.

It moves the new `for...of` typedtree and parsetree constructors to the end of their variants so v12 marshalled constructor tags remain stable.

## Root Cause

Editor analysis reads compiled `.cmt` files directly. Those files are OCaml `Marshal` payloads containing typedtree data, so variant constructors are decoded by their runtime constructor tag/index, not by constructor name.

The `for...of` implementation added new constructors in the middle of existing variants:

- `Texp_for_of`
- `Texp_for_await_of`
- `Pexp_for_of`
- `Pexp_for_await_of`

That shifted the numeric tags for existing constructors after `Texp_for` / `Pexp_for`. When v13 analysis accepted or tried to read v12 CMT files, an old constructor such as `Texp_send` could be decoded as `Texp_for_of`. The payload layout is different, so `Tast_iterator` could then read invalid values and segfault instead of raising a catchable OCaml exception.

## Why This Fix Works

Appending the new constructors preserves the tags and payload layout for every constructor that already existed in v12. That means v13 can safely read v12 CMTs for old syntax, while v13-generated artifacts can still use the new `for...of` constructors.

Close #8475 