### PR TITLE
Replace APT package cache action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Versions >1.4.3 interfere with caching done by our own CI script,
-      # causing the dune binary not to be found anymore.
-      - dependency-name: "awalsh128/cache-apt-pkgs-action"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,13 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        uses: gerlero/apt-install@v1.3.12
         with:
           # https://github.com/ocaml/setup-ocaml/blob/2f57267f071bc8547dfcb9433ff21d44fffef190/packages/setup-ocaml/src/unix.ts#L48
           # plus OPAM wants cmake
           packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
-          version: v4
+          install-recommends: false
+          upgrade: false
 
       - name: Restore rewatch build cache
         id: rewatch-build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,9 @@ jobs:
         with:
           # https://github.com/ocaml/setup-ocaml/blob/2f57267f071bc8547dfcb9433ff21d44fffef190/packages/setup-ocaml/src/unix.ts#L48
           # plus OPAM wants cmake
-          packages: bubblewrap g++-multilib gcc-multilib musl-tools rsync cmake
+          packages: >-
+            bubblewrap musl-tools rsync cmake
+            ${{ runner.arch == 'X64' && 'g++-multilib gcc-multilib' || '' }}
           install-recommends: false
           upgrade: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           # https://github.com/ocaml/setup-ocaml/blob/2f57267f071bc8547dfcb9433ff21d44fffef190/packages/setup-ocaml/src/unix.ts#L48
           # plus OPAM wants cmake
-          packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
+          packages: bubblewrap g++-multilib gcc-multilib musl-tools rsync cmake
           install-recommends: false
           upgrade: false
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Install system dependencies
         uses: gerlero/apt-install@v1.3.12
         with:
-          packages: bubblewrap g++-multilib gcc-multilib musl-tools rsync cmake
+          packages: >-
+            bubblewrap musl-tools rsync cmake
+            ${{ runner.arch == 'X64' && 'g++-multilib gcc-multilib' || '' }}
           install-recommends: false
           upgrade: false
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,10 +40,11 @@ jobs:
         run: yarn install
 
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        uses: gerlero/apt-install@v1.3.12
         with:
           packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
-          version: v4
+          install-recommends: false
+          upgrade: false
 
       # --- rewatch build cache ---------------------------------------------
       # `make coverage` shells out to `make` which builds rewatch; cache the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install system dependencies
         uses: gerlero/apt-install@v1.3.12
         with:
-          packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
+          packages: bubblewrap g++-multilib gcc-multilib musl-tools rsync cmake
           install-recommends: false
           upgrade: false
 


### PR DESCRIPTION
## Summary

- replace `awalsh128/cache-apt-pkgs-action` with `gerlero/apt-install`
- keep recommended packages and upgrades disabled for predictable CI environments
- remove the obsolete Dependabot exclusion for the previous action

## Why

The previous action transitively uses `actions/cache@v4`, which targets the deprecated Node.js 20 runtime. Newer releases of that action have repeatedly broken this repository's Dune setup. `gerlero/apt-install@v1.3.12` caches downloaded Debian packages using `actions/cache@v6` and installs them through dpkg.

## Validation

- parsed the modified workflow and Dependabot YAML files
- ran `git diff --cached --check`
- verified the pinned action uses `actions/cache/restore@v6` and `actions/cache/save@v6`
