### PR TITLE
Remove inactive maintainer from package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/darwin-arm64/package.json
+++ b/packages/@rescript/darwin-arm64/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/darwin-x64/package.json
+++ b/packages/@rescript/darwin-x64/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/linux-arm64/package.json
+++ b/packages/@rescript/linux-arm64/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/linux-x64/package.json
+++ b/packages/@rescript/linux-x64/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/runtime/package.json
+++ b/packages/@rescript/runtime/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/packages/@rescript/win32-x64/package.json
+++ b/packages/@rescript/win32-x64/package.json
@@ -19,7 +19,6 @@
     "Cristiano Calcagno (https://github.com/cristianoc)",
     "Dmitry Zakharov (https://github.com/DZakh)",
     "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-    "Florian Verdonck (https://github.com/nojaf)",
     "Gabriel Nordeborn (https://github.com/zth)",
     "Hyeseong Kim (https://github.com/cometkim)",
     "Jaap Frolich (https://github.com/jfrolich)",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -38,7 +38,6 @@ async function enforceCompilerMeta({ Yarn }) {
         "Cristiano Calcagno (https://github.com/cristianoc)",
         "Dmitry Zakharov (https://github.com/DZakh)",
         "Florian Hammerschmidt (https://github.com/fhammerschmidt)",
-        "Florian Verdonck (https://github.com/nojaf)",
         "Gabriel Nordeborn (https://github.com/zth)",
         "Hyeseong Kim (https://github.com/cometkim)",
         "Jaap Frolich (https://github.com/jfrolich)",


### PR DESCRIPTION
Remove Florian Verdonck (`@nojaf`) from the maintainer lists in the root package, runtime package, platform packages, and Yarn metadata configuration.

He is no longer active in the ReScript community and should therefore no longer be listed as a current maintainer.