### PR TITLE
Stop tools tests on unexpected failures

### DIFF
--- a/tests/tools_tests/test.sh
+++ b/tests/tools_tests/test.sh
@@ -1,10 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 shopt -s nullglob
 
 for file in src/*.{res,resi}; do
   output="$(dirname $file)/expected/$(basename $file).json"
   ../../_build/install/default/bin/rescript-tools doc $file > $output
   # # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
-  if [ "$RUNNER_OS" == "Windows" ]; then
+  if [ "${RUNNER_OS:-}" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output
   fi
 done
@@ -12,7 +16,7 @@ done
 for file in ppx/*.res; do
   output="src/expected/$(basename $file).jsout"
   ../../cli/bsc.js -ppx "../../_build/install/default/bin/rescript-tools ppx" $file > $output
-  if [ "$RUNNER_OS" == "Windows" ]; then
+  if [ "${RUNNER_OS:-}" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output
   fi
 done
@@ -20,8 +24,15 @@ done
 # Test format-codeblocks command
 for file in src/docstrings-format/*.{res,resi,md}; do
   output="src/expected/$(basename $file).expected"
-  ../../_build/install/default/bin/rescript-tools format-codeblocks "$file" --stdout > $output
-  if [ "$RUNNER_OS" == "Windows" ]; then
+  if [ "$(basename "$file")" == "FormatDocstringsTestError.res" ]; then
+    if ../../_build/install/default/bin/rescript-tools format-codeblocks "$file" --stdout > "$output" 2>/dev/null; then
+      echo "Expected format-codeblocks to fail for $file" >&2
+      exit 1
+    fi
+  else
+    ../../_build/install/default/bin/rescript-tools format-codeblocks "$file" --stdout > "$output"
+  fi
+  if [ "${RUNNER_OS:-}" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output
   fi
 done
@@ -29,8 +40,15 @@ done
 # Test extract-codeblocks command
 for file in src/docstrings-format/*.{res,resi,md}; do
   output="src/expected/$(basename $file).extracted.json.expected"
-  ../../_build/install/default/bin/rescript-tools extract-codeblocks "$file" --transform-assert-equal > $output
-  if [ "$RUNNER_OS" == "Windows" ]; then
+  if [ "$(basename "$file")" == "FormatDocstringsTestError.res" ]; then
+    if ../../_build/install/default/bin/rescript-tools extract-codeblocks "$file" --transform-assert-equal > "$output" 2>/dev/null; then
+      echo "Expected extract-codeblocks to fail for $file" >&2
+      exit 1
+    fi
+  else
+    ../../_build/install/default/bin/rescript-tools extract-codeblocks "$file" --transform-assert-equal > "$output"
+  fi
+  if [ "${RUNNER_OS:-}" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output
   fi
 done
@@ -39,7 +57,7 @@ done
 for file in src/migrate/*.{res,resi}; do
   output="src/expected/$(basename $file).expected"
   ../../_build/install/default/bin/rescript-tools migrate "$file" --stdout > $output
-  if [ "$RUNNER_OS" == "Windows" ]; then
+  if [ "${RUNNER_OS:-}" == "Windows" ]; then
     perl -pi -e 's/\r\n/\n/g' -- $output
   fi
 done


### PR DESCRIPTION
## Summary

- make the tools test script stop on unexpected command failures
- handle the intentionally invalid docstring fixture as an expected failure for both `format-codeblocks` and `extract-codeblocks`
- allow the script to run when `RUNNER_OS` is unset

## Why

The invalid docstring fixture correctly makes the tools commands exit with a non-zero status. The test script previously ignored those statuses and continued, so `make test-all` printed a prominent syntax error while still treating the tools suite as successful. The same behavior could also hide genuinely unexpected command failures.

The negative fixture is now asserted explicitly: the suite fails if either command unexpectedly succeeds, while all other failures stop the script immediately.

## Testing

- verified the formatter and extractor fail for `FormatDocstringsTestError.res` and produce the checked-in expected output
- `make -C tests/tools_tests test`
- `bash -n tests/tools_tests/test.sh`
