### PR TITLE
Fix exponentiation precedence for compound exponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 #### :bug: Bug fix
 
+- Preserve parentheses around multiplication, division, and modulo expressions used as exponents. https://github.com/rescript-lang/rescript/pull/8550
 - Preserve multibyte characters when wrapping long source lines in compiler code frames. https://github.com/rescript-lang/rescript/pull/8520
 - Fix reanalyze optional-argument diagnostics for functions passed or returned as first-class values. https://github.com/rescript-lang/rescript/pull/8321
 

--- a/compiler/core/js_op_util.ml
+++ b/compiler/core/js_op_util.ml
@@ -41,7 +41,7 @@ let op_prec (op : Js_op.binop) =
   | Lsl | Lsr | Asr -> (10, 10, 11)
   | Bnot | Plus | Minus -> (11, 11, 12)
   | Mul | Div | Mod -> (12, 12, 13)
-  | Pow -> (13, 14, 12)
+  | Pow -> (13, 14, 13)
 
 let op_int_prec (op : Js_op.int_op) =
   match op with

--- a/tests/tests/src/exponentiation_test.mjs
+++ b/tests/tests/src/exponentiation_test.mjs
@@ -7,25 +7,49 @@ let intPow = ((a, b) => Math.pow(a, b) | 0);
 
 let four = 4;
 
+function floatPowDiv(base, numerator, denominator) {
+  return base ** (numerator / denominator);
+}
+
+function floatPowMul(base, left, right) {
+  return base ** (left * right);
+}
+
+function floatPowMod(base, value, modulus) {
+  return base ** (value % modulus);
+}
+
+function bigintPowMul(base, left, right) {
+  return base ** (left * right);
+}
+
 Mocha.describe("Exponentiation_test", () => {
   Mocha.test("exponentiation operations", () => {
-    Test_utils.eq("File \"exponentiation_test.res\", line 11, characters 7-14", 2 ** 3 ** 2, Math.pow(2, Math.pow(3, 2)));
-    Test_utils.eq("File \"exponentiation_test.res\", line 12, characters 7-14", 2 ** (-3) ** 2, Math.pow(2, Math.pow(-3, 2)));
-    Test_utils.eq("File \"exponentiation_test.res\", line 13, characters 7-14", (2 ** 3) ** 2, Math.pow(Math.pow(2, 3), 2));
-    Test_utils.eq("File \"exponentiation_test.res\", line 14, characters 7-14", (-2) ** 2, Math.pow(-2, 2));
-    Test_utils.eq("File \"exponentiation_test.res\", line 16, characters 7-14", 512, intPow(2, intPow(3, 2)));
-    Test_utils.eq("File \"exponentiation_test.res\", line 17, characters 7-14", 512, intPow(2, intPow(-3, 2)));
-    Test_utils.eq("File \"exponentiation_test.res\", line 18, characters 7-14", 64, intPow(intPow(2, 3), 2));
-    Test_utils.eq("File \"exponentiation_test.res\", line 19, characters 7-14", -2147483648, intPow(-2, 31));
-    Test_utils.eq("File \"exponentiation_test.res\", line 20, characters 7-14", 0, intPow(2, 32));
-    Test_utils.eq("File \"exponentiation_test.res\", line 21, characters 7-14", 0, intPow(2147483647, 2));
-    Test_utils.eq("File \"exponentiation_test.res\", line 22, characters 7-14", 0, intPow(-2147483648, 2));
-    Test_utils.eq("File \"exponentiation_test.res\", line 24, characters 7-14", 256, four ** four | 0);
+    Test_utils.eq("File \"exponentiation_test.res\", line 17, characters 7-14", 2 ** 3 ** 2, Math.pow(2, Math.pow(3, 2)));
+    Test_utils.eq("File \"exponentiation_test.res\", line 18, characters 7-14", 2 ** (-3) ** 2, Math.pow(2, Math.pow(-3, 2)));
+    Test_utils.eq("File \"exponentiation_test.res\", line 19, characters 7-14", (2 ** 3) ** 2, Math.pow(Math.pow(2, 3), 2));
+    Test_utils.eq("File \"exponentiation_test.res\", line 20, characters 7-14", (-2) ** 2, Math.pow(-2, 2));
+    Test_utils.eq("File \"exponentiation_test.res\", line 22, characters 7-14", 512, intPow(2, intPow(3, 2)));
+    Test_utils.eq("File \"exponentiation_test.res\", line 23, characters 7-14", 512, intPow(2, intPow(-3, 2)));
+    Test_utils.eq("File \"exponentiation_test.res\", line 24, characters 7-14", 64, intPow(intPow(2, 3), 2));
+    Test_utils.eq("File \"exponentiation_test.res\", line 25, characters 7-14", -2147483648, intPow(-2, 31));
+    Test_utils.eq("File \"exponentiation_test.res\", line 26, characters 7-14", 0, intPow(2, 32));
+    Test_utils.eq("File \"exponentiation_test.res\", line 27, characters 7-14", 0, intPow(2147483647, 2));
+    Test_utils.eq("File \"exponentiation_test.res\", line 28, characters 7-14", 0, intPow(-2147483648, 2));
+    Test_utils.eq("File \"exponentiation_test.res\", line 30, characters 7-14", 256, four ** four | 0);
+    Test_utils.eq("File \"exponentiation_test.res\", line 32, characters 7-14", 2 ** (0 / 10000), 1);
+    Test_utils.eq("File \"exponentiation_test.res\", line 33, characters 7-14", 2 ** (3 * 4), 4096);
+    Test_utils.eq("File \"exponentiation_test.res\", line 34, characters 7-14", 2 ** (5 % 3), 4);
+    Test_utils.eq("File \"exponentiation_test.res\", line 35, characters 7-14", 2n ** (3n * 2n), 64n);
   });
 });
 
 export {
   intPow,
   four,
+  floatPowDiv,
+  floatPowMul,
+  floatPowMod,
+  bigintPowMul,
 }
 /*  Not a pure module */

--- a/tests/tests/src/exponentiation_test.res
+++ b/tests/tests/src/exponentiation_test.res
@@ -6,6 +6,12 @@ external jsPow: (float, float) => float = "Math.pow"
 let intPow: (int, int) => int = %raw(`(a, b) => Math.pow(a, b) | 0`)
 let four: int = %raw(`4`)
 
+let floatPowDiv = (base: float, numerator: float, denominator: float) =>
+  base ** (numerator /. denominator)
+let floatPowMul = (base: float, left: float, right: float) => base ** (left *. right)
+let floatPowMod = (base: float, value: float, modulus: float) => base ** (value % modulus)
+let bigintPowMul = (base: bigint, left: bigint, right: bigint) => base ** (left * right)
+
 describe(__MODULE__, () => {
   test("exponentiation operations", () => {
     eq(__LOC__, 2. ** 3. ** 2., jsPow(2., jsPow(3., 2.)))
@@ -22,5 +28,10 @@ describe(__MODULE__, () => {
     eq(__LOC__, -2147483648 ** 2, intPow(-2147483648, 2))
 
     eq(__LOC__, 4 ** 4, four ** four)
+
+    eq(__LOC__, floatPowDiv(2., 0., 10000.), 1.)
+    eq(__LOC__, floatPowMul(2., 3., 4.), 4096.)
+    eq(__LOC__, floatPowMod(2., 5., 3.), 4.)
+    eq(__LOC__, bigintPowMul(2n, 3n, 2n), 64n)
   })
 })


### PR DESCRIPTION
Fixes #8549.

## Summary

- Preserve parentheses around multiplication, division, and modulo expressions used as the right operand of exponentiation.
- Add regression coverage for float multiplication, division, and modulo, plus bigint multiplication.

## Root cause

The JavaScript printer assigned exponentiation a right-operand precedence of 12, equal to multiplication, division, and modulo. Because parentheses are only added when the required precedence is greater than the child expression's precedence, expressions such as `a ** (b / c)` were emitted as `a ** b / c`, changing their meaning.

Requiring precedence 13 on the right preserves compound exponents while retaining JavaScript's right-associative `a ** b ** c` output.

## Regression history and backport

This regression was introduced by #7153 when float and integer exponentiation switched from `Math.pow` calls to native JavaScript `**`.

The change was included in ReScript 12.0.0, so all 12.x releases are affected. This fix should therefore be backported to the maintained 12.x release branch.

## Validation

- `make test`
- `make test-syntax`
- `make checkformat`
- `git diff --check`
