### PR TITLE
Prevent stale developer playground PR previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Preserve parentheses around multiplication, division, and modulo expressions used as exponents. https://github.com/rescript-lang/rescript/pull/8550
 - Preserve multibyte characters when wrapping long source lines in compiler code frames. https://github.com/rescript-lang/rescript/pull/8520
 - Fix reanalyze optional-argument diagnostics for functions passed or returned as first-class values. https://github.com/rescript-lang/rescript/pull/8321
+- Prevent the developer playground from loading stale compiler and library assets after PR preview updates. https://github.com/rescript-lang/rescript/pull/8556
 
 #### :memo: Documentation
 

--- a/packages/dev-playground/src/CompilerApi.res
+++ b/packages/dev-playground/src/CompilerApi.res
@@ -171,6 +171,14 @@ let isConfiguredVersion = version =>
 let isLoadableVersion = version =>
   version->isConfiguredVersion || version->previewVersionRoot->Option.isSome
 
+// A PR preview URL is reused after every push, while the CDN caches its assets.
+let previewCacheBust = Date.now()->Float.toString
+
+let versionAssetUrl = (version, path) => {
+  let url = `${versionRoot(version)}/${path}`
+  version->isPreviewVersion ? `${url}?cacheBust=${previewCacheBust}` : url
+}
+
 let selectableCompilerVersions = activeVersion =>
   if activeVersion->isConfiguredVersion || !(activeVersion->previewVersionRoot->Option.isSome) {
     availableCompilerVersions
@@ -362,16 +370,20 @@ let loadRuntimeLibraries = async version => {
   switch activeLibraryVersion.contents {
   | Some(activeVersion) if activeVersion === selectedVersion => ()
   | _ =>
-    let root = versionRoot(selectedVersion)
-    let _ = await loadScript(`${root}/compiler-builtins/cmij.js`, ~cache=false)
+    let _ = await loadScript(
+      versionAssetUrl(selectedVersion, "compiler-builtins/cmij.js"),
+      ~cache=false,
+    )
 
     let libraries = try {
-      let _ = await loadScript(`${root}/@rescript/react/cmij.js`, ~cache=false)
+      let _ = await loadScript(
+        versionAssetUrl(selectedVersion, "@rescript/react/cmij.js"),
+        ~cache=false,
+      )
       ["compiler-builtins", "@rescript/react"]
     } catch {
     | _ => ["compiler-builtins"]
     }
-
     loadedLibrariesByVersion->Map.set(selectedVersion, libraries)
     activeLibraryVersion := Some(selectedVersion)
   }
@@ -389,8 +401,7 @@ let ensureCompilerApi = async version => {
     await loadRuntimeLibraries(selectedVersion)
     compilerApis->getMapValueOrThrow(selectedVersion, "Compiler API was not cached")
   } else {
-    let root = versionRoot(selectedVersion)
-    await loadScript(`${root}/compiler.js`)
+    await loadScript(versionAssetUrl(selectedVersion, "compiler.js"))
     let api = switch Api.global {
     | Some(api) if hasFunction(api, "make") => api
     | _ => JsError.throwWithMessage("rescript_compiler global was not registered by compiler.js")


### PR DESCRIPTION
## Summary

Add a per-page cache-busting parameter to compiler and library assets loaded for PR previews.

Configured compiler versions and local bundles retain their existing cache behavior.

## Motivation

PR preview bundles are uploaded repeatedly to the same URLs. Because the CDN caches these assets for several hours, the developer playground can continue loading an older compiler or library bundle after a successful upload.

The existing `cache=false` option only bypasses the playground's in-memory script cache; it does not bypass the browser or CDN cache.

## Verification

- Ran `yarn workspace dev-playground build`.
- Built the playground with the preview CDN configured.
- Loaded a deployed PR bundle and confirmed that the compiler, built-in library, and React library URLs share a per-page `cacheBust` parameter.
- Confirmed that the playground initializes and compiles successfully.
