### PR TITLE
Sync platform npm binaries via dune promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,8 +162,8 @@ jobs:
             _build
           key: ${{ steps.compiler-build-state-key.outputs.value }}
 
-      - name: Copy compiler exes to platform bin dir
-        run: node scripts/copyExes.js --compiler
+      - name: Verify promoted compiler exes
+        run: node scripts/checkCompilerExes.js
 
       - name: "Syntax: Run tests"
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 #### :house: Internal
 
+- Sync the platform npm package's compiler binaries (`packages/@rescript/<platform>/bin`) via dune promotion on every `dune build`, instead of Makefile/CI copy steps that only ran when make did: a plain `dune build` can no longer leave `cli/*.js` and the test harnesses running a stale compiler. https://github.com/rescript-lang/rescript/pull/8560
 - Remove unused compiler IR definitions, modules, helpers, error variants, and Typedtree fields. https://github.com/rescript-lang/rescript/pull/8551 https://github.com/rescript-lang/rescript/pull/8555
 - Add the `-check-lam` compiler option, enable Lambda invariant checking in compiler tests, and remove build-profile-dependent checking. https://github.com/rescript-lang/rescript/pull/8534
 - Replace `-bs-diagnose` with `-debug-ir` and make IR diagnostic artifacts deterministic, compilation-local, and easy to clean. https://github.com/rescript-lang/rescript/pull/8535

--- a/Makefile
+++ b/Makefile
@@ -102,24 +102,26 @@ COMPILER_SOURCE_DIRS := compiler tests analysis tools
 COMPILER_SOURCES = $(shell find $(COMPILER_SOURCE_DIRS) -type f \( -name '*.ml' -o -name '*.mli' -o -name '*.dune' -o -name dune -o -name dune-project \))
 COMPILER_BIN_NAMES := bsc rescript-editor-analysis rescript-tools
 COMPILER_EXES := $(addsuffix .exe,$(addprefix $(BIN_DIR)/,$(COMPILER_BIN_NAMES)))
-COMPILER_DUNE_BINS := $(addsuffix $(PLATFORM_EXE_EXT),$(addprefix $(DUNE_BIN_DIR)/,$(COMPILER_BIN_NAMES)))
 
 compiler: $(COMPILER_EXES)
 
-define MAKE_COMPILER_COPY_RULE
-$(BIN_DIR)/$(1).exe: $(DUNE_BIN_DIR)/$(1)$(PLATFORM_EXE_EXT)
-	$$(call COPY_EXE,$$<,$$@)
-endef
-
-$(foreach bin,$(COMPILER_BIN_NAMES),$(eval $(call MAKE_COMPILER_COPY_RULE,$(bin))))
-
-# "touch" after dune build to make sure that the binaries' timestamps are updated
-# even if the actual content of the sources hasn't changed.
+# The compiler binaries in $(BIN_DIR) are produced by dune itself: the
+# promotion rules in compiler/sync/dune copy (and strip) them into the
+# platform npm package on every `dune build`, comparing content so unchanged
+# binaries are not rewritten. Make only needs to know that running dune
+# produces them.
 $(COMPILER_BUILD_STAMP): $(COMPILER_SOURCES)
 	dune build
-	@$(foreach bin,$(COMPILER_DUNE_BINS),touch $(bin);)
 
-$(COMPILER_DUNE_BINS): $(COMPILER_BUILD_STAMP) ;
+$(COMPILER_EXES): $(COMPILER_BUILD_STAMP)
+	@cmp -s $@ _build/default/compiler/sync/$(@F) || { \
+	  rm -f _build/default/compiler/sync/$(@F); dune build; }
+	@cmp -s $@ _build/default/compiler/sync/$(@F) || { \
+	  echo "Error: $@ is missing or does not match the dune build output."; \
+	  echo "Dune promotion did not produce it; check that this platform is"; \
+	  echo "covered by a rule in compiler/sync/dune."; \
+	  exit 1; }
+	@test -x $@ || chmod 755 $@
 
 clean-compiler:
 	dune clean && rm -f $(COMPILER_EXES) $(COMPILER_BUILD_STAMP)
@@ -270,7 +272,6 @@ COVERAGE_TEST_ENV := BISECT_FILE=$(COVERAGE_BISECT_PREFIX) BISECT_SILENT=YES
 .PHONY: coverage-build
 coverage-build: | $(YARN_INSTALL_STAMP)
 	dune build --instrument-with bisect_ppx
-	@$(foreach bin,$(COMPILER_DUNE_BINS),touch $(bin);)
 	@$(foreach bin,$(COMPILER_BIN_NAMES), \
 		cp $(DUNE_BIN_DIR)/$(bin)$(PLATFORM_EXE_EXT) $(BIN_DIR)/$(bin).exe && \
 		chmod 755 $(BIN_DIR)/$(bin).exe;)

--- a/compiler/dune
+++ b/compiler/dune
@@ -9,6 +9,7 @@
  gentype
  jsoo
  ml
+ sync
  syntax)
 
 (env

--- a/compiler/sync/dune
+++ b/compiler/sync/dune
@@ -1,0 +1,118 @@
+; Keep the npm platform package's binaries in sync with every `dune build`.
+;
+; The packages/@rescript/<platform>/bin copies are what cli/*.js, the test
+; harnesses, and the runtime build actually run; these promotion rules are
+; their only producer (the Makefile no longer copies binaries). Promotion
+; compares content, so unchanged binaries are not rewritten and no-op builds
+; cause no timestamp churn downstream.
+;
+; One rule per platform; %{system}/%{architecture} come from `ocamlc -config`
+; (note: x64 is "amd64" there). Windows copies without stripping, matching
+; the historical packaging step. The browser profile is excluded because it
+; builds a playground-flavoured compiler that must never overwrite the
+; native binaries.
+
+(rule
+ (enabled_if
+  (and
+   (<> %{profile} browser)
+   (= %{system} macosx)
+   (= %{architecture} arm64)))
+ (targets bsc.exe rescript-editor-analysis.exe rescript-tools.exe)
+ (deps
+  ../bsc/rescript_compiler_main.exe
+  ../../analysis/bin/main.exe
+  ../../tools/bin/main.exe)
+ (mode
+  (promote
+   (until-clean)
+   (into ../../packages/@rescript/darwin-arm64/bin)))
+ (action
+  (progn
+   (run strip -o bsc.exe ../bsc/rescript_compiler_main.exe)
+   (run strip -o rescript-editor-analysis.exe ../../analysis/bin/main.exe)
+   (run strip -o rescript-tools.exe ../../tools/bin/main.exe))))
+
+(rule
+ (enabled_if
+  (and
+   (<> %{profile} browser)
+   (= %{system} macosx)
+   (= %{architecture} amd64)))
+ (targets bsc.exe rescript-editor-analysis.exe rescript-tools.exe)
+ (deps
+  ../bsc/rescript_compiler_main.exe
+  ../../analysis/bin/main.exe
+  ../../tools/bin/main.exe)
+ (mode
+  (promote
+   (until-clean)
+   (into ../../packages/@rescript/darwin-x64/bin)))
+ (action
+  (progn
+   (run strip -o bsc.exe ../bsc/rescript_compiler_main.exe)
+   (run strip -o rescript-editor-analysis.exe ../../analysis/bin/main.exe)
+   (run strip -o rescript-tools.exe ../../tools/bin/main.exe))))
+
+(rule
+ (enabled_if
+  (and
+   (<> %{profile} browser)
+   (= %{system} linux)
+   (= %{architecture} arm64)))
+ (targets bsc.exe rescript-editor-analysis.exe rescript-tools.exe)
+ (deps
+  ../bsc/rescript_compiler_main.exe
+  ../../analysis/bin/main.exe
+  ../../tools/bin/main.exe)
+ (mode
+  (promote
+   (until-clean)
+   (into ../../packages/@rescript/linux-arm64/bin)))
+ (action
+  (progn
+   (run strip -o bsc.exe ../bsc/rescript_compiler_main.exe)
+   (run strip -o rescript-editor-analysis.exe ../../analysis/bin/main.exe)
+   (run strip -o rescript-tools.exe ../../tools/bin/main.exe))))
+
+(rule
+ (enabled_if
+  (and
+   (<> %{profile} browser)
+   (= %{system} linux)
+   (= %{architecture} amd64)))
+ (targets bsc.exe rescript-editor-analysis.exe rescript-tools.exe)
+ (deps
+  ../bsc/rescript_compiler_main.exe
+  ../../analysis/bin/main.exe
+  ../../tools/bin/main.exe)
+ (mode
+  (promote
+   (until-clean)
+   (into ../../packages/@rescript/linux-x64/bin)))
+ (action
+  (progn
+   (run strip -o bsc.exe ../bsc/rescript_compiler_main.exe)
+   (run strip -o rescript-editor-analysis.exe ../../analysis/bin/main.exe)
+   (run strip -o rescript-tools.exe ../../tools/bin/main.exe))))
+
+(rule
+ (enabled_if
+  (and
+   (<> %{profile} browser)
+   (= %{system} mingw64)
+   (= %{architecture} amd64)))
+ (targets bsc.exe rescript-editor-analysis.exe rescript-tools.exe)
+ (deps
+  ../bsc/rescript_compiler_main.exe
+  ../../analysis/bin/main.exe
+  ../../tools/bin/main.exe)
+ (mode
+  (promote
+   (until-clean)
+   (into ../../packages/@rescript/win32-x64/bin)))
+ (action
+  (progn
+   (copy ../bsc/rescript_compiler_main.exe bsc.exe)
+   (copy ../../analysis/bin/main.exe rescript-editor-analysis.exe)
+   (copy ../../tools/bin/main.exe rescript-tools.exe))))

--- a/scripts/checkCompilerExes.js
+++ b/scripts/checkCompilerExes.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+// Verify that the compiler binaries in the platform npm package were
+// produced by dune promotion from the current build (compiler/sync/dune is
+// their only producer). Fails when a binary is missing - e.g. this
+// platform's promotion rule did not fire - or when a stale binary from an
+// earlier build is still in place.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { binDir } from "#cli/bins";
+
+const syncDir = path.join(
+  import.meta.dirname,
+  "..",
+  "_build",
+  "default",
+  "compiler",
+  "sync",
+);
+
+let ok = true;
+for (const exe of ["bsc", "rescript-editor-analysis", "rescript-tools"]) {
+  const promoted = path.join(binDir, `${exe}.exe`);
+  const built = path.join(syncDir, `${exe}.exe`);
+  if (
+    !fs.existsSync(promoted) ||
+    !fs.existsSync(built) ||
+    !fs.readFileSync(promoted).equals(fs.readFileSync(built))
+  ) {
+    console.error(`Error: ${promoted} does not match ${built}.`);
+    ok = false;
+  } else if (process.platform !== "win32") {
+    // Content being right is not enough: an archive round-trip can drop the
+    // executable bit while preserving bytes.
+    try {
+      fs.accessSync(promoted, fs.constants.X_OK);
+    } catch {
+      console.error(`Error: ${promoted} is not executable.`);
+      ok = false;
+    }
+  }
+}
+
+if (!ok) {
+  console.error(
+    "Dune promotion did not produce these binaries; check that this platform is covered by a rule in compiler/sync/dune.",
+  );
+  process.exit(1);
+}
+
+console.log("Compiler binaries in the platform package match the dune build.");

--- a/scripts/copyExes.js
+++ b/scripts/copyExes.js
@@ -2,22 +2,21 @@
 
 // @ts-check
 
-// Copy exes built by dune to platform bin dir
+// Copy the rewatch exe built by cargo to the platform bin dir.
+// The dune-built compiler binaries are copied by dune promotion instead
+// (see compiler/sync/dune).
 
 import * as child_process from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { binDir } from "#cli/bins";
-import { compilerBinDir, rewatchDir } from "#dev/paths";
+import { rewatchDir } from "#dev/paths";
 
 const args = parseArgs({
   args: process.argv.slice(2),
   options: {
     all: {
-      type: "boolean",
-    },
-    compiler: {
       type: "boolean",
     },
     rewatch: {
@@ -26,14 +25,7 @@ const args = parseArgs({
   },
 });
 
-const shouldCopyCompiler = args.values.all || args.values.compiler;
 const shouldCopyRewatch = args.values.all || args.values.rewatch;
-
-if (shouldCopyCompiler) {
-  copyExe(compilerBinDir, "rescript-editor-analysis");
-  copyExe(compilerBinDir, "rescript-tools");
-  copyExe(compilerBinDir, "bsc");
-}
 
 if (shouldCopyRewatch) {
   copyExe(path.join(rewatchDir, "target", "release"), "rescript");


### PR DESCRIPTION
## Rationale

The compiler binaries in `packages/@rescript/<platform>/bin` are what actually runs in most workflows: `cli/bsc.js` and friends resolve them via the platform npm package, and so do the mocha/build tests (`scripts/test.js`), the tools tests, the rewatch integration tests, and the runtime build. But those binaries were only refreshed by *copy steps* — mtime-based Makefile rules locally, and a separate `scripts/copyExes.js --compiler` step in CI — which run only when make (or that CI step) runs.

## The command sequence that gets into trouble

```
# edit a compiler source
$ dune build                # _build is now current
$ ./cli/bsc.js test.res     # ...runs the OLD compiler
```

Nothing updates the packages copy between those two commands. Worse, the tree becomes **split-brained**: `scripts/test_syntax.sh` and the analysis tests read `_build/install/default/bin` directly (new compiler), while everything routed through the cli reads the packages copy (old compiler) — in the same shell session, with no error anywhere. In practice this showed up as confusingly inconsistent results: syntax fixtures regenerated by the new compiler while mocha snapshots were regenerated by the old one, costing real debugging time before anyone suspects the binary.

A programmatic illustration (probe string compiled into the binaries, then one bare `dune build`):

```
binary                                               contains
_build/install/default/bin/bsc                       NEW
packages/@rescript/darwin-arm64/bin/bsc.exe          old   <- what cli/bsc.js runs

entry point                                          runs
cli/bsc.js, scripts/test.js, tools tests, rewatch    old
test_syntax.sh, analysis tests (read _build)         NEW
```

## Why this resolves it

Dune promotion makes the packages binaries an *output of the build itself*: rules in `compiler/sync/dune` (one per platform, covering `bsc`, `rescript-editor-analysis`, `rescript-tools`) copy-and-strip each binary into the platform package on **every** `dune build`. There is no separate step to forget. Key properties:

- **Content-compared**: promotion only rewrites a file when its bytes changed, so no-op builds cause no timestamp churn and make's downstream stamps (runtime build, etc.) don't re-trigger spuriously.
- **Sole producer**: the Makefile copy rules, both mtime-compensation `touch` loops, and `copyExes.js`'s compiler mode are deleted. If a platform's `enabled_if` predicate is wrong, the binary is *missing* on a fresh checkout and fails loudly and proximately — the "present but stale" failure mode no longer has a producer. (`copyExes.js` keeps its rewatch mode: that binary is cargo-built and stays make's responsibility.)
- **Platform matrix**: one rule per platform (`%{system}`/`%{architecture}` from `ocamlc -config`); Windows copies without `strip`, matching the historical packaging step.
- **Playground-safe**: all rules carry `(<> %{profile} browser)`, so a `make playground` build (which compiles a playground-flavoured `bsc`) can never overwrite the native binaries.

## Verification layers

- `make compiler` now *verifies instead of assumes*: each packages binary is `cmp`-checked against the dune build output (`_build/default/compiler/sync/`), with one forced re-promotion retry that also self-heals a damaged or deleted copy, and a lost executable bit is restored. If promotion genuinely didn't produce the binary (e.g. an uncovered platform), it fails with a message pointing at `compiler/sync/dune` instead of an `ENOENT` deep inside some downstream harness.
- CI's former copy step is replaced by `scripts/checkCompilerExes.js`, which asserts on every platform in the matrix that the promoted binaries byte-match the build (and are executable on Unix) — so the per-platform `enabled_if` predicates are actually tested rather than masked by a re-copy.

## Verifications done (macOS/arm64)

- The illustration above re-run after the change: every entry point converges on the new compiler after a bare `dune build`.
- Fresh production: binaries deleted, bare `dune build` re-creates all three; fresh worktree (fresh-clone equivalent) produces them from nothing.
- No-op build leaves promoted files' mtimes untouched (no downstream churn).
- Failure injection: a deliberately wrong `enabled_if` makes both `make compiler` and `checkCompilerExes.js` fail with the intended messages; a corrupted or `chmod 644` binary is detected and self-healed.
- Browser profile: `dune rules --profile browser` confirms the promotion targets don't exist there.
- `make compiler`, `make lib`, `make test`, Biome, and formatting all green.

Linux and Windows validation is exactly what this PR's CI run provides: with no fallback producer left, a wrong platform predicate means a missing binary and a loud, attributable failure in that job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
