### PR TITLE
Upgrade the development toolchain to OCaml 5.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@ LABEL org.opencontainers.image.description="Docker image for ReScript developmen
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+    binaryen \
     cmake \
     musl-tools \
     ninja-build \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,4 +16,4 @@ RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/o
 USER vscode
 ENV HOME=/home/vscode
 
-RUN opam init -y --shell-setup --enable-shell-hook --compiler=5.3.0 --disable-sandboxing
+RUN opam init -y --shell-setup --enable-shell-hook --compiler=5.5.0 --disable-sandboxing

--- a/.github/actions/setup-ocaml/action.yml
+++ b/.github/actions/setup-ocaml/action.yml
@@ -34,9 +34,9 @@ runs:
       run: |
         dependency_flags_key="${DEPENDENCY_FLAGS//--/}"
         dependency_flags_key="${dependency_flags_key// /_}"
-        key="$CACHE_PREFIX-$OS-3.6.0-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
+        key="$CACHE_PREFIX-$OS-3.7.2-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
         echo "value=${key//,/-}" >> "$GITHUB_OUTPUT"
-        echo "setup-version=3.6.0" >> "$GITHUB_OUTPUT"
+        echo "setup-version=3.7.2" >> "$GITHUB_OUTPUT"
 
     - name: Restore OPAM environment
       id: cache
@@ -53,7 +53,7 @@ runs:
 
     - name: Use OCaml ${{ inputs.compiler }}
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: ocaml/setup-ocaml@v3.6.0
+      uses: ocaml/setup-ocaml@v3.7.2
       with:
         ocaml-compiler: ${{ inputs.compiler }}
         opam-pin: false

--- a/.github/actions/setup-ocaml/action.yml
+++ b/.github/actions/setup-ocaml/action.yml
@@ -23,6 +23,54 @@ outputs:
 runs:
   using: composite
   steps:
+    # wasm_of_ocaml requires Binaryen 119 or newer, including wasm-merge.
+    # Hosted runners do not consistently provide a suitable complete version,
+    # so use the same pinned official release on Linux and macOS.
+    - name: Install Binaryen
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        BINARYEN_VERSION: "131"
+      run: |
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          Linux-X64)
+            platform=x86_64-linux
+            checksum=b5bf1f0eaf17c63ee588ff7a5954dc8f6ce2c26989051c66f24dfe9ece3e46db
+            ;;
+          Linux-ARM64)
+            platform=aarch64-linux
+            checksum=ba991f677edd9a21d2bc96c0144bc8ac5b112d4d98a3eb266e075e22e557df2a
+            ;;
+          macOS-X64)
+            platform=x86_64-macos
+            checksum=d209fadd8a894bdaf3bd3612a23c32a0af184d2f4a979b8c789e6e4f6a4de883
+            ;;
+          macOS-ARM64)
+            platform=arm64-macos
+            checksum=e441b48dc22163d209b4f05e44dc7210909b01237642b6c9ae48fd710a3ef83e
+            ;;
+          *)
+            echo "Unsupported Binaryen platform: $RUNNER_OS-$RUNNER_ARCH" >&2
+            exit 1
+            ;;
+        esac
+
+        archive="binaryen-version_${BINARYEN_VERSION}-${platform}.tar.gz"
+        install_dir="$RUNNER_TOOL_CACHE/binaryen/$BINARYEN_VERSION/$RUNNER_ARCH"
+        curl -fsSL \
+          "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${archive}" \
+          -o "$RUNNER_TEMP/$archive"
+
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          echo "$checksum  $RUNNER_TEMP/$archive" | shasum -a 256 --check
+        else
+          echo "$checksum  $RUNNER_TEMP/$archive" | sha256sum --check
+        fi
+
+        mkdir -p "$install_dir"
+        tar -xzf "$RUNNER_TEMP/$archive" --strip-components=1 -C "$install_dir"
+        echo "$install_dir/bin" >> "$GITHUB_PATH"
+
     - name: Get OPAM cache key
       id: cache-key
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04 # x64
-            ocaml_compiler: ocaml-variants.5.3.0+options,ocaml-option-static
+            ocaml_compiler: ocaml-variants.5.5.0+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
             node-target: linux-x64
             rust-target: x86_64-unknown-linux-musl
             dune-profile: static
           - os: ubuntu-24.04-arm # ARM
-            ocaml_compiler: ocaml-variants.5.3.0+options,ocaml-option-static
+            ocaml_compiler: ocaml-variants.5.5.0+options,ocaml-option-static
             upload_binaries: true
             # Build the playground compiler and run the benchmarks on the fastest runner
             build_playground: true
@@ -54,19 +54,19 @@ jobs:
             rust-target: aarch64-unknown-linux-musl
             dune-profile: static
           - os: macos-15-intel # x64
-            ocaml_compiler: 5.3.0
+            ocaml_compiler: 5.5.0
             upload_binaries: true
             node-target: darwin-x64
             rust-target: x86_64-apple-darwin
             dune-profile: release
           - os: macos-15 # ARM
-            ocaml_compiler: 5.3.0
+            ocaml_compiler: 5.5.0
             upload_binaries: true
             node-target: darwin-arm64
             rust-target: aarch64-apple-darwin
             dune-profile: release
           - os: windows-2025
-            ocaml_compiler: 5.3.0
+            ocaml_compiler: 5.5.0
             upload_binaries: true
             node-target: win32-x64
             rust-target: x86_64-pc-windows-gnu

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # For CodeCov OIDC
     env:
       OS: ubuntu-24.04-arm
-      OCAML_COMPILER: 5.3.0
+      OCAML_COMPILER: 5.5.0
       RUST_TARGET: aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
@@ -46,6 +46,12 @@ jobs:
           os: ${{ env.OS }}
           cache-prefix: opam-coverage-v1
           dependency-flags: --deps-only --with-test --with-dev-setup
+
+      - name: Install OCaml coverage tooling
+        run: >-
+          opam pin add bisect_ppx
+          git+https://github.com/patricoferris/bisect_ppx.git#7061d643ff492b0045796357ee6917ded21fb1f0
+          --yes
 
       # --- Coverage build cache --------------------------------------------
       # The bisect_ppx-instrumented dune build is a separate artifact from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ then verify that GitHub reports stack metadata and runs CI for every PR.
 
 ## Development Environment
 
-- **OCaml**: 5.3.0+ with opam
+- **OCaml**: 5.5.0+ with opam
 - **Build System**: dune with profiles (dev, release, browser)
 - **JavaScript**: Node.js 20+ for tooling
 - **Rust**: Toolchain needed for rewatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 #### :house: Internal
 
+- Upgrade the development toolchain and primary CI builds to OCaml 5.5 while retaining OCaml 5.0 as the minimum supported version. https://github.com/rescript-lang/rescript/pull/8589
 - Upgrade the vendored Flow parser from 0.267.0 to 0.320.0, the final release of the OCaml implementation. https://github.com/rescript-lang/rescript/pull/8588
 - Vendor the Flow parser 0.267.0 sources used by the compiler, removing the external `flow_parser` dependency and establishing a maintained baseline for future OCaml upgrades. https://github.com/rescript-lang/rescript/pull/8587
 - Store processed external declarations as structured data instead of serialized values in `pval_prim`, and lower external calls during Lambda translation. This removes `Pccall`, `external_spec`, and the unsupported `%absfloat` primitive. The AST, CMI, and CMT magic numbers are bumped (`ResImpl01301`/`ResIntf01301`, `Caml1999I025`, `Caml1999T026`). https://github.com/rescript-lang/rescript/pull/8581

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,9 @@ opam init
 
 # Any recent OCaml version works as a development compiler
 # Can also create local switch with opam switch create
-# If you get "No compiler matching `5.3.0' found" error,
+# If you get "No compiler matching `5.5.0' found" error,
 # then you need to run `opam update && opam upgrade` first
-opam switch create 5.3.0
+opam switch create 5.5.0
 
 # Install dev dependencies from OPAM
 opam install . --deps-only --with-test --with-dev-setup -y

--- a/Makefile
+++ b/Makefile
@@ -238,10 +238,9 @@ checkformat: | $(YARN_INSTALL_STAMP)
 
 # Coverage (bisect_ppx)
 #
-# Requires the `bisect_ppx` opam package (>= 2.8.0) in your switch:
-#   opam install bisect_ppx
-# or pull it in via the rescript dev-setup deps:
-#   opam install . --deps-only --with-dev-setup
+# Requires the pending `bisect_ppx` OCaml 5.5 compatibility patch in your switch:
+#   opam pin add bisect_ppx \
+#     git+https://github.com/patricoferris/bisect_ppx.git#7061d643ff492b0045796357ee6917ded21fb1f0
 #
 # Quick start:
 #   make coverage         # run full test suite, generate report

--- a/compiler/ml/pprintast.ml
+++ b/compiler/ml/pprintast.ml
@@ -243,10 +243,18 @@ let longident_loc f x = pp f "%a" longident x.txt
 
 let string_of_int_as_char i = Ext_util.string_of_int_as_char i
 
+(* Keep layout stable across OCaml <5.4 (byte width) and >=5.4 (Unicode scalar width). *)
+let print_string_with_byte_width f s = Format.pp_print_as f (String.length s) s
+
+let print_quoted_string_with_byte_width f s =
+  let quoted = Printf.sprintf "%S" s in
+  print_string_with_byte_width f quoted
+
 let constant f = function
   | Pconst_char i -> pp f "%s" (string_of_int_as_char i)
-  | Pconst_string (i, None) -> pp f "%S" i
-  | Pconst_string (i, Some delim) -> pp f "{%s|%s|%s}" delim i delim
+  | Pconst_string (i, None) -> print_quoted_string_with_byte_width f i
+  | Pconst_string (i, Some delim) ->
+    pp f "{%s|%a|%s}" delim print_string_with_byte_width i delim
   | Pconst_integer (i, None) -> paren (i.[0] = '-') (fun f -> pp f "%s") f i
   | Pconst_integer (i, Some m) ->
     paren (i.[0] = '-') (fun f (i, m) -> pp f "%s%c" i m) f (i, m)
@@ -279,7 +287,7 @@ let private_flag f = function
   | Public -> ()
   | Private -> pp f "private@ "
 
-let constant_string f s = pp f "%S" s
+let constant_string = print_quoted_string_with_byte_width
 let tyvar f str = pp f "'%s" str
 let tyvar_loc f str = pp f "'%s" str.txt
 let string_quot f x = pp f "`%s" x
@@ -373,6 +381,8 @@ and core_type1 ctxt f x =
         low
     | Ptyp_object (l, o) ->
       let core_field_type f = function
+        | Otag (l, [], ct) ->
+          pp f "@[<hov2>%s: %a@;<2 0>@]" l.txt (core_type ctxt) ct
         | Otag (l, attrs, ct) ->
           pp f "@[<hov2>%s: %a@ %a@ @]" l.txt (core_type ctxt) ct
             (attributes ctxt) attrs (* Cf #7200 *)

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
   (base
    (>= v0.16.3))
   (ppxlib
-   (>= 0.32.1))
+   (>= 0.38.0))
   (ppx_deriving :build)
   (ppx_gen_rec :build)
   wtf8
@@ -37,18 +37,16 @@
   (odoc :with-doc)
   (ocaml-lsp-server
    (and :with-dev-setup (>= 1.23.0)))
-  (bisect_ppx
-   (and :with-dev-setup (>= 2.8.0)))
   (js_of_ocaml
    (and
     (<> :os "win32")
     :with-test
-    (= 6.0.1)))
+    (= 6.4.1)))
   (wasm_of_ocaml-compiler
    (and
     (<> :os "win32")
     :with-test
-    (= 6.0.1)))))
+    (= 6.4.1)))))
 
 (package
  (name analysis)

--- a/rescript.opam
+++ b/rescript.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.17"}
   "base" {>= "v0.16.3"}
-  "ppxlib" {>= "0.32.1"}
+  "ppxlib" {>= "0.38.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "wtf8"
@@ -19,9 +19,8 @@ depends: [
   "ounit2" {with-test & = "2.2.7"}
   "odoc" {with-doc}
   "ocaml-lsp-server" {with-dev-setup & >= "1.23.0"}
-  "bisect_ppx" {with-dev-setup & >= "2.8.0"}
-  "js_of_ocaml" {os != "win32" & with-test & = "6.0.1"}
-  "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.0.1"}
+  "js_of_ocaml" {os != "win32" & with-test & = "6.4.1"}
+  "wasm_of_ocaml-compiler" {os != "win32" & with-test & = "6.4.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/tests/syntax_tests/data/parsing/grammar/typexpr/expected/poly.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/typexpr/expected/poly.res.txt
@@ -5,5 +5,5 @@ external getLogger :
                                                                     'a -> 'b
                                                                     ->
                                                                     int (a:2)
-                                                                >  (a:1) =
+                                                               >  (a:1) =
     "./src/logger.mock.js"


### PR DESCRIPTION
## Summary

- use OCaml 5.5 for local development, the development container, and primary CI builds
- retain `ocaml >= 5.0.0` as the package constraint and keep the dedicated OCaml 5.0 compatibility CI job
- upgrade ppxlib to 0.38, setup-ocaml to 3.7.2, and js_of_ocaml and wasm_of_ocaml to 6.4.1
- install a suitable Binaryen version for wasm_of_ocaml on CI and in the development container
- adapt the compiler pretty-printer to the OCaml 5.4 `Format` behavior change while keeping syntax-test output stable
- temporarily pin the pending bisect_ppx OCaml 5.5 compatibility fix for coverage builds

This is the fourth PR in the "Flow Forward" series. It is stacked on the OCamlformat 0.29 upgrade so the mechanical reformat and toolchain changes remain independently reviewable.

Related to #8567.