### PR TITLE
Disable setup-ocaml's redundant internal cache

### DIFF
--- a/.github/actions/setup-ocaml/action.yml
+++ b/.github/actions/setup-ocaml/action.yml
@@ -82,9 +82,9 @@ runs:
       run: |
         dependency_flags_key="${DEPENDENCY_FLAGS//--/}"
         dependency_flags_key="${dependency_flags_key// /_}"
-        key="$CACHE_PREFIX-$OS-3.7.2-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
+        key="$CACHE_PREFIX-$OS-3.8.0-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
         echo "value=${key//,/-}" >> "$GITHUB_OUTPUT"
-        echo "setup-version=3.7.2" >> "$GITHUB_OUTPUT"
+        echo "setup-version=3.8.0" >> "$GITHUB_OUTPUT"
 
     - name: Restore OPAM environment
       id: cache
@@ -101,10 +101,11 @@ runs:
 
     - name: Use OCaml ${{ inputs.compiler }}
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: ocaml/setup-ocaml@v3.7.2
+      uses: ocaml/setup-ocaml@v3.8.0
       with:
         ocaml-compiler: ${{ inputs.compiler }}
         opam-pin: false
+        cache: false
 
     - name: Get OPAM executable path
       if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Upgrade `ocaml/setup-ocaml` from 3.7.2 to 3.8.0
- Disable its action-managed OPAM cache
- Update our cache keys to include the new setup-ocaml version

## Why

We already cache the complete OPAM environment, including project dependencies. setup-ocaml's internal cache covers overlapping paths and creates an additional, less-complete cache before dependencies are installed.

Disabling it avoids redundant cache uploads and reduces pressure on GitHub Actions' cache storage limit. Our existing cache continues to provide warm OPAM environments.
