### PR TITLE
Add regression tests for doc comment attribute formatting

### DIFF
--- a/tests/syntax_tests/data/printer/comments/docCommentAttributes.res
+++ b/tests/syntax_tests/data/printer/comments/docCommentAttributes.res
@@ -1,0 +1,21 @@
+/** Doc comment */
+@a @b
+external f: unit => unit = "f"
+
+/* Normal comment */
+@a @b
+external f: unit => unit = "f"
+
+/**
+Doc comment Doc comment Doc comment Doc comment Doc comment
+Doc comment Doc comment Doc comment Doc comment Doc comment
+*/
+@a @b
+external f: unit => unit = "f"
+
+/*
+Normal comment Normal comment Normal comment Normal comment Normal comment
+Normal comment Normal comment Normal comment Normal comment Normal comment
+*/
+@a @b
+external f: unit => unit = "f"

--- a/tests/syntax_tests/data/printer/comments/expected/docCommentAttributes.res.txt
+++ b/tests/syntax_tests/data/printer/comments/expected/docCommentAttributes.res.txt
@@ -1,0 +1,21 @@
+/** Doc comment */
+@a @b
+external f: unit => unit = "f"
+
+/* Normal comment */
+@a @b
+external f: unit => unit = "f"
+
+/**
+Doc comment Doc comment Doc comment Doc comment Doc comment
+Doc comment Doc comment Doc comment Doc comment Doc comment
+*/
+@a @b
+external f: unit => unit = "f"
+
+/*
+Normal comment Normal comment Normal comment Normal comment Normal comment
+Normal comment Normal comment Normal comment Normal comment Normal comment
+*/
+@a @b
+external f: unit => unit = "f"


### PR DESCRIPTION
Adds the four examples from #6302 as formatter regression tests, verifying that single-line and multiline doc comments preserve the same attribute layout as normal comments. The underlying behavior was fixed in #7529.

Validation: `make test-syntax`, `make test-syntax-roundtrip`, and narrow-width formatting stability checks passed.

Closes #6302.
