### PR TITLE
Print coercions with context-aware parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 #### :nail_care: Polish
 
-- Omit unnecessary parentheses around coercions in call arguments, collection elements, and array indices while preserving expression grouping. https://github.com/rescript-lang/rescript/pull/8614
+- Omit unnecessary parentheses around coercions where the surrounding syntax already delimits the expression, while preserving required grouping. https://github.com/rescript-lang/rescript/pull/8614
 - Print external declarations in signatures and type errors with their processed attributes instead of the `"#rescript-external"` placeholder, and print inline constants using `@inline` syntax. https://github.com/rescript-lang/rescript/pull/8581
 - Improve diagnostics for dynamic imports of local values and attempts to use `import` as a first-class value. https://github.com/rescript-lang/rescript/pull/8582
 - Allow inferred labeled functions to be called with labels in any order by removing legacy curried-arrow commutation locks. https://github.com/rescript-lang/rescript/pull/8547

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 
 #### :nail_care: Polish
 
+- Omit unnecessary parentheses around coercions in call arguments, bindings, and collection elements while preserving expression grouping. https://github.com/rescript-lang/rescript/issues/6254
 - Print external declarations in signatures and type errors with their processed attributes instead of the `"#rescript-external"` placeholder, and print inline constants using `@inline` syntax. https://github.com/rescript-lang/rescript/pull/8581
 - Improve diagnostics for dynamic imports of local values and attempts to use `import` as a first-class value. https://github.com/rescript-lang/rescript/pull/8582
 - Allow inferred labeled functions to be called with labels in any order by removing legacy curried-arrow commutation locks. https://github.com/rescript-lang/rescript/pull/8547

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 #### :nail_care: Polish
 
-- Omit unnecessary parentheses around coercions in call arguments, bindings, and collection elements while preserving expression grouping. https://github.com/rescript-lang/rescript/issues/6254
+- Omit unnecessary parentheses around coercions in call arguments, bindings, and collection elements while preserving expression grouping. https://github.com/rescript-lang/rescript/pull/8614
 - Print external declarations in signatures and type errors with their processed attributes instead of the `"#rescript-external"` placeholder, and print inline constants using `@inline` syntax. https://github.com/rescript-lang/rescript/pull/8581
 - Improve diagnostics for dynamic imports of local values and attempts to use `import` as a first-class value. https://github.com/rescript-lang/rescript/pull/8582
 - Allow inferred labeled functions to be called with labels in any order by removing legacy curried-arrow commutation locks. https://github.com/rescript-lang/rescript/pull/8547

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 #### :nail_care: Polish
 
-- Omit unnecessary parentheses around coercions in call arguments, bindings, and collection elements while preserving expression grouping. https://github.com/rescript-lang/rescript/pull/8614
+- Omit unnecessary parentheses around coercions in call arguments, collection elements, and array indices while preserving expression grouping. https://github.com/rescript-lang/rescript/pull/8614
 - Print external declarations in signatures and type errors with their processed attributes instead of the `"#rescript-external"` placeholder, and print inline constants using `@inline` syntax. https://github.com/rescript-lang/rescript/pull/8581
 - Improve diagnostics for dynamic imports of local values and attempts to use `import` as a first-class value. https://github.com/rescript-lang/rescript/pull/8582
 - Allow inferred labeled functions to be called with labels in any order by removing legacy curried-arrow commutation locks. https://github.com/rescript-lang/rescript/pull/8547

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -16,13 +16,6 @@ let expr ?(allow_coercion = false) expr =
     | {pexp_desc = Pexp_constraint _ | Pexp_coerce _} -> Parenthesized
     | _ -> Nothing)
 
-(* A source annotation may precede :> directly, but nested coercions need
-   grouping. Preserve explicit braces through the normal expression rule. *)
-let coerce_expr_operand expression =
-  match (expr expression, expression.Parsetree.pexp_desc) with
-  | Parenthesized, Pexp_constraint _ -> Nothing
-  | kind, _ -> kind
-
 let expr_record_row_rhs ~optional e =
   let kind = expr e in
   match kind with

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -1,7 +1,7 @@
 module Parsetree_viewer = Res_parsetree_viewer
 type kind = Parenthesized | Braced of Location.t | Nothing
 
-let expr expr =
+let expr ?(allow_coercion = false) expr =
   let opt_braces, _ = Parsetree_viewer.process_braces_attr expr in
   match opt_braces with
   | Some ({Location.loc = braces_loc}, _) -> Braced braces_loc
@@ -12,8 +12,16 @@ let expr expr =
        Pexp_constraint ({pexp_desc = Pexp_pack _}, {ptyp_desc = Ptyp_package _});
     } ->
       Nothing
-    | {pexp_desc = Pexp_constraint _} -> Parenthesized
+    | {pexp_desc = Pexp_coerce _} when allow_coercion -> Nothing
+    | {pexp_desc = Pexp_constraint _ | Pexp_coerce _} -> Parenthesized
     | _ -> Nothing)
+
+(* A source annotation may precede :> directly, but nested coercions need
+   grouping. Preserve explicit braces through the normal expression rule. *)
+let coerce_expr_operand expression =
+  match (expr expression, expression.Parsetree.pexp_desc) with
+  | Parenthesized, Pexp_constraint _ -> Nothing
+  | kind, _ -> kind
 
 let expr_record_row_rhs ~optional e =
   let kind = expr e in
@@ -50,9 +58,9 @@ let call_expr expr =
       Nothing
     | {
      pexp_desc =
-       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_setfield _
-       | Pexp_match _ | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_for_of _
-       | Pexp_for_await_of _ | Pexp_ifthenelse _ );
+       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_coerce _
+       | Pexp_setfield _ | Pexp_match _ | Pexp_try _ | Pexp_while _ | Pexp_for _
+       | Pexp_for_of _ | Pexp_for_await_of _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
     | _ when Parsetree_viewer.expr_is_await expr -> Parenthesized
@@ -72,7 +80,7 @@ let structure_expr expr =
        Pexp_constraint ({pexp_desc = Pexp_pack _}, {ptyp_desc = Ptyp_package _});
     } ->
       Nothing
-    | {pexp_desc = Pexp_constraint _} -> Parenthesized
+    | {pexp_desc = Pexp_constraint _ | Pexp_coerce _} -> Parenthesized
     | _ -> Nothing)
 
 let unary_expr_operand expr =
@@ -100,8 +108,8 @@ let unary_expr_operand expr =
       Nothing
     | {
      pexp_desc =
-       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_setfield _
-       | Pexp_extension _ (* readability? maybe remove *)
+       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_coerce _
+       | Pexp_setfield _ | Pexp_extension _ (* readability? maybe remove *)
        | Pexp_object_literal _ (* ({"a": 1})["a"] *)
        | Pexp_object_set _ (* (o["x"] = v)["y"] *) | Pexp_match _ | Pexp_try _
        | Pexp_while _ | Pexp_for _ | Pexp_for_of _ | Pexp_for_await_of _
@@ -125,7 +133,8 @@ let binary_expr_operand ~is_lhs expr =
     | {pexp_desc = Pexp_fun _}
       when Parsetree_viewer.is_underscore_apply_sugar expr ->
       Nothing
-    | {pexp_desc = Pexp_constraint _ | Pexp_fun _} -> Parenthesized
+    | {pexp_desc = Pexp_constraint _ | Pexp_coerce _ | Pexp_fun _} ->
+      Parenthesized
     | expr when Parsetree_viewer.is_binary_expression expr -> Parenthesized
     | expr when Parsetree_viewer.is_ternary_expr expr -> Parenthesized
     | {pexp_desc = Pexp_assert _} when is_lhs -> Parenthesized
@@ -182,7 +191,7 @@ let flatten_operand_rhs parent_operator rhs =
     false
   | Pexp_fun {params = {p_pat = {ppat_desc = Ppat_var {txt = "__x"}}} :: _} ->
     false
-  | Pexp_fun _ | Pexp_setfield _ | Pexp_constraint _ -> true
+  | Pexp_fun _ | Pexp_setfield _ | Pexp_constraint _ | Pexp_coerce _ -> true
   | _ when Parsetree_viewer.is_ternary_expr rhs -> true
   | _ -> false
 
@@ -220,9 +229,9 @@ let assert_or_await_expr_rhs ?(in_await = false) expr =
       Nothing
     | {
      pexp_desc =
-       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_setfield _
-       | Pexp_match _ | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_for_of _
-       | Pexp_for_await_of _ | Pexp_ifthenelse _ );
+       ( Pexp_assert _ | Pexp_fun _ | Pexp_constraint _ | Pexp_coerce _
+       | Pexp_setfield _ | Pexp_match _ | Pexp_try _ | Pexp_while _ | Pexp_for _
+       | Pexp_for_of _ | Pexp_for_await_of _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
     | _ when (not in_await) && Parsetree_viewer.expr_is_await expr ->
@@ -267,9 +276,9 @@ let field_expr expr =
      pexp_desc =
        ( Pexp_assert _ | Pexp_extension _ (* %extension.x vs (%extension).x *)
        | Pexp_object_literal _ (* ({"a": 1})["a"] *) | Pexp_fun _
-       | Pexp_constraint _ | Pexp_setfield _ | Pexp_match _ | Pexp_try _
-       | Pexp_while _ | Pexp_for _ | Pexp_for_of _ | Pexp_for_await_of _
-       | Pexp_ifthenelse _ );
+       | Pexp_constraint _ | Pexp_coerce _ | Pexp_setfield _ | Pexp_match _
+       | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_for_of _
+       | Pexp_for_await_of _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
     | _ when Parsetree_viewer.expr_is_await expr -> Parenthesized
@@ -286,11 +295,11 @@ let ternary_operand expr =
        Pexp_constraint ({pexp_desc = Pexp_pack _}, {ptyp_desc = Ptyp_package _});
     } ->
       Nothing
-    | {pexp_desc = Pexp_constraint _} -> Parenthesized
+    | {pexp_desc = Pexp_constraint _ | Pexp_coerce _} -> Parenthesized
     | _ when Res_parsetree_viewer.is_fun_expr expr -> (
       let _, _parameters, return_expr = Parsetree_viewer.fun_expr expr in
       match return_expr.pexp_desc with
-      | Pexp_constraint _ -> Parenthesized
+      | Pexp_constraint _ | Pexp_coerce _ -> Parenthesized
       | _ -> Nothing)
     | _ -> Nothing)
 

--- a/compiler/syntax/src/res_parens.ml
+++ b/compiler/syntax/src/res_parens.ml
@@ -1,7 +1,7 @@
 module Parsetree_viewer = Res_parsetree_viewer
 type kind = Parenthesized | Braced of Location.t | Nothing
 
-let expr ?(allow_coercion = false) expr =
+let expr_with_coercion_kind coercion_kind expr =
   let opt_braces, _ = Parsetree_viewer.process_braces_attr expr in
   match opt_braces with
   | Some ({Location.loc = braces_loc}, _) -> Braced braces_loc
@@ -12,9 +12,12 @@ let expr ?(allow_coercion = false) expr =
        Pexp_constraint ({pexp_desc = Pexp_pack _}, {ptyp_desc = Ptyp_package _});
     } ->
       Nothing
-    | {pexp_desc = Pexp_coerce _} when allow_coercion -> Nothing
-    | {pexp_desc = Pexp_constraint _ | Pexp_coerce _} -> Parenthesized
+    | {pexp_desc = Pexp_coerce _} -> coercion_kind
+    | {pexp_desc = Pexp_constraint _} -> Parenthesized
     | _ -> Nothing)
+
+let expr expr = expr_with_coercion_kind Parenthesized expr
+let expr_allowing_coercion expr = expr_with_coercion_kind Nothing expr
 
 let expr_record_row_rhs ~optional e =
   let kind = expr e in

--- a/compiler/syntax/src/res_parens.mli
+++ b/compiler/syntax/src/res_parens.mli
@@ -1,8 +1,8 @@
 type kind = Parenthesized | Braced of Location.t | Nothing
 
 (* Set [allow_coercion] to [true] only in grammar positions accepting a trailing
-   coercion without parentheses, such as call arguments and binding right-hand
-   sides. Arrow bodies require parentheses. *)
+   coercion without parentheses, such as call arguments and collection elements.
+   Bindings and arrow bodies require parentheses. *)
 val expr : ?allow_coercion:bool -> Parsetree.expression -> kind
 val structure_expr : Parsetree.expression -> kind
 
@@ -40,5 +40,3 @@ val arrow_return_typ_expr : Parsetree.core_type -> bool
 val pattern_record_row_rhs : Parsetree.pattern -> bool
 
 val expr_record_row_rhs : optional:bool -> Parsetree.expression -> kind
-
-val coerce_expr_operand : Parsetree.expression -> kind

--- a/compiler/syntax/src/res_parens.mli
+++ b/compiler/syntax/src/res_parens.mli
@@ -1,6 +1,9 @@
 type kind = Parenthesized | Braced of Location.t | Nothing
 
-val expr : Parsetree.expression -> kind
+(* Set [allow_coercion] to [true] only in grammar positions accepting a trailing
+   coercion without parentheses, such as call arguments and binding right-hand
+   sides. Arrow bodies require parentheses. *)
+val expr : ?allow_coercion:bool -> Parsetree.expression -> kind
 val structure_expr : Parsetree.expression -> kind
 
 val unary_expr_operand : Parsetree.expression -> kind
@@ -37,3 +40,5 @@ val arrow_return_typ_expr : Parsetree.core_type -> bool
 val pattern_record_row_rhs : Parsetree.pattern -> bool
 
 val expr_record_row_rhs : optional:bool -> Parsetree.expression -> kind
+
+val coerce_expr_operand : Parsetree.expression -> kind

--- a/compiler/syntax/src/res_parens.mli
+++ b/compiler/syntax/src/res_parens.mli
@@ -1,9 +1,11 @@
 type kind = Parenthesized | Braced of Location.t | Nothing
 
-(* Set [allow_coercion] to [true] only in grammar positions accepting a trailing
-   coercion without parentheses, such as call arguments and collection elements.
-   Bindings and arrow bodies require parentheses. *)
-val expr : ?allow_coercion:bool -> Parsetree.expression -> kind
+val expr : Parsetree.expression -> kind
+
+(* Unlike [expr], this does not request parentheses for a top-level coercion.
+   Use only where the surrounding grammar delimits the expression, such as call
+   arguments and collection elements. *)
+val expr_allowing_coercion : Parsetree.expression -> kind
 val structure_expr : Parsetree.expression -> kind
 
 val unary_expr_operand : Parsetree.expression -> kind

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1716,7 +1716,7 @@ and print_spread_dict_expr ~state parts (expr : Parsetree.expression) cmt_tbl =
     in
     let spread_doc =
       let doc = print_expression ~state spread_expr cmt_tbl in
-      match Parens.expr ~allow_coercion:true spread_expr with
+      match Parens.expr_allowing_coercion spread_expr with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc spread_expr braces
       | Nothing -> doc
@@ -3044,7 +3044,7 @@ and print_expression_with_comments_and_parens ~state expr cmt_tbl =
 and print_expression_args ~state (args : Parsetree.expression list) cmt_tbl =
   let print_arg expr =
     let doc = print_expression_with_comments ~state expr cmt_tbl in
-    match Parens.expr expr with
+    match Parens.expr_allowing_coercion expr with
     | Parens.Parenthesized -> add_parens doc
     | Braced braces -> print_braces doc expr braces
     | Nothing -> doc
@@ -3270,7 +3270,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
               Doc.line;
               Doc.dotdotdot;
               (let doc = print_expression_with_comments ~state expr cmt_tbl in
-               match Parens.expr ~allow_coercion:true expr with
+               match Parens.expr_allowing_coercion expr with
                | Parens.Parenthesized -> add_parens doc
                | Braced braces -> print_braces doc expr braces
                | Nothing -> doc);
@@ -3292,7 +3292,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr ~allow_coercion:true expr with
+                           match Parens.expr_allowing_coercion expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3324,7 +3324,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr ~allow_coercion:true expr with
+                           match Parens.expr_allowing_coercion expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3353,7 +3353,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr ~allow_coercion:true expr with
+                           match Parens.expr_allowing_coercion expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3387,7 +3387,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
               Doc.concat
                 [
                   Doc.dotdotdot;
-                  (match Parens.expr ~allow_coercion:true expr with
+                  (match Parens.expr_allowing_coercion expr with
                   | Parens.Parenthesized -> add_parens doc
                   | Braced braces -> print_braces doc expr braces
                   | Nothing -> doc);
@@ -3737,14 +3737,10 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
           print_cases ~state cases cmt_tbl;
         ]
     | Pexp_coerce (expr, (), typ) ->
-      let doc_expr = print_expression_with_comments ~state expr cmt_tbl in
-      let doc_typ = print_typ_expr ~state typ cmt_tbl in
       let doc_expr =
-        match Parens.expr expr with
-        | Parens.Parenthesized -> add_parens doc_expr
-        | Braced braces -> print_braces doc_expr expr braces
-        | Nothing -> doc_expr
+        print_expression_with_comments_and_parens ~state expr cmt_tbl
       in
+      let doc_typ = print_typ_expr ~state typ cmt_tbl in
       let doc = Doc.concat [doc_expr; Doc.text " :> "; doc_typ] in
       (* Keep attributes on the coercion rather than its operand. *)
       if Parsetree_viewer.has_printable_attributes e.pexp_attributes then
@@ -4250,7 +4246,7 @@ and print_array_spread_apply ~state sub_lists cmt_tbl =
       (* Print expression without leading comments (they're already extracted) *)
       let expr_doc =
         let doc = print_expression ~state expr cmt_tbl in
-        match Parens.expr ~allow_coercion:true expr with
+        match Parens.expr_allowing_coercion expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc expr braces
         | Nothing -> doc
@@ -4282,7 +4278,7 @@ and print_array_spread_apply ~state sub_lists cmt_tbl =
         (List.map
            (fun expr ->
              let doc = print_expression_with_comments ~state expr cmt_tbl in
-             match Parens.expr ~allow_coercion:true expr with
+             match Parens.expr_allowing_coercion expr with
              | Parens.Parenthesized -> add_parens doc
              | Braced braces -> print_braces doc expr braces
              | Nothing -> doc)
@@ -4317,7 +4313,7 @@ and print_list_spread_apply ~state sub_lists cmt_tbl =
           comma_before_spread;
           Doc.dotdotdot;
           (let doc = print_expression_with_comments ~state expr cmt_tbl in
-           match Parens.expr ~allow_coercion:true expr with
+           match Parens.expr_allowing_coercion expr with
            | Parens.Parenthesized -> add_parens doc
            | Braced braces -> print_braces doc expr braces
            | Nothing -> doc);
@@ -4338,7 +4334,7 @@ and print_list_spread_apply ~state sub_lists cmt_tbl =
           (List.map
              (fun expr ->
                let doc = print_expression_with_comments ~state expr cmt_tbl in
-               match Parens.expr ~allow_coercion:true expr with
+               match Parens.expr_allowing_coercion expr with
                | Parens.Parenthesized -> add_parens doc
                | Braced braces -> print_braces doc expr braces
                | Nothing -> doc)
@@ -4438,7 +4434,7 @@ and print_pexp_apply ~state expr cmt_tbl =
     let member =
       let member_doc =
         let doc = print_expression_with_comments ~state member_expr cmt_tbl in
-        match Parens.expr ~allow_coercion:true member_expr with
+        match Parens.expr_allowing_coercion member_expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc member_expr braces
         | Nothing -> doc
@@ -4485,7 +4481,7 @@ and print_pexp_apply ~state expr cmt_tbl =
     let member =
       let member_doc =
         let doc = print_expression_with_comments ~state member_expr cmt_tbl in
-        match Parens.expr ~allow_coercion:true member_expr with
+        match Parens.expr_allowing_coercion member_expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc member_expr braces
         | Nothing -> doc
@@ -5138,7 +5134,7 @@ and print_arguments ~state ~partial
   | [(Nolabel, arg)] when Parsetree_viewer.is_huggable_expression arg ->
     let arg_doc =
       let doc = print_expression_with_comments ~state arg cmt_tbl in
-      match Parens.expr ~allow_coercion:true arg with
+      match Parens.expr_allowing_coercion arg with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc arg braces
       | Nothing -> doc
@@ -5252,7 +5248,7 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
     in
     let printed_expr =
       let doc = print_expression_with_comments ~state expr cmt_tbl in
-      match Parens.expr ~allow_coercion:true expr with
+      match Parens.expr_allowing_coercion expr with
       | Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc expr braces
       | Nothing -> doc

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -5819,7 +5819,9 @@ and print_payload ~state (payload : Parsetree.payload) cmt_tbl =
   match payload with
   | PStr [] -> Doc.nil
   | PStr [{pstr_desc = Pstr_eval (expr, attrs)}] ->
-    let expr_doc = print_expression_with_comments ~state expr cmt_tbl in
+    let expr_doc =
+      print_expression_with_comments_and_parens ~state expr cmt_tbl
+    in
     let needs_parens =
       match attrs with
       | [] -> false
@@ -5985,7 +5987,7 @@ and print_mod_expr ~state mod_expr cmt_tbl =
         Doc.group
           (Doc.concat
              [
-               print_expression_with_comments ~state expr cmt_tbl;
+               print_expression_with_comments_and_parens ~state expr cmt_tbl;
                module_constraint;
              ])
       in

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -2498,7 +2498,7 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
     let opt_braces, expr = Parsetree_viewer.process_braces_attr vb.pvb_expr in
     let printed_expr =
       let doc = print_expression_with_comments ~state vb.pvb_expr cmt_tbl in
-      match Parens.expr ~allow_coercion:true vb.pvb_expr with
+      match Parens.expr vb.pvb_expr with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc expr braces
       | Nothing -> doc
@@ -3731,7 +3731,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
       let doc_expr = print_expression_with_comments ~state expr cmt_tbl in
       let doc_typ = print_typ_expr ~state typ cmt_tbl in
       let doc_expr =
-        match Parens.coerce_expr_operand expr with
+        match Parens.expr expr with
         | Parens.Parenthesized -> add_parens doc_expr
         | Braced braces -> print_braces doc_expr expr braces
         | Nothing -> doc_expr

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -1716,7 +1716,7 @@ and print_spread_dict_expr ~state parts (expr : Parsetree.expression) cmt_tbl =
     in
     let spread_doc =
       let doc = print_expression ~state spread_expr cmt_tbl in
-      match Parens.expr spread_expr with
+      match Parens.expr ~allow_coercion:true spread_expr with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc spread_expr braces
       | Nothing -> doc
@@ -2498,7 +2498,7 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
     let opt_braces, expr = Parsetree_viewer.process_braces_attr vb.pvb_expr in
     let printed_expr =
       let doc = print_expression_with_comments ~state vb.pvb_expr cmt_tbl in
-      match Parens.expr vb.pvb_expr with
+      match Parens.expr ~allow_coercion:true vb.pvb_expr with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc expr braces
       | Nothing -> doc
@@ -3261,7 +3261,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
               Doc.line;
               Doc.dotdotdot;
               (let doc = print_expression_with_comments ~state expr cmt_tbl in
-               match Parens.expr expr with
+               match Parens.expr ~allow_coercion:true expr with
                | Parens.Parenthesized -> add_parens doc
                | Braced braces -> print_braces doc expr braces
                | Nothing -> doc);
@@ -3283,7 +3283,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr expr with
+                           match Parens.expr ~allow_coercion:true expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3315,7 +3315,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr expr with
+                           match Parens.expr ~allow_coercion:true expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3344,7 +3344,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
                            let doc =
                              print_expression_with_comments ~state expr cmt_tbl
                            in
-                           match Parens.expr expr with
+                           match Parens.expr ~allow_coercion:true expr with
                            | Parens.Parenthesized -> add_parens doc
                            | Braced braces -> print_braces doc expr braces
                            | Nothing -> doc)
@@ -3378,7 +3378,7 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
               Doc.concat
                 [
                   Doc.dotdotdot;
-                  (match Parens.expr expr with
+                  (match Parens.expr ~allow_coercion:true expr with
                   | Parens.Parenthesized -> add_parens doc
                   | Braced braces -> print_braces doc expr braces
                   | Nothing -> doc);
@@ -3730,7 +3730,17 @@ and print_expression ~state (e : Parsetree.expression) cmt_tbl =
     | Pexp_coerce (expr, (), typ) ->
       let doc_expr = print_expression_with_comments ~state expr cmt_tbl in
       let doc_typ = print_typ_expr ~state typ cmt_tbl in
-      Doc.concat [Doc.lparen; doc_expr; Doc.text " :> "; doc_typ; Doc.rparen]
+      let doc_expr =
+        match Parens.coerce_expr_operand expr with
+        | Parens.Parenthesized -> add_parens doc_expr
+        | Braced braces -> print_braces doc_expr expr braces
+        | Nothing -> doc_expr
+      in
+      let doc = Doc.concat [doc_expr; Doc.text " :> "; doc_typ] in
+      (* Keep attributes on the coercion rather than its operand. *)
+      if Parsetree_viewer.has_printable_attributes e.pexp_attributes then
+        add_parens doc
+      else doc
     | Pexp_object_get (parent_expr, label) ->
       print_object_get_doc ~state parent_expr label cmt_tbl
     | Pexp_object_set (obj, member, rhs) ->
@@ -4231,7 +4241,7 @@ and print_array_spread_apply ~state sub_lists cmt_tbl =
       (* Print expression without leading comments (they're already extracted) *)
       let expr_doc =
         let doc = print_expression ~state expr cmt_tbl in
-        match Parens.expr expr with
+        match Parens.expr ~allow_coercion:true expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc expr braces
         | Nothing -> doc
@@ -4263,7 +4273,7 @@ and print_array_spread_apply ~state sub_lists cmt_tbl =
         (List.map
            (fun expr ->
              let doc = print_expression_with_comments ~state expr cmt_tbl in
-             match Parens.expr expr with
+             match Parens.expr ~allow_coercion:true expr with
              | Parens.Parenthesized -> add_parens doc
              | Braced braces -> print_braces doc expr braces
              | Nothing -> doc)
@@ -4298,7 +4308,7 @@ and print_list_spread_apply ~state sub_lists cmt_tbl =
           comma_before_spread;
           Doc.dotdotdot;
           (let doc = print_expression_with_comments ~state expr cmt_tbl in
-           match Parens.expr expr with
+           match Parens.expr ~allow_coercion:true expr with
            | Parens.Parenthesized -> add_parens doc
            | Braced braces -> print_braces doc expr braces
            | Nothing -> doc);
@@ -4319,7 +4329,7 @@ and print_list_spread_apply ~state sub_lists cmt_tbl =
           (List.map
              (fun expr ->
                let doc = print_expression_with_comments ~state expr cmt_tbl in
-               match Parens.expr expr with
+               match Parens.expr ~allow_coercion:true expr with
                | Parens.Parenthesized -> add_parens doc
                | Braced braces -> print_braces doc expr braces
                | Nothing -> doc)
@@ -4419,7 +4429,7 @@ and print_pexp_apply ~state expr cmt_tbl =
     let member =
       let member_doc =
         let doc = print_expression_with_comments ~state member_expr cmt_tbl in
-        match Parens.expr member_expr with
+        match Parens.expr ~allow_coercion:true member_expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc member_expr braces
         | Nothing -> doc
@@ -4466,7 +4476,7 @@ and print_pexp_apply ~state expr cmt_tbl =
     let member =
       let member_doc =
         let doc = print_expression_with_comments ~state member_expr cmt_tbl in
-        match Parens.expr member_expr with
+        match Parens.expr ~allow_coercion:true member_expr with
         | Parens.Parenthesized -> add_parens doc
         | Braced braces -> print_braces doc member_expr braces
         | Nothing -> doc
@@ -5119,7 +5129,7 @@ and print_arguments ~state ~partial
   | [(Nolabel, arg)] when Parsetree_viewer.is_huggable_expression arg ->
     let arg_doc =
       let doc = print_expression_with_comments ~state arg cmt_tbl in
-      match Parens.expr arg with
+      match Parens.expr ~allow_coercion:true arg with
       | Parens.Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc arg braces
       | Nothing -> doc
@@ -5233,7 +5243,7 @@ and print_argument ~state (arg_lbl, arg) cmt_tbl =
     in
     let printed_expr =
       let doc = print_expression_with_comments ~state expr cmt_tbl in
-      match Parens.expr expr with
+      match Parens.expr ~allow_coercion:true expr with
       | Parenthesized -> add_parens doc
       | Braced braces -> print_braces doc expr braces
       | Nothing -> doc

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -2419,7 +2419,7 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
                   print_typ_expr ~state pvc_type cmt_tbl;
                   Doc.text " =";
                   Doc.line;
-                  print_expression_with_comments ~state expr cmt_tbl;
+                  print_expression_with_comments_and_parens ~state expr cmt_tbl;
                 ]);
          ])
   | {
@@ -2463,7 +2463,8 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
                     Doc.concat
                       [
                         Doc.line;
-                        print_expression_with_comments ~state expr cmt_tbl;
+                        print_expression_with_comments_and_parens ~state expr
+                          cmt_tbl;
                       ];
                   ]);
            ])
@@ -2490,7 +2491,8 @@ and print_value_binding ~state ~rec_flag (vb : Parsetree.value_binding) cmt_tbl
                     Doc.concat
                       [
                         Doc.line;
-                        print_expression_with_comments ~state expr cmt_tbl;
+                        print_expression_with_comments_and_parens ~state expr
+                          cmt_tbl;
                       ];
                   ]);
            ]))
@@ -3031,6 +3033,13 @@ and print_pattern_dict_row ~state
 and print_expression_with_comments ~state expr cmt_tbl : Doc.t =
   let doc = print_expression ~state expr cmt_tbl in
   print_comments doc cmt_tbl expr.Parsetree.pexp_loc
+
+and print_expression_with_comments_and_parens ~state expr cmt_tbl =
+  let doc = print_expression_with_comments ~state expr cmt_tbl in
+  match Parens.expr expr with
+  | Parens.Parenthesized -> add_parens doc
+  | Braced braces -> print_braces doc expr braces
+  | Nothing -> doc
 
 and print_expression_args ~state (args : Parsetree.expression list) cmt_tbl =
   let print_arg expr =
@@ -4895,7 +4904,7 @@ and print_jsx_prop ~state prop cmt_tbl =
            [
              Doc.lbrace;
              Doc.dotdotdot;
-             print_expression_with_comments ~state value cmt_tbl;
+             print_expression_with_comments_and_parens ~state value cmt_tbl;
              Doc.rbrace;
            ])
   in
@@ -5301,7 +5310,7 @@ and print_case ~state (case : Parsetree.case) cmt_tbl =
            [
              Doc.line;
              Doc.text "if ";
-             print_expression_with_comments ~state expr cmt_tbl;
+             print_expression_with_comments_and_parens ~state expr cmt_tbl;
            ])
   in
   let should_inline_rhs =
@@ -5863,7 +5872,7 @@ and print_payload ~state (payload : Parsetree.payload) cmt_tbl =
           [
             Doc.line;
             Doc.text "if ";
-            print_expression_with_comments ~state expr cmt_tbl;
+            print_expression_with_comments_and_parens ~state expr cmt_tbl;
           ]
       | None -> Doc.nil
     in

--- a/packages/dev-playground/src/CompilerApi.res
+++ b/packages/dev-playground/src/CompilerApi.res
@@ -235,7 +235,7 @@ let applyConfig = (
   ~experimentalFeatures: array<PlaygroundConfig.experimentalFeature>,
 ) => {
   if hasFunction(instance, "setModuleSystem") {
-    instance->Instance.setModuleSystem((moduleSystem :> string))
+    instance->Instance.setModuleSystem(moduleSystem :> string)
   }
   if hasFunction(instance, "setWarnFlags") {
     instance->Instance.setWarnFlags(warnFlags === "" ? defaultConfig.warnFlags : warnFlags)

--- a/packages/dev-playground/src/UrlState.res
+++ b/packages/dev-playground/src/UrlState.res
@@ -42,7 +42,7 @@ let applyUrlState = (~encoded, ~config: PlaygroundConfig.t) => {
     params->UrlSearchParams.delete("sourceMapSourcesContent")
     params->UrlSearchParams.delete("sourceMapRoot")
   | sourceMapMode =>
-    params->UrlSearchParams.set("sourceMap", (sourceMapMode :> string))
+    params->UrlSearchParams.set("sourceMap", sourceMapMode :> string)
     params->UrlSearchParams.set(
       "sourceMapSourcesContent",
       config.sourceMapSourcesContent ? "true" : "false",

--- a/tests/syntax_tests/data/printer/expr/coerce.res
+++ b/tests/syntax_tests/data/printer/expr/coerce.res
@@ -25,7 +25,7 @@ let foo = (~a=(3:int:>int), b) => 34
 
 let x = (/* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */)
 
-// Delimited arguments and binding right-hand sides need no extra parentheses.
+// Delimited arguments need no extra parentheses.
 foo(v :> b)
 foo((v :> b))
 foo(~arg=(v :> b), ~optional=?(v :> b))
@@ -76,3 +76,15 @@ let piped = (value :> b)->foo
 let blockTail = {foo(); (value :> b)}
 let blockHead = {(value :> b); foo()}
 let dictSpread = dict{...(value :> dict<b>), "field": value}
+
+// A constrained operand needs parentheses when the coercion is a binding RHS.
+let constrainedOperand = (x: t) :> u
+let constrainedChain = ((x: t) :> u) :> v
+let constrainedBlock = {(x: t) :> u}
+call((x: t) :> u)
+
+// A following JSX element must not be read as coercion type arguments.
+let beforeJsx = () => {
+  let value = (x :> string)
+  <option value />
+}

--- a/tests/syntax_tests/data/printer/expr/coerce.res
+++ b/tests/syntax_tests/data/printer/expr/coerce.res
@@ -24,3 +24,55 @@ let foo = (~a=(3:int:>int), b) => 34
 // let x : int1 :> int2 = 3 :> int3
 
 let x = (/* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */)
+
+// Delimited arguments and binding right-hand sides need no extra parentheses.
+foo(v :> b)
+foo((v :> b))
+foo(~arg=(v :> b), ~optional=?(v :> b))
+foo((v :> b), x => x)
+foo(x => x, (v :> b))
+let tuple = ((v :> b), (w :> c))
+let array = [(v :> b), (w :> c)]
+let spreadArray = [...(vs :> array<b>), (w :> b)]
+let list = list{(v :> b), ...(vs :> list<b>)}
+let constructor = Some((v :> b))
+let variant = #Value((v :> b))
+
+// Preserve grouping when the surrounding expression needs it.
+let result = x => (x :> b)
+let callback = foo(x => (x :> b))
+let coercedFunction = (x => x) :> (a => b)
+let call = (f :> (a => b))(v)
+let field = (v :> b).name
+let objectField = (v :> b)["name"]
+let equalLeft = (v :> b) == w
+let equalRight = v == (w :> b)
+let unary = !(v :> b)
+let awaited = await (v :> b)
+let nested = (v :> b) :> c
+let record = {field: (v :> b)}
+let conditional = condition ? (v :> b) : (w :> b)
+let block = {v :> b}
+let default = (~arg=(v :> b)) => arg
+let jsx = <Component value={(v :> b)}> {(v :> b)} </Component>
+
+// Comments must stay attached when parentheses disappear.
+foo(/* before */ (v /* operand */ :> /* type */ b) /* after */)
+foo((v :> b) // trailing line comment
+)
+let attributed = (@foo v) :> b
+let coercionAttribute = @foo (v :> b)
+let long = functionWithAVeryLongName((valueWithAVeryLongName :> typeWithAVeryLongName))
+
+let arrayIndex = values[(index :> int)]
+values[(index :> int)] = (value :> b)
+let recordSpread = {...(value :> b), field: value}
+let bracedOperand = {value} :> b
+let blockSequence = {foo(); value :> b}
+let checked = assert(value :> bool)
+(value :> b)
+let ternaryCallback = condition ? (x => (x :> b)) : other
+let piped = (value :> b)->foo
+let blockTail = {foo(); (value :> b)}
+let blockHead = {(value :> b); foo()}
+let dictSpread = dict{...(value :> dict<b>), "field": value}

--- a/tests/syntax_tests/data/printer/expr/coerce.res
+++ b/tests/syntax_tests/data/printer/expr/coerce.res
@@ -98,3 +98,11 @@ let jsxSpread = <Component {...(props :> propsType)} />
 
 @attr(?value if (flag :> bool))
 let attributeGuard = value
+
+// Attribute and extension payloads parse their contents as plain expressions.
+@attr((value :> b))
+let attributePayload = value
+let extensionPayload = %extension((value :> b))
+
+// First-class module unpacking also parses a plain expression.
+module Coerced = unpack((packed :> moduleValue))

--- a/tests/syntax_tests/data/printer/expr/coerce.res
+++ b/tests/syntax_tests/data/printer/expr/coerce.res
@@ -88,3 +88,13 @@ let beforeJsx = () => {
   let value = (x :> string)
   <option value />
 }
+
+// These grammar positions don't parse a bare trailing coercion.
+let locallyAbstract: type a. a = (value :> a)
+let guarded = switch value {
+| _ if (flag :> bool) => value
+}
+let jsxSpread = <Component {...(props :> propsType)} />
+
+@attr(?value if (flag :> bool))
+let attributeGuard = value

--- a/tests/syntax_tests/data/printer/expr/coerce.res
+++ b/tests/syntax_tests/data/printer/expr/coerce.res
@@ -25,7 +25,7 @@ let foo = (~a=(3:int:>int), b) => 34
 
 let x = (/* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */)
 
-// Delimited arguments need no extra parentheses.
+// Delimited expression positions need no extra parentheses.
 foo(v :> b)
 foo((v :> b))
 foo(~arg=(v :> b), ~optional=?(v :> b))

--- a/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
@@ -1,31 +1,31 @@
-let z = x :> int
+let z = (x :> int)
 
-let z2 = x :> int
+let z2 = (x :> int)
 
 let foo = (x: int) => (x :> int)
 
 let foo2 = (x: int) => (x :> int)
 
-let bar = x => (x: t :> int)
+let bar = x => ((x: t) :> int)
 
-let bar2 = x => (x: t :> int)
+let bar2 = x => ((x: t) :> int)
 
-call(~x=y :> int, ~z=w: int :> int, ~a, ~b)
+call(~x=y :> int, ~z=(w: int) :> int, ~a, ~b)
 
 let foo = (~a=3: int, b) => 34
 
 let foo = (~a=3 :> int, b) => 34
 
-let foo = (~a=3: int :> int, b) => 34
+let foo = (~a=(3: int) :> int, b) => 34
 
 // THESE SHOULD NOT PARSE: no magic in the syntax
 // let x: int :> string = y
 // let x :> string = y
 // let x : int1 :> int2 = 3 :> int3
 
-let x = /* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */
+let x = (/* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */)
 
-// Delimited arguments and binding right-hand sides need no extra parentheses.
+// Delimited arguments need no extra parentheses.
 foo(v :> b)
 foo(v :> b)
 foo(~arg=v :> b, ~optional=?v :> b)
@@ -41,7 +41,7 @@ let variant = #Value(v :> b)
 // Preserve grouping when the surrounding expression needs it.
 let result = x => (x :> b)
 let callback = foo(x => (x :> b))
-let coercedFunction = x => x :> a => b
+let coercedFunction = (x => x :> a => b)
 let call = (f :> a => b)(v)
 let field = (v :> b).name
 let objectField = (v :> b)["name"]
@@ -49,7 +49,7 @@ let equalLeft = (v :> b) == w
 let equalRight = v == (w :> b)
 let unary = !(v :> b)
 let awaited = await (v :> b)
-let nested = (v :> b) :> c
+let nested = ((v :> b) :> c)
 let record = {field: (v :> b)}
 let conditional = condition ? (v :> b) : (w :> b)
 let block = {v :> b}
@@ -59,14 +59,14 @@ let jsx = <Component value={v :> b}> {v :> b} </Component>
 // Comments must stay attached when parentheses disappear.
 foo(/* before */ v /* operand */ :> /* type */ b /* after */)
 foo(v :> b) // trailing line comment
-let attributed = @foo v :> b
-let coercionAttribute = @foo (v :> b)
+let attributed = (@foo v :> b)
+let coercionAttribute = (@foo (v :> b))
 let long = functionWithAVeryLongName(valueWithAVeryLongName :> typeWithAVeryLongName)
 
 let arrayIndex = values[index :> int]
 values[index :> int] = (value :> b)
 let recordSpread = {...value :> b, field: value}
-let bracedOperand = {value} :> b
+let bracedOperand = ({value} :> b)
 let blockSequence = {
   {
     foo()
@@ -86,3 +86,15 @@ let blockHead = {
   foo()
 }
 let dictSpread = dict{...value :> dict<b>, "field": value}
+
+// A constrained operand needs parentheses when the coercion is a binding RHS.
+let constrainedOperand = ((x: t) :> u)
+let constrainedChain = (((x: t) :> u) :> v)
+let constrainedBlock = {(x: t) :> u}
+call((x: t) :> u)
+
+// A following JSX element must not be read as coercion type arguments.
+let beforeJsx = () => {
+  let value = (x :> string)
+  <option value />
+}

--- a/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
@@ -1,6 +1,6 @@
-let z = (x :> int)
+let z = x :> int
 
-let z2 = (x :> int)
+let z2 = x :> int
 
 let foo = (x: int) => (x :> int)
 
@@ -10,17 +10,79 @@ let bar = x => (x: t :> int)
 
 let bar2 = x => (x: t :> int)
 
-call(~x=(y :> int), ~z=(w: int :> int), ~a, ~b)
+call(~x=y :> int, ~z=w: int :> int, ~a, ~b)
 
 let foo = (~a=3: int, b) => 34
 
-let foo = (~a=(3 :> int), b) => 34
+let foo = (~a=3 :> int, b) => 34
 
-let foo = (~a=(3: int :> int), b) => 34
+let foo = (~a=3: int :> int, b) => 34
 
 // THESE SHOULD NOT PARSE: no magic in the syntax
 // let x: int :> string = y
 // let x :> string = y
 // let x : int1 :> int2 = 3 :> int3
 
-let x = /* c0 */ (x /* c1 */ :> /* c2 */ int) /* c3 */
+let x = /* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */
+
+// Delimited arguments and binding right-hand sides need no extra parentheses.
+foo(v :> b)
+foo(v :> b)
+foo(~arg=v :> b, ~optional=?v :> b)
+foo(v :> b, x => x)
+foo(x => x, v :> b)
+let tuple = (v :> b, w :> c)
+let array = [v :> b, w :> c]
+let spreadArray = [...vs :> array<b>, w :> b]
+let list = list{v :> b, ...vs :> list<b>}
+let constructor = Some(v :> b)
+let variant = #Value(v :> b)
+
+// Preserve grouping when the surrounding expression needs it.
+let result = x => (x :> b)
+let callback = foo(x => (x :> b))
+let coercedFunction = x => x :> a => b
+let call = (f :> a => b)(v)
+let field = (v :> b).name
+let objectField = (v :> b)["name"]
+let equalLeft = (v :> b) == w
+let equalRight = v == (w :> b)
+let unary = !(v :> b)
+let awaited = await (v :> b)
+let nested = (v :> b) :> c
+let record = {field: (v :> b)}
+let conditional = condition ? (v :> b) : (w :> b)
+let block = {v :> b}
+let default = (~arg=v :> b) => arg
+let jsx = <Component value={v :> b}> {v :> b} </Component>
+
+// Comments must stay attached when parentheses disappear.
+foo(/* before */ v /* operand */ :> /* type */ b /* after */)
+foo(v :> b) // trailing line comment
+let attributed = @foo v :> b
+let coercionAttribute = @foo (v :> b)
+let long = functionWithAVeryLongName(valueWithAVeryLongName :> typeWithAVeryLongName)
+
+let arrayIndex = values[index :> int]
+values[index :> int] = (value :> b)
+let recordSpread = {...value :> b, field: value}
+let bracedOperand = {value} :> b
+let blockSequence = {
+  {
+    foo()
+    value
+  } :> b
+}
+let checked = assert(value :> bool)
+(value :> b)
+let ternaryCallback = condition ? (x => (x :> b)) : other
+let piped = (value :> b)->foo
+let blockTail = {
+  foo()
+  (value :> b)
+}
+let blockHead = {
+  (value :> b)
+  foo()
+}
+let dictSpread = dict{...value :> dict<b>, "field": value}

--- a/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
@@ -25,7 +25,7 @@ let foo = (~a=(3: int) :> int, b) => 34
 
 let x = (/* c0 */ x /* c1 */ :> /* c2 */ int /* c3 */)
 
-// Delimited arguments need no extra parentheses.
+// Delimited expression positions need no extra parentheses.
 foo(v :> b)
 foo(v :> b)
 foo(~arg=v :> b, ~optional=?v :> b)

--- a/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
@@ -98,3 +98,13 @@ let beforeJsx = () => {
   let value = (x :> string)
   <option value />
 }
+
+// These grammar positions don't parse a bare trailing coercion.
+let locallyAbstract: type a. a = (value :> a)
+let guarded = switch value {
+| _ if (flag :> bool) => value
+}
+let jsxSpread = <Component {...(props :> propsType)} />
+
+@attr(? value if (flag :> bool))
+let attributeGuard = value

--- a/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
+++ b/tests/syntax_tests/data/printer/expr/expected/coerce.res.txt
@@ -108,3 +108,11 @@ let jsxSpread = <Component {...(props :> propsType)} />
 
 @attr(? value if (flag :> bool))
 let attributeGuard = value
+
+// Attribute and extension payloads parse their contents as plain expressions.
+@attr((value :> b))
+let attributePayload = value
+let extensionPayload = %extension((value :> b))
+
+// First-class module unpacking also parses a plain expression.
+module Coerced = unpack((packed :> moduleValue))

--- a/tests/tests/src/Coercion.res
+++ b/tests/tests/src/Coercion.res
@@ -8,4 +8,4 @@ type r2 = {x: int}
 type t1 = array<r1>
 type t2 = array<r2>
 
-let foo = (x: t1) => {(x :> t2)}
+let foo = (x: t1) => {x :> t2}

--- a/tests/tests/src/VariantCoercion.res
+++ b/tests/tests/src/VariantCoercion.res
@@ -124,7 +124,7 @@ module CoerceFromPolyvariantToVariant = {
 module CoerceVariantBinaryOp = {
   type flag = | @as(0) A | @as(2) B
 
-  let x = 0->Int.bitwiseOr((B :> int))
+  let x = 0->Int.bitwiseOr(B :> int)
 
   let v = B
   let f1 = () =>

--- a/tests/tests/src/poly_variant_test.res
+++ b/tests/tests/src/poly_variant_test.res
@@ -82,7 +82,7 @@ describe(__MODULE__, () => {
   })
 
   test("emoji poly variant conversion", () => {
-    eq(__LOC__, "🚀", (#"🚀": t :> string))
-    eq(__LOC__, "🔥", (#"🔥": t :> string))
+    eq(__LOC__, "🚀", (#"🚀": t) :> string)
+    eq(__LOC__, "🔥", (#"🔥": t) :> string)
   })
 })

--- a/tests/tests/src/type_coercion_free_vars.res
+++ b/tests/tests/src/type_coercion_free_vars.res
@@ -5,7 +5,7 @@ module NoFreeVars = {
 
   let g = (y: t) => ()
 
-  let h = x => (g(x), (x :> int))
+  let h = x => (g(x), x :> int)
 
   //  let h2 = x => ((x :> int), g(x))
 }


### PR DESCRIPTION
The formatter currently turns `foo(v :> b)` into `foo((v :> b))`. Reuse the existing parentheses rules to omit unnecessary parentheses in calls, collections, and array indices while preserving grouping where required.

Keep parentheses for binding right-hand sides, arrow bodies, operators, field access, block sequences, constrained operands, and attributes. Bindings remain parenthesized because a following JSX element can otherwise be parsed as coercion type arguments. The parser is unchanged.

Add regression coverage for constrained operands and bindings followed by JSX, and reformat existing sources affected by the new rules.

Validation: `make test`, `make checkformat`, `make test-syntax`, and `make test-syntax-roundtrip`, plus structure-preservation and formatting-stability checks at widths 20, 80, and 100.

Fixes #6254.
