### PR TITLE
Developer playground: Remove the now unused lam tab

### DIFF
--- a/packages/dev-playground/src/Bindings.res
+++ b/packages/dev-playground/src/Bindings.res
@@ -80,7 +80,6 @@ module CompileResult = {
   @get external parsetree: compileResult => option<string> = "parsetree"
   @get external typedtree: compileResult => option<string> = "typedtree"
   @get external lambda: compileResult => option<string> = "lambda"
-  @get external lam: compileResult => option<string> = "lam"
   @get external gentype: compileResult => option<string> = "gentype"
   @get external sourceMap: compileResult => option<string> = "source_map"
   @get external errors: compileResult => option<array<diagnostic>> = "errors"

--- a/packages/dev-playground/src/CompilerApi.res
+++ b/packages/dev-playground/src/CompilerApi.res
@@ -62,7 +62,6 @@ type success = {
   parsetree: string,
   typedtree: string,
   lambda: string,
-  lam: string,
   gentype: option<string>,
   sourceMap: option<string>,
   warnings: array<string>,
@@ -403,9 +402,8 @@ let normalize = (compileOutput, elapsedMs): compileResult => {
     compileOutput->CompileResult.parsetree,
     compileOutput->CompileResult.typedtree,
     compileOutput->CompileResult.lambda,
-    compileOutput->CompileResult.lam,
   ) {
-  | (Some(parsetree), Some(typedtree), Some(lambda), Some(lam)) =>
+  | (Some(parsetree), Some(typedtree), Some(lambda)) =>
     let warnings = switch compileOutput->CompileResult.warnings {
     | Some(warnings) => warnings->Array.map(warningToText)
     | None => []
@@ -419,7 +417,7 @@ let normalize = (compileOutput, elapsedMs): compileResult => {
     let gentype = compileOutput->CompileResult.gentype
     let sourceMap = compileOutput->CompileResult.sourceMap
 
-    Ok({jsCode, parsetree, typedtree, lambda, lam, gentype, sourceMap, warnings, time: elapsedMs})
+    Ok({jsCode, parsetree, typedtree, lambda, gentype, sourceMap, warnings, time: elapsedMs})
 
   | _ => Error(failureFromCompileOutput(compileOutput, elapsedMs))
   }

--- a/packages/dev-playground/src/CompilerApi.resi
+++ b/packages/dev-playground/src/CompilerApi.resi
@@ -25,7 +25,6 @@ type success = {
   parsetree: string,
   typedtree: string,
   lambda: string,
-  lam: string,
   gentype: option<string>,
   sourceMap: option<string>,
   warnings: array<string>,

--- a/packages/dev-playground/src/Main.res
+++ b/packages/dev-playground/src/Main.res
@@ -4,7 +4,6 @@ type tab =
   | Parsetree
   | Typedtree
   | Lambda
-  | Lam
   | JavaScript
   | GenType
   | SourceMap
@@ -26,7 +25,7 @@ type compileSnapshot = {
   result: CompilerApi.compileResult,
 }
 
-let baseTabs: array<tab> = [Parsetree, Typedtree, Lambda, Lam, JavaScript]
+let baseTabs: array<tab> = [Parsetree, Typedtree, Lambda, JavaScript]
 let moduleSystems: array<moduleSystem> = [Esmodule, Commonjs]
 let sourceMapModes: array<sourceMapMode> = [Disabled, Linked, Inline, Hidden]
 
@@ -34,7 +33,7 @@ let tabIsVisible = (config: PlaygroundConfig.t, tab) =>
   switch tab {
   | GenType => config.gentypeEnabled
   | SourceMap => config.sourceMapMode !== Disabled
-  | Parsetree | Typedtree | Lambda | Lam | JavaScript | Settings => true
+  | Parsetree | Typedtree | Lambda | JavaScript | Settings => true
   }
 
 let tabsForConfig = (config: PlaygroundConfig.t) => {
@@ -63,7 +62,6 @@ let tabLabel = tab =>
   | Parsetree => "parsetree"
   | Typedtree => "typedtree"
   | Lambda => "lambda"
-  | Lam => "lam"
   | JavaScript => "js"
   | GenType => "gentype"
   | SourceMap => "source map"
@@ -225,7 +223,6 @@ let selectedOutput = (snapshot: option<compileSnapshot>, activeTab: tab) =>
     | Parsetree => result.parsetree
     | Typedtree => result.typedtree
     | Lambda => result.lambda
-    | Lam => result.lam
     | JavaScript => result.jsCode
     | GenType =>
       optionalOutput(result.gentype, "This compiler bundle does not expose gentype output yet.")


### PR DESCRIPTION
I guess this one became obsolete recently...