### PR TITLE
Add devcontainer CLI instructions

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,2 @@
+devcontainer-lock.json
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,21 @@ Run the `Dev Containers: Rebuild and Reopen in Container` action to get started.
 
 You can also open this dev container with [GitHub Codespaces](https://github.com/features/codespaces/).
 
+Alternatively, install the [Dev Container CLI](https://github.com/devcontainers/cli) through npm:
+
+```sh
+npm install -g @devcontainers/cli
+```
+
+Then create the development container and open a shell in it:
+
+```sh
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . zsh
+```
+
+Use the Dev Container tooling rather than building `.devcontainer/Dockerfile` directly. The tooling installs the features declared in `devcontainer.json`, including Node.js, and runs the post-create command. A plain `docker build` does not apply these features or lifecycle commands.
+
 ## Building the Compiler
 
 Main targets:


### PR DESCRIPTION
## Summary

- document how to install the Dev Container CLI
- add commands for creating the container and opening a shell
- clarify that building the Dockerfile directly does not install Dev Container features or run lifecycle commands
- ignore the CLI-generated `devcontainer-lock.json`

## Motivation

The development container relies on features declared in `devcontainer.json` to install tools such as Node.js. This was not clear when using the configuration outside VS Code, and building the Dockerfile directly results in an incomplete development environment.