### PR TITLE
Keep the source type of a record coercion in the typed tree

### DIFF
--- a/compiler/ext/config.ml
+++ b/compiler/ext/config.ml
@@ -13,6 +13,6 @@ and ast0_impl_magic_number = "Caml1999M022"
 
 and ast0_intf_magic_number = "Caml1999N022"
 
-and cmt_magic_number = "Caml1999T036"
+and cmt_magic_number = "Caml1999T037"
 
 let load_path = ref ([] : string list)

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -252,10 +252,10 @@ and expression_extra i ppf x attrs =
     line i ppf "Texp_constraint\n";
     attributes i ppf attrs;
     core_type i ppf ct
-  | Texp_coerce {source; target} ->
+  | Texp_coerce {source_type; target} ->
     line i ppf "Texp_coerce\n";
     attributes i ppf attrs;
-    line i ppf "source %a\n" Printtyp.type_expr source;
+    line i ppf "source %a\n" Printtyp.type_expr source_type;
     core_type i ppf target
   | Texp_open (ovf, m, _, _) ->
     line i ppf "Texp_open %a \"%a\"\n" fmt_override_flag ovf fmt_path m;

--- a/compiler/ml/printtyped.ml
+++ b/compiler/ml/printtyped.ml
@@ -252,10 +252,11 @@ and expression_extra i ppf x attrs =
     line i ppf "Texp_constraint\n";
     attributes i ppf attrs;
     core_type i ppf ct
-  | Texp_coerce cto2 ->
+  | Texp_coerce {source; target} ->
     line i ppf "Texp_coerce\n";
     attributes i ppf attrs;
-    core_type i ppf cto2
+    line i ppf "source %a\n" Printtyp.type_expr source;
+    core_type i ppf target
   | Texp_open (ovf, m, _, _) ->
     line i ppf "Texp_open %a \"%a\"\n" fmt_override_flag ovf fmt_path m;
     attributes i ppf attrs

--- a/compiler/ml/tast_iterator.ml
+++ b/compiler/ml/tast_iterator.ml
@@ -139,7 +139,7 @@ let pat sub {pat_extra; pat_desc; pat_env; _} =
 let expr sub {exp_extra; exp_desc; exp_env; _} =
   let extra = function
     | Texp_constraint cty -> sub.typ sub cty
-    | Texp_coerce cty2 -> sub.typ sub cty2
+    | Texp_coerce {target} -> sub.typ sub target
     | Texp_open (_, _, _, _) -> ()
   in
   List.iter (fun (e, _, _) -> extra e) exp_extra;

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -182,7 +182,8 @@ let pat sub x =
 let expr sub x =
   let extra = function
     | Texp_constraint cty -> Texp_constraint (sub.typ sub cty)
-    | Texp_coerce cty2 -> Texp_coerce (sub.typ sub cty2)
+    | Texp_coerce {source; target} ->
+      Texp_coerce {source; target = sub.typ sub target}
     | Texp_open (ovf, path, loc, env) ->
       Texp_open (ovf, path, loc, sub.env sub env)
   in

--- a/compiler/ml/tast_mapper.ml
+++ b/compiler/ml/tast_mapper.ml
@@ -182,8 +182,8 @@ let pat sub x =
 let expr sub x =
   let extra = function
     | Texp_constraint cty -> Texp_constraint (sub.typ sub cty)
-    | Texp_coerce {source; target} ->
-      Texp_coerce {source; target = sub.typ sub target}
+    | Texp_coerce {source_type; target; target_type} ->
+      Texp_coerce {source_type; target = sub.typ sub target; target_type}
     | Texp_open (ovf, path, loc, env) ->
       Texp_open (ovf, path, loc, sub.env sub env)
   in

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -3394,7 +3394,12 @@ and type_expect_ ?deprecated_context ~context ?(recarg = Rejected) env sexp
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra =
-          ( Texp_coerce {source = arg.exp_type; target = cty'},
+          ( Texp_coerce
+              {
+                source_type = expand_head env arg.exp_type;
+                target = cty';
+                target_type = expand_head env ty';
+              },
             loc,
             sexp.pexp_attributes )
           :: arg.exp_extra;

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -3394,7 +3394,10 @@ and type_expect_ ?deprecated_context ~context ?(recarg = Rejected) env sexp
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra =
-          (Texp_coerce cty', loc, sexp.pexp_attributes) :: arg.exp_extra;
+          ( Texp_coerce {source = arg.exp_type; target = cty'},
+            loc,
+            sexp.pexp_attributes )
+          :: arg.exp_extra;
       }
   | Pexp_object_literal sfields ->
     (* Fields are typed in source order. A duplicate name is typed against the

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -74,7 +74,11 @@ and expression = {
 
 and exp_extra =
   | Texp_constraint of core_type
-  | Texp_coerce of {source: type_expr; target: core_type}
+  | Texp_coerce of {
+      source_type: type_expr;
+      target: core_type;
+      target_type: type_expr;
+    }
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
 
 and expression_desc =

--- a/compiler/ml/typedtree.ml
+++ b/compiler/ml/typedtree.ml
@@ -74,7 +74,7 @@ and expression = {
 
 and exp_extra =
   | Texp_constraint of core_type
-  | Texp_coerce of core_type
+  | Texp_coerce of {source: type_expr; target: core_type}
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
 
 and expression_desc =

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -117,7 +117,12 @@ and expression = {
 
 and exp_extra =
   | Texp_constraint of core_type  (** E : T *)
-  | Texp_coerce of core_type  (** E :> T           [Texp_coerce T]
+  | Texp_coerce of {source: type_expr; target: core_type}
+      (** E :> T           [Texp_coerce {source; target}]
+
+            [source] is the inferred type of E, which the surface syntax does
+            not spell out. It is kept so consumers can relate the two types,
+            e.g. to pair up the record labels a coercion projects.
          *)
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
       (** let open[!] M in    [Texp_open (!, P, M, env)]

--- a/compiler/ml/typedtree.mli
+++ b/compiler/ml/typedtree.mli
@@ -117,12 +117,18 @@ and expression = {
 
 and exp_extra =
   | Texp_constraint of core_type  (** E : T *)
-  | Texp_coerce of {source: type_expr; target: core_type}
-      (** E :> T           [Texp_coerce {source; target}]
+  | Texp_coerce of {
+      source_type: type_expr;
+      target: core_type;
+      target_type: type_expr;
+    }
+      (** E :> T           [Texp_coerce {source_type; target; target_type}]
 
-            [source] is the inferred type of E, which the surface syntax does
-            not spell out. It is kept so consumers can relate the two types,
-            e.g. to pair up the record labels a coercion projects.
+            [target] is T as written. [source_type] is the inferred type of E,
+            which the surface syntax never spells out, and [target_type] is the
+            type of T; both are head-expanded, so a consumer without a typing
+            environment can still relate them - e.g. to pair up the record
+            labels a coercion projects.
          *)
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
       (** let open[!] M in    [Texp_open (!, P, M, env)]

--- a/compiler/ml/typedtree_iter.ml
+++ b/compiler/ml/typedtree_iter.ml
@@ -216,7 +216,7 @@ end = struct
         | cstr, _, _attrs -> (
           match cstr with
           | Texp_constraint ct -> iter_core_type ct
-          | Texp_coerce cty2 -> iter_core_type cty2
+          | Texp_coerce {target} -> iter_core_type target
           | Texp_open _ -> ()))
       exp.exp_extra;
     (match exp.exp_desc with


### PR DESCRIPTION
Groundwork for #8643. No behaviour change on its own; the fix that uses it is stacked on top.

`(e :> T)` is typed by checking the argument's type against the target and then rebuilding the node:

```ocaml
{ exp_desc = arg.exp_desc;   (* spliced in, not nested *)
  exp_type = ty';            (* target *)
  exp_extra = (Texp_coerce cty', loc, ...) :: arg.exp_extra }
```

`arg.exp_type` — the source type — is dropped. Because the argument is spliced rather than nested there is no child node carrying it either, and `Texp_coerce` held only the target. `-dtypedtree` on the issue's repro shows all that survives:

```
Texp_coerce
core_type
  Ttyp_constr "Person!.t"
  []
  Texp_ident "john"
```

The surface syntax never spells the source type out either: ReScript has no `(e : t1 :> t2)` form, so `Pexp_coerce`'s source slot is `unit` (OCaml keeps a `core_type option` there for exactly that form). The type checker is therefore the only place where both types of a coercion are ever known at once.

So keep it:

```ocaml
- | Texp_coerce of core_type
+ | Texp_coerce of {source: type_expr; target: core_type}
```

`Typecore` fills in the type it had already computed for the subtype check. The other four sites are mechanical; `Printtyped` also prints `source`, which is how the stacked PR's behaviour was checked.

Consumers can now relate the two types of a coercion. `reanalyze` needs exactly that to see that reading a label on the target record is a read of the source label of the same name — rescript-lang/rescript#8643.
