### PR TITLE
Link record labels reached through a coercion in reanalyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 #### :bug: Bug fix
 
+- Fix `reanalyze` reporting record labels reached through a record coercion as dead. The typed tree now keeps the source type of a coercion, so reading a label on the target counts as reading the source label of the same name. https://github.com/rescript-lang/rescript/issues/8643
 - Fix constant folding of pattern matches on unboxed variants whose payload overlaps a literal constructor, so inlined calls agree with runtime matching. Reject multi-argument unboxed constructors instead of crashing. https://github.com/rescript-lang/rescript/pull/8631
 - Fix escaped backticks and interpolation openers in backquoted `%raw`, `%ffi`, and `%re` payloads leaking into emitted JavaScript. https://github.com/rescript-lang/rescript/pull/8630
 - Fix the side-effect analysis treating bigint exponentiation and bounds-checked array and string reads as pure, which let dead-code elimination drop an unused one that throws: `let _ = 2n ** -1n` no longer raised. https://github.com/rescript-lang/rescript/pull/8617

--- a/analysis/reanalyze/src/cross_file_items.ml
+++ b/analysis/reanalyze/src/cross_file_items.ml
@@ -16,6 +16,11 @@ type optional_arg_call = {
 
 type function_ref = {pos_from: Lexing.position; pos_to: Lexing.position}
 
+type coercion = {
+  source_type_paths: Dce_path.t list;
+  target_type_paths: Dce_path.t list;
+}
+
 type optional_arg_value_escape = {
   pos_from: Lexing.position;
   pos_to: Lexing.position;
@@ -28,6 +33,7 @@ type t = {
   optional_arg_calls: optional_arg_call list;
   function_refs: function_ref list;
   optional_arg_value_escapes: optional_arg_value_escape list;
+  coercions: coercion list;
 }
 
 type builder = {
@@ -35,6 +41,7 @@ type builder = {
   mutable optional_arg_calls: optional_arg_call list;
   mutable function_refs: function_ref list;
   mutable optional_arg_value_escapes: optional_arg_value_escape list;
+  mutable coercions: coercion list;
 }
 
 (** {2 Builder API} *)
@@ -45,6 +52,7 @@ let create_builder () : builder =
     optional_arg_calls = [];
     function_refs = [];
     optional_arg_value_escapes = [];
+    coercions = [];
   }
 
 let add_exception_ref (b : builder) ~exception_path ~loc_from =
@@ -62,6 +70,9 @@ let add_optional_arg_value_escape (b : builder) ~pos_from ~pos_to =
   b.optional_arg_value_escapes <-
     {pos_from; pos_to} :: b.optional_arg_value_escapes
 
+let add_coercion (b : builder) ~source_type_paths ~target_type_paths =
+  b.coercions <- {source_type_paths; target_type_paths} :: b.coercions
+
 (** {2 Merge API} *)
 
 let merge_all (builders : builder list) : t =
@@ -75,11 +86,13 @@ let merge_all (builders : builder list) : t =
   let optional_arg_value_escapes =
     builders |> List.concat_map (fun b -> b.optional_arg_value_escapes)
   in
+  let coercions = builders |> List.concat_map (fun b -> b.coercions) in
   {
     exception_refs;
     optional_arg_calls;
     function_refs;
     optional_arg_value_escapes;
+    coercions;
   }
 
 (** {2 Builder extraction for reactive merge} *)
@@ -90,6 +103,7 @@ let builder_to_t (builder : builder) : t =
     optional_arg_calls = builder.optional_arg_calls;
     function_refs = builder.function_refs;
     optional_arg_value_escapes = builder.optional_arg_value_escapes;
+    coercions = builder.coercions;
   }
 
 (** {2 Processing API} *)

--- a/analysis/reanalyze/src/cross_file_items.mli
+++ b/analysis/reanalyze/src/cross_file_items.mli
@@ -18,6 +18,14 @@ type optional_arg_call = {
 
 type function_ref = {pos_from: Lexing.position; pos_to: Lexing.position}
 
+type coercion = {
+  source_type_paths: Dce_path.t list;
+  target_type_paths: Dce_path.t list;
+}
+(** A record coercion [(e :> Target.t)], as the candidate paths of the source
+    and target types. The two types can live in different files, so the labels
+    are paired up after all declarations are known. *)
+
 type optional_arg_value_escape = {
   pos_from: Lexing.position;
   pos_to: Lexing.position;
@@ -30,6 +38,7 @@ type t = {
   optional_arg_calls: optional_arg_call list;
   function_refs: function_ref list;
   optional_arg_value_escapes: optional_arg_value_escape list;
+  coercions: coercion list;
 }
 (** Immutable cross-file items - for processing after merge *)
 
@@ -59,6 +68,13 @@ val add_function_reference :
 val add_optional_arg_value_escape :
   builder -> pos_from:Lexing.position -> pos_to:Lexing.position -> unit
 (** Record an optional-arg function used as a first-class value. *)
+
+val add_coercion :
+  builder ->
+  source_type_paths:Dce_path.t list ->
+  target_type_paths:Dce_path.t list ->
+  unit
+(** Record a record coercion, to be resolved against the declarations later. *)
 
 (** {2 Merge API} *)
 

--- a/analysis/reanalyze/src/dead_type.ml
+++ b/analysis/reanalyze/src/dead_type.ml
@@ -68,20 +68,44 @@ let add_declaration ~config ~decls ~file ~(module_path : Module_path.t)
       decls
   | _ -> ()
 
+(* A record coercion [(e :> Target.t)] views the source record through the
+   target's labels: reading a target label is a read of the source label of the
+   same name. The edge runs target -> source only - reading a source label says
+   nothing about the target's.
+
+   The batch and the reactive pipelines share this rule and the shape of a
+   record-label declaration below, and differ only in how they index
+   declarations and how they record an edge. *)
+(* Use raw declaration positions, not [declGetLoc], because references are keyed
+   by raw positions (decl.pos). [declGetLoc] applies [posAdjustment] (e.g. +2 for
+   OtherVariant), which is intended for reporting locations, not for reference
+   graph keys. *)
+let decl_raw_loc (decl : Decl.t) : Location.t =
+  {Location.loc_start = decl.pos; loc_end = decl.pos_end; loc_ghost = false}
+
+let record_label_of_decl (decl : Decl.t) =
+  match (decl.decl_kind, decl.path) with
+  | RecordLabel, label :: type_path ->
+    Some (type_path, (label, decl |> decl_raw_loc))
+  | _ -> None
+
+let pair_coercion_labels ~source_labels ~target_labels ~add_edge =
+  target_labels
+  |> List.iter (fun (label, (target_loc : Location.t)) ->
+      match List.assoc_opt label source_labels with
+      | Some (source_loc : Location.t)
+        when (not source_loc.loc_ghost) && (not target_loc.loc_ghost)
+             && source_loc.loc_start <> target_loc.loc_start ->
+        add_edge ~source_loc ~target_loc
+      | _ -> ())
+
 module Path_map = Map.Make (struct
   type t = Dce_path.t
 
   let compare = Stdlib.compare
 end)
 
-let process_type_label_dependencies ~config ~decls ~refs =
-  (* Use raw declaration positions, not [declGetLoc], because references are keyed
-     by raw positions (decl.pos). [declGetLoc] applies [posAdjustment] (e.g. +2
-     for OtherVariant), which is intended for reporting locations, not for
-     reference graph keys. *)
-  let decl_raw_loc (decl : Decl.t) : Location.t =
-    {Location.loc_start = decl.pos; loc_end = decl.pos_end; loc_ghost = false}
-  in
+let process_type_label_dependencies ~config ~decls ~refs ~coercions =
   (* Build an index from full label path -> list of locations *)
   let index =
     Declarations.fold
@@ -206,6 +230,41 @@ let process_type_label_dependencies ~config ~decls ~refs =
         )
       | _ -> ())
     decls;
+
+  (* Record coercions: pair the labels with [pair_coercion_labels], indexing
+     declarations by the type path they belong to. *)
+  (if coercions <> [] then
+     let labels_by_type_path =
+       Declarations.fold
+         (fun _pos decl acc ->
+           match record_label_of_decl decl with
+           | Some (type_path, label) ->
+             let existing =
+               Path_map.find_opt type_path acc |> Option.value ~default:[]
+             in
+             Path_map.add type_path (label :: existing) acc
+           | None -> acc)
+         decls Path_map.empty
+     in
+     let labels_of_candidates paths =
+       paths
+       |> List.concat_map (fun path ->
+           Path_map.find_opt path labels_by_type_path
+           |> Option.value ~default:[])
+       (* Keep the pairing independent of declaration traversal order. *)
+       |> List.fast_sort (fun (_, l1) (_, l2) ->
+           compare_pos l1.Location.loc_start l2.Location.loc_start)
+     in
+     coercions |> List.fast_sort compare
+     |> List.iter
+          (fun {Cross_file_items.source_type_paths; target_type_paths} ->
+            match labels_of_candidates source_type_paths with
+            | [] -> ()
+            | source_labels ->
+              pair_coercion_labels ~source_labels
+                ~target_labels:(labels_of_candidates target_type_paths)
+                ~add_edge:(fun ~source_loc ~target_loc ->
+                  extend_type_dependencies ~config ~refs source_loc target_loc)));
 
   groups |> Hashtbl.to_seq |> List.of_seq
   |> List.map (fun (current_type_path, (rep_pos, manifest_type_path, items)) ->

--- a/analysis/reanalyze/src/dead_value.ml
+++ b/analysis/reanalyze/src/dead_value.ml
@@ -128,8 +128,50 @@ let process_optional_args ~config ~cross_file ~exp_type ~(loc_from : Location.t)
     |> Dead_optional_args.add_references ~config ~cross_file ~loc_from ~loc_to
          ~binding ~path)
 
-let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
-    ~(last_binding : Location.t) super self (e : Typedtree.expression) =
+let type_path_candidates ~file ~(module_path : Module_path.t) path =
+  let path = Dce_path.from_path_t path in
+  let module_context =
+    module_path.path @ [File_context.module_name_tagged file]
+  in
+  let add_unique paths path =
+    if List.exists (fun existing -> existing = path) paths then paths
+    else path :: paths
+  in
+  [path; path @ module_context]
+  |> List.fold_left
+       (fun paths path ->
+         [
+           path;
+           Dce_path.module_to_implementation path;
+           Dce_path.module_to_interface path;
+         ]
+         |> List.fold_left add_unique paths)
+       []
+
+(* A record coercion [(e :> Target.t)] views the source record through the
+   target's labels, so reading a target label reads the source label of the same
+   name; without that link the source labels look unread. The two types can live
+   in different files, so record the candidate paths and let the global pass
+   pair the labels up. Both types come from [Texp_coerce] already head-expanded,
+   so an alias names the type that owns the labels; the source type is there at
+   all only because the typed tree keeps it - the syntax never spells it out. *)
+let add_coercion ~cross_file ~file ~module_path ~source ~target =
+  if !Config.analyze_types then
+    let type_paths typ =
+      match (Ctype.repr typ).Types.desc with
+      | Types.Tconstr (path, _, _) ->
+        type_path_candidates ~file ~module_path path
+      | _ -> []
+    in
+    match (type_paths source, type_paths target) with
+    | [], _ | _, [] -> ()
+    | source_type_paths, target_type_paths ->
+      Cross_file_items.add_coercion cross_file ~source_type_paths
+        ~target_type_paths
+
+let rec collect_expr ~config ~decls ~refs ~file_deps ~cross_file ~direct_callees
+    ~file ~module_path ~(last_binding : Location.t) super self
+    (e : Typedtree.expression) =
   let loc_from = e.exp_loc in
   let binding = last_binding in
   let add_optional_arg_value_escape ~val_type pos_from pos_to =
@@ -137,6 +179,13 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
       Cross_file_items.add_optional_arg_value_escape cross_file ~pos_from
         ~pos_to
   in
+  e.exp_extra
+  |> List.iter (fun (extra, _, _) ->
+      match extra with
+      | Typedtree.Texp_coerce {source_type; target_type} ->
+        add_coercion ~cross_file ~file ~module_path ~source:source_type
+          ~target:target_type
+      | _ -> ());
   (match e.exp_desc with
   | Texp_ident
       (_path, _, {Types.val_loc = {loc_ghost = false; _} as loc_to; val_type})
@@ -244,8 +293,8 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
         | Typedtree.Overridden (_, ({exp_loc} as e)) when exp_loc.loc_ghost ->
           (* Punned field in OCaml projects has ghost location in expression *)
           let e = {e with exp_loc = {exp_loc with loc_ghost = false}} in
-          collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
-            ~last_binding super self e
+          collect_expr ~config ~decls ~refs ~file_deps ~cross_file
+            ~direct_callees ~file ~module_path ~last_binding super self e
           |> ignore
         | _ -> ())
   | _ -> ());
@@ -261,26 +310,6 @@ let rec collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
   With this annotation we declare a new type for each branch to allow the
   function to be typed.
   *)
-let type_path_candidates ~file ~(module_path : Module_path.t) path =
-  let path = Dce_path.from_path_t path in
-  let module_context =
-    module_path.path @ [File_context.module_name_tagged file]
-  in
-  let add_unique paths path =
-    if List.exists (fun existing -> existing = path) paths then paths
-    else path :: paths
-  in
-  [path; path @ module_context]
-  |> List.fold_left
-       (fun paths path ->
-         [
-           path;
-           Dce_path.module_to_implementation path;
-           Dce_path.module_to_interface path;
-         ]
-         |> List.fold_left add_unique paths)
-       []
-
 let add_record_label_type_references ~config ~refs ~pos_from labels =
   labels
   |> List.iter (fun {Types.ld_loc = {loc_start = pos_to; loc_ghost}; _} ->
@@ -425,8 +454,8 @@ let traverse_structure ~config ~decls ~refs ~file_deps ~cross_file ~file
         expr =
           (fun _self e ->
             e
-            |> collect_expr ~config ~refs ~file_deps ~cross_file ~direct_callees
-                 ~last_binding super mapper);
+            |> collect_expr ~config ~decls ~refs ~file_deps ~cross_file
+                 ~direct_callees ~file ~module_path ~last_binding super mapper);
         pat =
           (fun _self p ->
             p

--- a/analysis/reanalyze/src/reactive_coercions.ml
+++ b/analysis/reanalyze/src/reactive_coercions.ml
@@ -1,0 +1,103 @@
+(** Reactive record-coercion label linking.
+
+    Expresses coercion resolution as reactive joins:
+    - coercions: candidate source/target type paths from CrossFileItems
+    - labels_by_type_path: record labels indexed by the type they belong to
+    - result: type refs (pos_to = source label, pos_from = target label)
+
+    When declarations or coercions change, only affected refs update.
+
+    The pairing rule itself lives in [Dead_type.pair_coercion_labels], shared
+    with the batch pipeline; only the indexing and the edge recording differ. *)
+
+(** {1 Types} *)
+
+type t = {
+  labels_by_type_path: (Dce_path.t, (Name.t * Location.t) list) Reactive.t;
+  resolved_refs: (Lexing.position, Pos_set.t) Reactive.t;
+  resolved_refs_from: (Lexing.position, Pos_set.t) Reactive.t;
+}
+(** Reactive coercion ref collections *)
+
+(** {1 Creation} *)
+
+(** Create reactive coercion refs from decls and cross-file coercions.
+
+    [decls] is the reactive declarations collection.
+    [coercions] is the reactive collection of coercions from CrossFileItems,
+    keyed by the coercion itself so identical coercions collapse. *)
+let create ~(decls : (Lexing.position, Decl.t) Reactive.t)
+    ~(coercions : (Cross_file_items.coercion, unit) Reactive.t) : t =
+  (* Step 1: Index record labels by the path of the type declaring them *)
+  let labels_by_type_path =
+    Reactive.flat_map ~name:"coercions.labels_by_type_path" decls
+      ~f:(fun _pos decl ->
+        match Dead_type.record_label_of_decl decl with
+        | Some (type_path, label) -> [(type_path, [label])]
+        | None -> [])
+      ~merge:List.append ()
+  in
+  (* Step 2: Look up one side of each coercion. A coercion carries candidate
+     paths because the tagging of a module path is not known when it is
+     collected, so emit one lookup per candidate and union the results. *)
+  let labels_of_side ~name ~paths_of =
+    let lookups =
+      Reactive.flat_map ~name:(name ^ ".lookups") coercions
+        ~f:(fun coercion () ->
+          paths_of coercion |> List.map (fun path -> (path, [coercion])))
+        ~merge:List.append ()
+    in
+    Reactive.join ~name lookups labels_by_type_path
+      ~key_of:(fun path _coercions -> path)
+      ~f:(fun _path cs labels_opt ->
+        match labels_opt with
+        | Some labels -> cs |> List.map (fun coercion -> (coercion, labels))
+        | None -> [])
+      ~merge:List.append ()
+  in
+  let source_labels =
+    labels_of_side ~name:"coercions.source_labels" ~paths_of:(fun c ->
+        c.Cross_file_items.source_type_paths)
+  in
+  let target_labels =
+    labels_of_side ~name:"coercions.target_labels" ~paths_of:(fun c ->
+        c.Cross_file_items.target_type_paths)
+  in
+  (* Step 3: Bring both sides of a coercion together and pair the labels *)
+  let resolved_refs =
+    Reactive.join ~name:"coercions.resolved_refs" target_labels source_labels
+      ~key_of:(fun coercion _target_labels -> coercion)
+      ~f:(fun _coercion target_labels source_labels_opt ->
+        match source_labels_opt with
+        | None -> []
+        | Some source_labels ->
+          let refs = ref [] in
+          Dead_type.pair_coercion_labels ~source_labels ~target_labels
+            ~add_edge:(fun ~source_loc ~target_loc ->
+              refs :=
+                ( source_loc.Location.loc_start,
+                  Pos_set.singleton target_loc.Location.loc_start )
+                :: !refs);
+          !refs)
+      ~merge:Pos_set.union ()
+  in
+  (* Step 4: Create refs_from direction by inverting *)
+  let resolved_refs_from =
+    Reactive.flat_map ~name:"coercions.resolved_refs_from" resolved_refs
+      ~f:(fun pos_to pos_from_set ->
+        Pos_set.elements pos_from_set
+        |> List.map (fun pos_from -> (pos_from, Pos_set.singleton pos_to)))
+      ~merge:Pos_set.union ()
+  in
+  {labels_by_type_path; resolved_refs; resolved_refs_from}
+
+(** {1 Freezing} *)
+
+(** Add all resolved coercion refs to a References.builder *)
+let add_to_refs_builder (t : t) ~(refs : References.builder) : unit =
+  Reactive.iter
+    (fun pos_to pos_from_set ->
+      Pos_set.iter
+        (fun pos_from -> References.add_type_ref refs ~pos_to ~pos_from)
+        pos_from_set)
+    t.resolved_refs

--- a/analysis/reanalyze/src/reactive_liveness.ml
+++ b/analysis/reanalyze/src/reactive_liveness.ml
@@ -23,10 +23,15 @@ let create ~(merged : Reactive_merge.t) : t =
       merged.exception_refs.resolved_refs_from ~merge:Pos_set.union ()
   in
 
-  (* Combine type refs using union: per-file refs + type deps from ReactiveTypeDeps *)
+  (* Combine type refs using union: per-file refs + type deps from
+     ReactiveTypeDeps + record coercion links *)
   let type_refs_from : (Lexing.position, Pos_set.t) Reactive.t =
-    Reactive.union ~name:"liveness.type_refs_from" merged.type_refs_from
-      merged.type_deps.all_type_refs_from ~merge:Pos_set.union ()
+    let with_type_deps =
+      Reactive.union ~name:"liveness.type_refs_from" merged.type_refs_from
+        merged.type_deps.all_type_refs_from ~merge:Pos_set.union ()
+    in
+    Reactive.union ~name:"liveness.type_refs_from_with_coercions" with_type_deps
+      merged.coercion_refs.resolved_refs_from ~merge:Pos_set.union ()
   in
 
   (* Step 1: Build decl_refs_index - maps decl -> (value_targets, type_targets) *)

--- a/analysis/reanalyze/src/reactive_merge.ml
+++ b/analysis/reanalyze/src/reactive_merge.ml
@@ -16,6 +16,7 @@ type t = {
   (* Reactive type/exception dependencies *)
   type_deps: Reactive_type_deps.t;
   exception_refs: Reactive_exception_refs.t;
+  coercion_refs: Reactive_coercions.t;
 }
 (** All derived reactive collections from per-file data *)
 
@@ -90,6 +91,7 @@ let create (source : (string, Dce_file_processing.file_data option) Reactive.t)
             function_refs = a.function_refs @ b.function_refs;
             optional_arg_value_escapes =
               a.optional_arg_value_escapes @ b.optional_arg_value_escapes;
+            coercions = a.coercions @ b.coercions;
           })
       ()
   in
@@ -143,6 +145,21 @@ let create (source : (string, Dce_file_processing.file_data option) Reactive.t)
       ~exception_refs:exception_refs_collection
   in
 
+  (* Extract coercions from cross_file_items, keyed by the coercion itself so
+     the same coercion seen in several files collapses to one entry *)
+  let coercions_collection =
+    Reactive.flat_map ~name:"coercions_collection" cross_file_items
+      ~f:(fun _path items ->
+        items.Cross_file_items.coercions
+        |> List.map (fun (c : Cross_file_items.coercion) -> (c, ())))
+      ()
+  in
+
+  (* Create reactive coercion label linking *)
+  let coercion_refs =
+    Reactive_coercions.create ~decls ~coercions:coercions_collection
+  in
+
   {
     decls;
     annotations;
@@ -153,6 +170,7 @@ let create (source : (string, Dce_file_processing.file_data option) Reactive.t)
     files;
     type_deps;
     exception_refs;
+    coercion_refs;
   }
 
 (** {1 Conversion to solver-ready format} *)
@@ -228,6 +246,7 @@ let collect_cross_file_items (t : t) : Cross_file_items.t =
   let optional_arg_calls = ref [] in
   let function_refs = ref [] in
   let optional_arg_value_escapes = ref [] in
+  let coercions = ref [] in
   Reactive.iter
     (fun _path items ->
       exception_refs := items.Cross_file_items.exception_refs @ !exception_refs;
@@ -236,13 +255,15 @@ let collect_cross_file_items (t : t) : Cross_file_items.t =
       function_refs := items.Cross_file_items.function_refs @ !function_refs;
       optional_arg_value_escapes :=
         items.Cross_file_items.optional_arg_value_escapes
-        @ !optional_arg_value_escapes)
+        @ !optional_arg_value_escapes;
+      coercions := items.Cross_file_items.coercions @ !coercions)
     t.cross_file_items;
   {
     Cross_file_items.exception_refs = !exception_refs;
     optional_arg_calls = !optional_arg_calls;
     function_refs = !function_refs;
     optional_arg_value_escapes = !optional_arg_value_escapes;
+    coercions = !coercions;
   }
 
 (** Convert reactive file deps to FileDeps.t for solver.

--- a/analysis/reanalyze/src/reactive_merge.mli
+++ b/analysis/reanalyze/src/reactive_merge.mli
@@ -37,6 +37,7 @@ type t = {
   (* Reactive type/exception dependencies *)
   type_deps: Reactive_type_deps.t;
   exception_refs: Reactive_exception_refs.t;
+  coercion_refs: Reactive_coercions.t;
 }
 (** All derived reactive collections from per-file data *)
 

--- a/analysis/reanalyze/src/reanalyze.ml
+++ b/analysis/reanalyze/src/reanalyze.ml
@@ -302,7 +302,8 @@ let run_analysis ~dce_config ~cmt_root ~reactive_collection ~reactive_merge
                         ~into:file_deps_builder));
                 (* Compute type-label dependencies after merge *)
                 Dead_type.process_type_label_dependencies ~config:dce_config
-                  ~decls ~refs:refs_builder;
+                  ~decls ~refs:refs_builder
+                  ~coercions:cross_file.Cross_file_items.coercions;
                 let find_exception =
                   Dead_exception.find_exception_from_decls decls
                 in

--- a/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/expected/deadcode.txt
@@ -1654,6 +1654,51 @@
   addTypeReference Tuples.res:49:84 --> Tuples.res:36:2
   addValueReference Tuples.res:49:4 --> Tuples.res:49:31
   addValueReference Tuples.res:49:4 --> Tuples.res:49:31
+  Scanning TypeCoercion.cmt Source:TypeCoercion.res
+  addValueDeclaration +readNarrow TypeCoercion.res:22:4 path:+TypeCoercion
+  addValueDeclaration +takesUnread TypeCoercion.res:23:4 path:+TypeCoercion
+  addValueDeclaration +readAliasedNarrow TypeCoercion.res:24:4 path:+TypeCoercion
+  addValueDeclaration +readAliasedTarget TypeCoercion.res:25:4 path:+TypeCoercion
+  addValueDeclaration +main TypeCoercion.res:27:4 path:+TypeCoercion
+  addRecordLabelDeclaration name TypeCoercion.res:3:13 path:+TypeCoercion.user
+  addRecordLabelDeclaration email TypeCoercion.res:3:27 path:+TypeCoercion.user
+  addRecordLabelDeclaration age TypeCoercion.res:3:42 path:+TypeCoercion.user
+  addRecordLabelDeclaration a TypeCoercion.res:6:13 path:+TypeCoercion.wide
+  addRecordLabelDeclaration b TypeCoercion.res:6:24 path:+TypeCoercion.wide
+  addRecordLabelDeclaration a TypeCoercion.res:7:15 path:+TypeCoercion.narrow
+  addRecordLabelDeclaration u TypeCoercion.res:10:21 path:+TypeCoercion.unreadSource
+  addRecordLabelDeclaration u TypeCoercion.res:11:21 path:+TypeCoercion.unreadTarget
+  addRecordLabelDeclaration sa TypeCoercion.res:14:22 path:+TypeCoercion.aliasedSource
+  addRecordLabelDeclaration sb TypeCoercion.res:14:34 path:+TypeCoercion.aliasedSource
+  addRecordLabelDeclaration sa TypeCoercion.res:16:22 path:+TypeCoercion.aliasedNarrow
+  addRecordLabelDeclaration ta TypeCoercion.res:18:22 path:+TypeCoercion.aliasedTarget
+  addRecordLabelDeclaration tb TypeCoercion.res:18:34 path:+TypeCoercion.aliasedTarget
+  addRecordLabelDeclaration ta TypeCoercion.res:19:28 path:+TypeCoercion.aliasedTargetNarrow
+  addTypeReference TypeCoercion.res:22:44 --> TypeCoercion.res:7:15
+  addValueReference TypeCoercion.res:22:4 --> TypeCoercion.res:22:18
+  addTypeReference TypeCoercion.res:24:58 --> TypeCoercion.res:16:22
+  addValueReference TypeCoercion.res:24:4 --> TypeCoercion.res:24:25
+  addTypeReference TypeCoercion.res:25:62 --> TypeCoercion.res:19:28
+  addValueReference TypeCoercion.res:25:4 --> TypeCoercion.res:25:25
+  addValueDeclaration +john TypeCoercion.res:28:6 path:+TypeCoercion
+  addValueDeclaration +source TypeCoercion.res:32:6 path:+TypeCoercion
+  addValueDeclaration +aliasedSource TypeCoercion.res:34:6 path:+TypeCoercion
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:25:4
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:34:6
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:24:4
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:32:6
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:23:4
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:22:4
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:28:6
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercionPerson.res:3:4
+  addTypeReference TypeCoercion.res:29:14 --> TypeCoercion.res:3:27
+  addValueReference TypeCoercion.res:27:4 --> TypeCoercion.res:28:6
+  addValueReference TypeCoercion.res:39:0 --> TypeCoercion.res:27:4
+  Scanning TypeCoercionPerson.cmt Source:TypeCoercionPerson.res
+  addValueDeclaration +greet TypeCoercionPerson.res:3:4 path:+TypeCoercionPerson
+  addRecordLabelDeclaration name TypeCoercionPerson.res:1:10 path:+TypeCoercionPerson.t
+  addTypeReference TypeCoercionPerson.res:3:47 --> TypeCoercionPerson.res:1:10
+  addValueReference TypeCoercionPerson.res:3:4 --> TypeCoercionPerson.res:3:13
   Scanning TypeParams1.cmt Source:TypeParams1.res
   addValueDeclaration +exportSomething TypeParams1.res:4:4 path:+TypeParams1
   Scanning TypeParams2.cmt Source:TypeParams2.res
@@ -2054,6 +2099,16 @@
   addTypeReference DeadTypeTest.resi:9:2 --> DeadTypeTest.res:9:2
   extendTypeDependencies DeadTypeTest.resi:9:2 --> DeadTypeTest.res:9:2
   addTypeReference DeadTypeTest.res:9:2 --> DeadTypeTest.resi:9:2
+  extendTypeDependencies TypeCoercion.res:14:22 --> TypeCoercion.res:16:22
+  addTypeReference TypeCoercion.res:16:22 --> TypeCoercion.res:14:22
+  extendTypeDependencies TypeCoercion.res:18:22 --> TypeCoercion.res:19:28
+  addTypeReference TypeCoercion.res:19:28 --> TypeCoercion.res:18:22
+  extendTypeDependencies TypeCoercion.res:10:21 --> TypeCoercion.res:11:21
+  addTypeReference TypeCoercion.res:11:21 --> TypeCoercion.res:10:21
+  extendTypeDependencies TypeCoercion.res:3:13 --> TypeCoercionPerson.res:1:10
+  addTypeReference TypeCoercionPerson.res:1:10 --> TypeCoercion.res:3:13
+  extendTypeDependencies TypeCoercion.res:6:13 --> TypeCoercion.res:7:15
+  addTypeReference TypeCoercion.res:7:15 --> TypeCoercion.res:6:13
   extendTypeDependencies TypeReexportCrossFileB.res:4:2 --> TypeReexportCrossFileA.res:5:2
   addTypeReference TypeReexportCrossFileA.res:5:2 --> TypeReexportCrossFileB.res:4:2
   extendTypeDependencies TypeReexportCrossFileA.res:5:2 --> TypeReexportCrossFileB.res:4:2
@@ -2106,10 +2161,11 @@
   
 Forward Liveness Analysis
 
-    decls: 746
-    roots(external targets): 161
-    decl-deps: decls_with_out=451 edges_to_decls=323
+    decls: 770
+    roots(external targets): 167
+    decl-deps: decls_with_out=461 edges_to_decls=341
 
+    Root (external ref): Value +TypeCoercion.+main
     Root (external ref): Value +FirstClassModules.M.InnerModule2.+k
     Root (external ref): VariantCase DeadRT.moduleAccessPath.Root
     Root (external ref): Value +TypeReexport.VariantUseOriginal.+value
@@ -2226,6 +2282,7 @@ Forward Liveness Analysis
     Root (external ref): VariantCase +DeadTest.WithInclude.t.A
     Root (annotated): Value +Records.+origin
     Root (annotated): Value +Variants.+onlySunday
+    Root (external ref): RecordLabel +TypeCoercion.aliasedNarrow.sa
     Root (annotated): Value +TypeParams3.+test2
     Root (annotated): Value +Tuples.+origin
     Root (annotated): Value +Records.+getPayloadRecord
@@ -2252,6 +2309,7 @@ Forward Liveness Analysis
     Root (external ref): RecordLabel +Types.mutuallyRecursiveA.b
     Root (annotated): RecordLabel +ImportHooks.props.renderMe
     Root (external ref): Value +EmptyArray.Z.+make
+    Root (external ref): RecordLabel +TypeCoercion.user.email
     Root (annotated): Value +ScopedAnnotationsLiveVsDead.LiveScope.+root
     Root (external ref): Value +Newton.+result
     Root (annotated): Value +Records.+findAllAddresses
@@ -2295,6 +2353,7 @@ Forward Liveness Analysis
     Root (annotated): Value +OcamlWarningSuppressToplevel.M.+suppressed3
     Root (annotated): Value +Uncurried.+uncurried0
     Root (annotated): Value +Records.+someBusiness
+    Root (external ref): RecordLabel +TypeCoercionPerson.t.name
     Root (annotated): Value +Records.+computeArea4
     Root (external ref): RecordLabel +Hooks.vehicle.name
     Root (external ref): RecordLabel +Tuples.person.age
@@ -2397,6 +2456,7 @@ Forward Liveness Analysis
     Root (annotated): Value +Docstrings.+grouped
     Root (annotated): Value +TransitiveType1.+convertAlias
     Root (annotated): Value +Records.+payloadValue
+    Root (external ref): RecordLabel +TypeCoercion.aliasedTargetNarrow.ta
     Root (annotated): Value +ForOf.+keep
     Root (external ref): RecordLabel +Uncurried.auth.login
     Root (external ref): VariantCase +Unison.stack.Cons
@@ -2428,6 +2488,7 @@ Forward Liveness Analysis
     Root (external ref): Value +TypeReexport.OnlyReexportedDead.+value
     Root (annotated): Value +DeadTest.GloobLive.+globallyLive3
     Root (annotated): Value +ImportIndex.+make
+    Root (external ref): RecordLabel +TypeCoercion.narrow.a
     Root (annotated): Value +Unboxed.+testV1
     Root (annotated): Value +NestedModules.Universe.+theAnswer
     Root (annotated): Value +References.+access
@@ -2459,8 +2520,16 @@ Forward Liveness Analysis
     Root (annotated): Value +UseImportJsValue.+useGetProp
     Root (annotated): Value +Hooks.+functionWithRenamedArgs
   
-  348 roots found
+  354 roots found
 
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+readNarrow
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+takesUnread
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+readAliasedNarrow
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+readAliasedTarget
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+john
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+source
+    Propagate: +TypeCoercion.+main -> +TypeCoercion.+aliasedSource
+    Propagate: +TypeCoercion.+main -> +TypeCoercionPerson.+greet
     Propagate: DeadRT.moduleAccessPath.Root -> +DeadRT.moduleAccessPath.Root
     Propagate: +TypeReexportCrossFileB.reexportedRecord.usedField -> +TypeReexportCrossFileA.originalRecord.usedField
     Propagate: +OptArg.+wrapfourArgs -> +OptArg.+fourArgs
@@ -2482,6 +2551,7 @@ Forward Liveness Analysis
     Propagate: +TypeReexport.UseReexported.reexportedType.usedField -> +TypeReexport.UseReexported.originalType.usedField
     Propagate: +CrossFileOptionalArgValueUse.+liveReturnCaller -> +CrossFileOptionalArgProvider.+formatDate
     Propagate: +DeadTest.WithInclude.t.A -> +DeadTest.WithInclude.t.A
+    Propagate: +TypeCoercion.aliasedNarrow.sa -> +TypeCoercion.aliasedSource.sa
     Propagate: +References.+get -> +References.R.+get
     Propagate: +TopLevelOptionalArgValueUse.+mutuallyRecursiveCaller -> +TopLevelOptionalArgValueUse.+mutuallyRecursiveTarget
     Propagate: +DeadTest.MM.+x -> +DeadTest.MM.+x
@@ -2496,6 +2566,7 @@ Forward Liveness Analysis
     Propagate: +OptArg.+wrapOneArg -> +OptArg.+oneArg
     Propagate: +TestImmutableArray.+testImmutableArrayGet -> ImmutableArray.Array.+get
     Propagate: +ContextOptionalArgs.NotificationProvider.Provider.+make -> +ContextOptionalArgs.NotificationProvider.+dispatchNotificationContext
+    Propagate: +TypeCoercionPerson.t.name -> +TypeCoercion.user.name
     Propagate: +TypeReexport.VariantUseReexported.reexportedType.A -> +TypeReexport.VariantUseReexported.originalType.A
     Propagate: +Unison.+toString -> +Unison.+fits
     Propagate: +References.+set -> +References.R.+set
@@ -2509,10 +2580,12 @@ Forward Liveness Analysis
     Propagate: +DeadRT.moduleAccessPath.Kaboom -> DeadRT.moduleAccessPath.Kaboom
     Propagate: +TopLevelOptionalArgValueUse.+liveReturnedFunctionCaller -> +TopLevelOptionalArgValueUse.+returnedFunction
     Propagate: DeadValueTest.+valueAlive -> +DeadValueTest.+valueAlive
+    Propagate: +TypeCoercion.aliasedTargetNarrow.ta -> +TypeCoercion.aliasedTarget.ta
     Propagate: +TopLevelOptionalArgValueUse.+liveForwardingCaller -> +TopLevelOptionalArgValueUse.+formatDateForwarded
     Propagate: +DeadTest.VariantUsedOnlyInImplementation.+a -> +DeadTest.VariantUsedOnlyInImplementation.+a
     Propagate: +ImportJsValue.+useGetAbs -> +ImportJsValue.AbsoluteValue.+getAbs
     Propagate: +TypeReexport.VariantUseOriginal.reexportedType.A -> +TypeReexport.VariantUseOriginal.originalType.A
+    Propagate: +TypeCoercion.narrow.a -> +TypeCoercion.wide.a
     Propagate: +TypeReexport.OnlyReexportedDead.reexportedType.usedField -> +TypeReexport.OnlyReexportedDead.originalType.usedField
     Propagate: +TopLevelOptionalArgValueUse.+formatDateAlias2 -> +TopLevelOptionalArgValueUse.+formatDateAlias
     Propagate: ReturnedOptionalSignature.+returnedOptional -> +ReturnedOptionalSignature.+returnedOptional
@@ -2533,7 +2606,7 @@ Forward Liveness Analysis
     Propagate: +TopLevelOptionalArgValueUse.+returnedFunction -> +TopLevelOptionalArgValueUse.+returnsFunction
     Propagate: +ImportJsValue.AbsoluteValue.+getAbs -> +ImportJsValue.AbsoluteValue.+getAbs
   
-  71 declarations marked live via propagation
+  83 declarations marked live via propagation
 
   Dead VariantCase +AutoAnnotate.variant.R
   Dead RecordLabel +AutoAnnotate.record.variant
@@ -4039,6 +4112,81 @@ Forward Liveness Analysis
   Live (annotated) Value +Tuples.+changeSecondAge
       deps: in=0 (live=0 dead=0) out=1
         -> +Tuples.person.age
+  Live (propagated) RecordLabel +TypeCoercion.user.name
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercionPerson.t.name (live)
+  Live (external ref) RecordLabel +TypeCoercion.user.email
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.+main (live)
+  Dead RecordLabel +TypeCoercion.user.age
+  Live (propagated) RecordLabel +TypeCoercion.wide.a
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.narrow.a (live)
+  Dead RecordLabel +TypeCoercion.wide.b
+  Live (external ref) RecordLabel +TypeCoercion.narrow.a
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+readNarrow (live)
+        -> +TypeCoercion.wide.a
+  Dead RecordLabel +TypeCoercion.unreadSource.u
+      deps: in=1 (live=0 dead=1) out=0
+        <- +TypeCoercion.unreadTarget.u (dead)
+  Dead RecordLabel +TypeCoercion.unreadTarget.u
+      deps: in=0 (live=0 dead=0) out=1
+        -> +TypeCoercion.unreadSource.u
+  Live (propagated) RecordLabel +TypeCoercion.aliasedSource.sa
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.aliasedNarrow.sa (live)
+  Dead RecordLabel +TypeCoercion.aliasedSource.sb
+  Live (external ref) RecordLabel +TypeCoercion.aliasedNarrow.sa
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+readAliasedNarrow (live)
+        -> +TypeCoercion.aliasedSource.sa
+  Live (propagated) RecordLabel +TypeCoercion.aliasedTarget.ta
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.aliasedTargetNarrow.ta (live)
+  Dead RecordLabel +TypeCoercion.aliasedTarget.tb
+  Live (external ref) RecordLabel +TypeCoercion.aliasedTargetNarrow.ta
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+readAliasedTarget (live)
+        -> +TypeCoercion.aliasedTarget.ta
+  Live (propagated) Value +TypeCoercion.+readNarrow
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+main (live)
+        -> +TypeCoercion.narrow.a
+  Live (propagated) Value +TypeCoercion.+takesUnread
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.+main (live)
+  Live (propagated) Value +TypeCoercion.+readAliasedNarrow
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+main (live)
+        -> +TypeCoercion.aliasedNarrow.sa
+  Live (propagated) Value +TypeCoercion.+readAliasedTarget
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+main (live)
+        -> +TypeCoercion.aliasedTargetNarrow.ta
+  Live (external ref) Value +TypeCoercion.+main
+      deps: in=0 (live=0 dead=0) out=9
+        -> +TypeCoercion.+readNarrow
+        -> +TypeCoercion.+takesUnread
+        -> +TypeCoercion.+readAliasedNarrow
+        -> ... (6 more)
+  Live (propagated) Value +TypeCoercion.+john
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.+main (live)
+  Live (propagated) Value +TypeCoercion.+source
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.+main (live)
+  Live (propagated) Value +TypeCoercion.+aliasedSource
+      deps: in=1 (live=1 dead=0) out=0
+        <- +TypeCoercion.+main (live)
+  Live (external ref) RecordLabel +TypeCoercionPerson.t.name
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercionPerson.+greet (live)
+        -> +TypeCoercion.user.name
+  Live (propagated) Value +TypeCoercionPerson.+greet
+      deps: in=1 (live=1 dead=0) out=1
+        <- +TypeCoercion.+main (live)
+        -> +TypeCoercionPerson.t.name
   Dead Value +TypeParams1.+exportSomething
   Dead RecordLabel +TypeParams2.item.id
   Dead Value +TypeParams2.+exportSomething
@@ -5404,6 +5552,30 @@ Forward Liveness Analysis
   TransitiveType3.res:4:3-11
   t3.s is a record label never used to read a value
 
+  Warning Dead Type
+  TypeCoercion.res:3:43-50
+  user.age is a record label never used to read a value
+
+  Warning Dead Type
+  TypeCoercion.res:6:25-33
+  wide.b is a record label never used to read a value
+
+  Warning Dead Type
+  TypeCoercion.res:10:22-30
+  unreadSource.u is a record label never used to read a value
+
+  Warning Dead Type
+  TypeCoercion.res:11:22-30
+  unreadTarget.u is a record label never used to read a value
+
+  Warning Dead Type
+  TypeCoercion.res:14:35-44
+  aliasedSource.sb is a record label never used to read a value
+
+  Warning Dead Type
+  TypeCoercion.res:18:35-44
+  aliasedTarget.tb is a record label never used to read a value
+
   Warning Dead Module
   TypeParams1.res:0:1
   TypeParams1 is a dead module as all its items are dead.
@@ -5660,4 +5832,4 @@ Forward Liveness Analysis
   OptArg.res:14:1-42
   optional argument b of function twoArgs is never used
   
-  Analysis reported 330 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:23, Warning Dead Type:94, Warning Dead Value:179, Warning Dead Value With Side Effects:6, Warning Redundant Optional Argument:7, Warning Unused Argument:18)
+  Analysis reported 336 issues (Incorrect Dead Annotation:1, Warning Dead Exception:2, Warning Dead Module:23, Warning Dead Type:100, Warning Dead Value:179, Warning Dead Value With Side Effects:6, Warning Redundant Optional Argument:7, Warning Unused Argument:18)

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TypeCoercion.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TypeCoercion.res
@@ -1,0 +1,39 @@
+// Coercing a record to a narrower one reads the source labels through the
+// target's: `name` is read by TypeCoercionPerson.greet, while `age` is dead.
+type user = {name: string, email: string, age: int}
+
+// Same file, same shape: `a` is read through `narrow`, `b` is dead.
+type wide = {a: string, b: string}
+type narrow = {a: string}
+
+// Nothing reads `unreadTarget.u`, so the coercion leaves `unreadSource.u` dead.
+type unreadSource = {u: string}
+type unreadTarget = {u: string}
+
+// Through an alias on either side: `sa` and `ta` are read, `sb` and `tb` are not.
+type aliasedSource = {sa: string, sb: string}
+type aliasedSourceName = aliasedSource
+type aliasedNarrow = {sa: string}
+
+type aliasedTarget = {ta: string, tb: string}
+type aliasedTargetNarrow = {ta: string}
+type aliasedTargetName = aliasedTargetNarrow
+
+let readNarrow = (n: narrow) => Console.log(n.a)
+let takesUnread = (_: unreadTarget) => ()
+let readAliasedNarrow = (n: aliasedNarrow) => Console.log(n.sa)
+let readAliasedTarget = (n: aliasedTargetName) => Console.log(n.ta)
+
+let main = () => {
+  let john = {name: "John", email: "john@example.com", age: 42}
+  Console.log(john.email)
+  TypeCoercionPerson.greet((john :> TypeCoercionPerson.t))
+  readNarrow(({a: "x", b: "y"} :> narrow))
+  let source: unreadSource = {u: "u"}
+  takesUnread((source :> unreadTarget))
+  let aliasedSource: aliasedSourceName = {sa: "x", sb: "y"}
+  readAliasedNarrow((aliasedSource :> aliasedNarrow))
+  readAliasedTarget(({ta: "x", tb: "y"}: aliasedTarget :> aliasedTargetName))
+}
+
+main()

--- a/tests/analysis_tests/tests-reanalyze/deadcode/src/TypeCoercionPerson.res
+++ b/tests/analysis_tests/tests-reanalyze/deadcode/src/TypeCoercionPerson.res
@@ -1,0 +1,3 @@
+type t = {name: string}
+
+let greet = (p: t) => Console.log("Hello, " ++ p.name)


### PR DESCRIPTION
Fixes #8643. Stacked on #8644, which keeps the source type of a coercion in the typed tree.

### The bug

```rescript
// User.res
type t = {name: string, email: string, age: int}
// Person.res
type t = {name: string}
let greet = (p: t) => Console.log("Hello, " ++ p.name)
// Main.res
Person.greet((john :> Person.t))
```

`User.t.name` was reported as *a record label never used to read a value*. It is read — as `Person.t.name`, through the coercion. reanalyze never saw the coercion at all: `exp_extra` is not traversed anywhere in it.

### The fix

Collect each coercion per file, and pair the labels once every declaration is known. The deferral is forced: the source type's declaration usually lives in another file, and each file is processed with its own `decls` builder. Resolving through the environment doesn't help either — `Ctype.extract_concrete_typedecl` returns `Not_found` on every coercion in the test corpus, because the environment restored from a cmt is a summary. This is the same collect-then-resolve shape the cross-file exception refs already use.

The edge runs **target → source only**. Reading a source label says nothing about the target's, so a coercion whose target labels are all dead leaves the source labels dead too.

### Both pipelines

The editor runs the reactive pipeline, so it gets this too. The two share the pairing rule and the shape of a record-label declaration — `Dead_type.pair_coercion_labels` and `record_label_of_decl` — and differ only where they must: how declarations are indexed and how an edge is recorded. `Path_map` + `extend_type_dependencies` in the batch pass; reactive joins feeding `type_refs_from` in the new `Reactive_coercions`.

### Tests

`TypeCoercion.res` + `TypeCoercionPerson.res` cover a cross-file coercion, a same-file one, and a coerced pair whose target label nobody reads:

| | before | after |
|---|---|---|
| `user.name`, read cross-file through the coercion | dead ❌ | not reported ✓ |
| `user.age`, genuinely unread | dead ✓ | dead ✓ |
| `wide.a` / `wide.b`, same-file coercion | both dead ❌ | only `b` ✓ |
| `unreadSource.u`, coerced but target never read | dead ✓ | dead ✓ |

In `expected/deadcode.txt` the only changes are the new fixture's entries and the debug counters — no pre-existing finding moved.

Verified in both modes. Temporarily removing the reactive union re-reports the two labels, which confirms the reactive edge is what fixes it there rather than incidental agreement with the batch pass. `make test`, `make test-analysis`, `make test-gentype`, `make test-tools`, the termination and order-independence suites, `dune build --profile browser @check` and `make checkformat` all pass.

### Noticed on the way, not fixed here

Batch and reactive disagree on the `TypeReexport*` fixtures: reactive reports 7 findings the batch pass does not, because the re-export (`manifest_type_path`) linking in `Dead_type.process_type_label_dependencies` has no counterpart in `Reactive_type_deps`. Pre-existing and unrelated to coercions — those fixtures contain none — so I left it alone. Worth its own issue.
