### PR TITLE
Allow slower Rewatch startup in CI

### DIFF
--- a/rewatch/tests/watch/04-watch-config-change.sh
+++ b/rewatch/tests/watch/04-watch-config-change.sh
@@ -20,7 +20,7 @@ rewatch_bg watch > rewatch.log 2>&1 &
 success "Watcher Started"
 
 # Wait for initial build to complete
-if ! wait_for_file "./src/Test.mjs" 20; then
+if ! wait_for_file "./src/Test.mjs" 60; then
   error "Initial build did not complete"
   cat rewatch.log
   exit_watcher


### PR DESCRIPTION
The Rewatch config-change test can fail on slower macOS runners when its cold 472-module build takes longer than 20 seconds, even though compilation is still progressing.

Increase the polling timeout to 60 seconds. The check still returns immediately when the expected output appears, so normal test duration is unchanged.

Validation: `bash -n rewatch/tests/watch/04-watch-config-change.sh`
